### PR TITLE
Resolve issues #2, #12, #13, #14: vault_id required, parent retrieval, ingestion integrity, embedding migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ opencodeRAGAPPv3-remote/
 opencodeRAGAPPv2-remote/
 .swarm/
 opencodeRAGAPPv2-remote/
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,69 @@ When swarm mode is enabled:
 - Across many different repositories, explore local patterns first rather than assuming one project's conventions apply to another.
 
 If `.claude/session/swarm-mode.md` does not exist, behave normally.
+
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ On first launch, you'll be redirected to the **Setup Wizard** (`/setup`) to crea
 | `JWT_SECRET_KEY` | change-me-... | Secret key for JWT signing (generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`) |
 | `JWT_ALGORITHM` | HS256 | JWT signing algorithm |
 | `ADMIN_SECRET_TOKEN` | "" | Legacy admin token for API key auth mode |
+| `PARENT_RETRIEVAL_ENABLED` | `false` | Enable small-to-big context expansion (parent window retrieval) |
+| `PARENT_WINDOW_CHARS` | `6000` | Total parent window size in characters (±3000 around matched chunk) |
+| `NEW_DEDUP_POLICY` | `true` | Use group-aware dedup (caps per-doc chunks and distinct docs in results) |
+| `PER_DOC_CHUNK_CAP` | `2` | Max chunks per document in retrieval results |
+| `UNIQUE_DOCS_IN_TOP_K` | `5` | Max distinct documents in retrieval result set |
+| `INDEX_REBUILD_DELTA` | `0.2` | Delete churn fraction (0–1) that triggers ANN index rebuild |
+| `REUPLOAD_SAFE_ORDER` | `true` | Insert new chunks before deleting old on re-upload (eliminates zero-chunk window) |
 
 ### Data Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,52 @@ docker compose logs knowledgevault
 3. Adjust `MAX_DISTANCE_THRESHOLD` to filter results (lower = more strict)
 4. Ensure Ollama has GPU access if available
 
+## Upgrading
+
+### Embedding Dimension Change (Harrier Migration)
+
+If you are upgrading from a version that used BGE-M3 (768-dim) embeddings to Harrier
+(`microsoft/harrier-oss-v1-0.6b`, 1024-dim), **existing documents are not automatically
+re-indexed**. The LanceDB vector store cannot be converted in-place because embeddings are
+dimension-incompatible.
+
+**Symptom:** Chat returns no document results or the `/api/health?deep=true` response
+includes `"stale_embeddings": true` in the `vector_store` section.
+
+**Required steps:**
+
+```bash
+# 1. Backup your data before proceeding
+cp -r /your/data/dir/lancedb /your/data/dir/lancedb.bak
+cp /your/data/dir/app.db /your/data/dir/app.db.bak
+
+# 2. Run the migration script to clear stale embeddings
+#    (dry-run first to see what will change)
+python scripts/migrate_embeddings.py --dry-run
+
+# 3. Run the actual migration — this wipes LanceDB and resets file statuses to pending
+python scripts/migrate_embeddings.py
+
+# 4. Restart the application — the background processor will re-index all files
+docker compose restart knowledgevault
+```
+
+The background processor automatically re-embeds all files with `status='pending'`.
+Depending on the number of documents and your hardware, this may take several minutes.
+
+**Health check after migration:**
+
+```bash
+# Verify embedding dimension is correct
+curl http://localhost:9090/api/health?deep=true | jq .vector_store
+# Expected: {"ok": true, "rows": <N>, "stale_embeddings": null or absent}
+```
+
+> **Note:** `scripts/migrate_embeddings.py` is safe to run multiple times. On a clean
+> deployment (no existing LanceDB data), it is a no-op.
+
+---
+
 ## API Endpoints
 
 ### Health & Status

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -478,7 +478,7 @@ async def get_document_stats(
 async def upload_document_root(
     request: Request,
     file: Optional[UploadFile] = None,
-    vault_id: int = Query(1, description="Target vault ID"),
+    vault_id: int = Query(..., description="Target vault ID (required — no default)"),
     settings_dep: Settings = Depends(get_settings),
     vector_store: VectorStore = Depends(get_vector_store),
     embedding_service: EmbeddingService = Depends(get_embedding_service),
@@ -498,7 +498,7 @@ async def upload_document_root(
 async def upload_document(
     request: Request,
     file: Optional[UploadFile] = None,
-    vault_id: int = Query(1, description="Target vault ID"),
+    vault_id: int = Query(..., description="Target vault ID (required — no default)"),
     settings_dep: Settings = Depends(get_settings),
     vector_store: VectorStore = Depends(get_vector_store),
     embedding_service: EmbeddingService = Depends(get_embedding_service),

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -43,13 +43,38 @@ async def health_check(
         llm_status = await llm_checker.check_all()
         models_status = await model_checker.check_models()
 
-        # Probe vector store connectivity
+        # Probe vector store connectivity and embedding dimension consistency
         vector_status = {"ok": False}
         try:
             vector_store = getattr(request.app.state, "vector_store", None)
             if vector_store and vector_store.table:
                 row_count = await vector_store.table.count_rows()
                 vector_status = {"ok": True, "rows": row_count}
+
+                # Issue #2: Warn if stored embedding dimension mismatches configured dim.
+                # A mismatch means documents were indexed with a different model and
+                # searches will return empty or incorrect results until re-embedded.
+                try:
+                    from app.config import settings as _settings
+                    stored_dim = await vector_store._get_expected_embedding_dim()
+                    configured_dim = _settings.embedding_dim
+                    if stored_dim and stored_dim != configured_dim:
+                        vector_status["stale_embeddings"] = True
+                        vector_status["stale_embeddings_detail"] = (
+                            f"LanceDB index was built with {stored_dim}-dim embeddings but "
+                            f"EMBEDDING_DIM is now {configured_dim}. "
+                            f"Run scripts/migrate_embeddings.py to re-index."
+                        )
+                        logger.warning(
+                            "Stale embedding dimensions detected: stored=%d, configured=%d. "
+                            "Documents will not be searchable until re-embedded. "
+                            "Run scripts/migrate_embeddings.py.",
+                            stored_dim,
+                            configured_dim,
+                        )
+                except Exception as _dim_exc:
+                    logger.debug("Embedding dimension check failed (non-fatal): %s", _dim_exc)
+
             elif vector_store:
                 vector_status = {"ok": True, "rows": 0}
             else:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -190,6 +190,41 @@ class Settings(BaseSettings):
     recency_decay_lambda: float = 0.001
     """Exponential decay rate (lambda) for recency scoring. Higher values decay faster."""
 
+    # ── Parent-document retrieval configuration (Issue #12) ──────────────────
+    parent_retrieval_enabled: bool = False
+    """Enable parent-window expansion at prompt time: retrieve on small chunks, deliver the
+    surrounding parent window to the LLM for broader context. Default False until migration
+    (add_parent_window) has been run and verified in staging.  Flip to True after migration."""
+
+    new_dedup_policy: bool = True
+    """Enable group-aware dedup: preserve up to PER_DOC_CHUNK_CAP chunks per document and
+    cap breadth at UNIQUE_DOCS_IN_TOP_K distinct documents. Replaces UID-strip dedup that
+    collapsed the best document's multiple strong chunks to one. Default True (safe improvement)."""
+
+    per_doc_chunk_cap: int = 2
+    """Maximum chunks kept per document after group-aware dedup. Higher values give more
+    context from each document at the cost of less diversity across sources."""
+
+    unique_docs_in_top_k: int = 5
+    """Maximum distinct documents allowed in the final dedup output when new_dedup_policy is
+    enabled. Balances breadth vs. depth in source diversity."""
+
+    parent_window_chars: int = 6000
+    """Size of the parent window (in characters) delivered to the prompt when
+    parent_retrieval_enabled=True. The matched small chunk is bracketed with [[MATCH:…]]
+    markers inside this window for the LLM to orient itself."""
+
+    # ── Ingestion integrity configuration (Issue #13) ────────────────────────
+    index_rebuild_delta: float = 0.2
+    """Fraction of row churn (deletes / previous row count) that triggers an IVF_PQ index
+    rebuild. Default 0.2 = 20% row loss triggers rebuild. Keeps ANN search accurate after
+    bulk deletes without rebuilding on every small delete."""
+
+    reupload_safe_order: bool = True
+    """Use insert-then-delete ordering for re-uploads with a changed file hash. When True,
+    new chunks are inserted and the file pointer is flipped BEFORE old chunks are deleted,
+    ensuring the corpus is never in a zero-chunk state for a live document."""
+
     # ── Tri-vector embedding configuration (deprecated) ───────────────────────
     tri_vector_search_enabled: bool = False
     """Deprecated: BGE-M3 replaced by Harrier. Field retained for config compatibility."""
@@ -457,6 +492,24 @@ class Settings(BaseSettings):
     def validate_multi_scale_overlap_ratio(cls, v: float) -> float:
         """Validate multi_scale_overlap_ratio is in range 0.0-1.0."""
         return cls._validate_float_range(v, 0.0, 1.0, "multi_scale_overlap_ratio")
+
+    @field_validator("index_rebuild_delta", mode="after")
+    @classmethod
+    def validate_index_rebuild_delta(cls, v: float) -> float:
+        """Validate index_rebuild_delta is in range 0.0-1.0."""
+        return cls._validate_float_range(v, 0.0, 1.0, "index_rebuild_delta")
+
+    @field_validator("per_doc_chunk_cap", mode="after")
+    @classmethod
+    def validate_per_doc_chunk_cap(cls, v: int) -> int:
+        """Validate per_doc_chunk_cap is >= 1."""
+        return cls._validate_int_range(v, 1, None, "per_doc_chunk_cap")
+
+    @field_validator("unique_docs_in_top_k", mode="after")
+    @classmethod
+    def validate_unique_docs_in_top_k(cls, v: int) -> int:
+        """Validate unique_docs_in_top_k is >= 1."""
+        return cls._validate_int_range(v, 1, None, "unique_docs_in_top_k")
 
     @field_validator("hybrid_alpha", mode="after")
     @classmethod

--- a/backend/app/migrations/__init__.py
+++ b/backend/app/migrations/__init__.py
@@ -1,0 +1,1 @@
+# Migration scripts for LanceDB and SQLite schema changes.

--- a/backend/app/migrations/add_parent_window.py
+++ b/backend/app/migrations/add_parent_window.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Migration: add_parent_window — add parent-document retrieval columns to LanceDB (Issue #12).
+
+Adds four new columns to the LanceDB ``chunks`` table that are required for
+parent-document / small-to-big retrieval:
+
+- ``parent_doc_id``       (str, nullable) — denormalized file_id for query-time access
+- ``parent_window_start`` (int, nullable) — char offset into source doc where parent window begins
+- ``parent_window_end``   (int, nullable) — char offset into source doc where parent window ends
+- ``chunk_position``      (int, nullable) — sequential chunk index within parent document
+
+Existing rows are backfilled:
+  - ``parent_doc_id``  ← ``file_id`` (already present on every chunk)
+  - ``chunk_position`` ← ``chunk_index`` (already present on every chunk)
+  - ``parent_window_start / end`` ← ``None`` (populated on next re-ingest)
+
+Properties:
+  - Idempotent: safe to run multiple times.
+  - ``--dry-run`` mode reports rows that would be updated without writing.
+  - Restores FTS and vector indices after table rewrite.
+
+Usage:
+    python -m app.migrations.add_parent_window [--dry-run] [--db-path PATH]
+
+    Or via the VectorStore.migrate_add_parent_window() async method called from
+    the lifespan hook or a management command.
+"""
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+async def run_migration(db_path: Path, dry_run: bool = False) -> int:
+    """Run the parent window migration against a LanceDB database.
+
+    Args:
+        db_path: Path to the LanceDB directory.
+        dry_run: If True, report affected rows without writing.
+
+    Returns:
+        Number of rows migrated (or that would have been migrated in dry-run).
+    """
+    # Import inside the function to allow standalone invocation without the
+    # full application config being loaded.
+    from app.services.vector_store import VectorStore
+
+    store = VectorStore(db_path=db_path)
+    await store.connect()
+
+    count = await store.migrate_add_parent_window(dry_run=dry_run)
+
+    mode = "[DRY RUN] " if dry_run else ""
+    if count == 0:
+        logger.info("%sMigration not needed — all rows already have parent window columns.", mode)
+    else:
+        logger.info("%sMigration complete: %d rows affected.", mode, count)
+
+    return count
+
+
+def main() -> None:
+    """Entry point for CLI invocation."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Add parent_doc_id / parent_window_start / parent_window_end / chunk_position "
+        "columns to the LanceDB chunks table."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report rows to be updated without making any changes.",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="Path to the LanceDB directory. Defaults to settings.lancedb_path.",
+    )
+    args = parser.parse_args()
+
+    if args.db_path is None:
+        try:
+            from app.config import settings
+            db_path = settings.lancedb_path
+        except Exception as exc:
+            print(
+                f"ERROR: could not load settings to determine lancedb_path: {exc}\n"
+                "Pass --db-path explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        db_path = args.db_path
+
+    count = asyncio.run(run_migration(db_path=db_path, dry_run=args.dry_run))
+
+    if args.dry_run:
+        print(f"[DRY RUN] {count} rows would be migrated.")
+    else:
+        print(f"Migration complete: {count} rows migrated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/migrations/audit_vault_defaults.py
+++ b/backend/app/migrations/audit_vault_defaults.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Migration: audit_vault_defaults — identify auto-assigned vault-1 documents (Issue #13).
+
+The upload API previously accepted requests without a ``vault_id`` and silently
+assigned ``vault_id=1`` (the "orphan" vault).  This migration queries the SQLite
+``files`` table for documents that are likely to have been auto-assigned and logs
+them for operator review.
+
+It does NOT move or modify any documents — it only surfaces the situation so an
+operator can decide whether to reassign them to the correct vault.
+
+A document is flagged as a candidate for review when **all** of the following hold:
+  1. ``vault_id = 1``
+  2. ``source = 'upload'`` (not auto-scan or email ingestion which legitimately use vault 1)
+  3. ``status = 'indexed'``
+
+Operators should review the flagged list and manually move documents to the correct
+vault if needed.
+
+Properties:
+  - Read-only: makes no changes to any data.
+  - Idempotent: safe to run multiple times.
+  - Output: logs one line per flagged document; also writes a summary to stdout.
+
+Usage:
+    python -m app.migrations.audit_vault_defaults [--db-path PATH] [--output-csv PATH]
+"""
+
+import argparse
+import csv
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def run_audit(db_path: Path, output_csv: Path | None = None) -> list[dict]:
+    """Query SQLite for auto-assigned vault-1 documents.
+
+    Args:
+        db_path: Path to the SQLite database file (settings.sqlite_path).
+        output_csv: Optional path to write results as CSV.
+
+    Returns:
+        List of row dicts for flagged documents.
+    """
+    if not db_path.exists():
+        logger.warning("SQLite database not found at %s — no audit performed.", db_path)
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+
+    try:
+        # Verify the files table exists
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='files'"
+        )
+        if cursor.fetchone() is None:
+            logger.info("'files' table does not exist — no audit needed.")
+            return []
+
+        # Check available columns (source column may not exist on old schemas)
+        cursor = conn.execute("PRAGMA table_info(files)")
+        columns = {row[1] for row in cursor.fetchall()}
+
+        if "source" in columns:
+            query = (
+                "SELECT id, file_name, file_path, vault_id, source, status, created_at "
+                "FROM files "
+                "WHERE vault_id = 1 AND source = 'upload' AND status = 'indexed' "
+                "ORDER BY created_at"
+            )
+        else:
+            # Older schema without source column — flag all vault-1 indexed uploads
+            logger.warning(
+                "Column 'source' missing from files table — flagging all vault_id=1 indexed files."
+            )
+            query = (
+                "SELECT id, file_name, file_path, vault_id, status, created_at "
+                "FROM files "
+                "WHERE vault_id = 1 AND status = 'indexed' "
+                "ORDER BY created_at"
+            )
+
+        rows = conn.execute(query).fetchall()
+        results = [dict(row) for row in rows]
+
+        logger.info(
+            "Audit complete: %d document(s) flagged as potential auto-assigned vault-1 uploads.",
+            len(results),
+        )
+
+        for row in results:
+            logger.warning(
+                "FLAGGED: id=%s file=%r path=%r created_at=%s",
+                row.get("id"),
+                row.get("file_name"),
+                row.get("file_path"),
+                row.get("created_at"),
+            )
+
+        if output_csv and results:
+            fieldnames = list(results[0].keys())
+            with open(output_csv, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(results)
+            logger.info("Results written to %s", output_csv)
+
+        return results
+
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    """Entry point for CLI invocation."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Audit SQLite files table for documents auto-assigned to vault_id=1."
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="Path to the SQLite database file. Defaults to settings.sqlite_path.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=None,
+        help="Optional path to write the flagged document list as a CSV file.",
+    )
+    args = parser.parse_args()
+
+    if args.db_path is None:
+        try:
+            from app.config import settings
+            db_path = settings.sqlite_path
+        except Exception as exc:
+            print(
+                f"ERROR: could not load settings to determine sqlite_path: {exc}\n"
+                "Pass --db-path explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        db_path = args.db_path
+
+    results = run_audit(db_path=db_path, output_csv=args.output_csv)
+
+    print(f"\nAudit result: {len(results)} document(s) flagged.")
+    if results:
+        print(
+            "\nThese documents were uploaded without an explicit vault_id and were "
+            "auto-assigned to vault_id=1 (the orphan vault).\n"
+            "Review the list and reassign documents to the correct vault if needed."
+        )
+    else:
+        print("No auto-assigned vault-1 uploads found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/services/chunking.py
+++ b/backend/app/services/chunking.py
@@ -28,6 +28,11 @@ class ProcessedChunk:
         chunk_uid: Unique identifier for windowing (format: file_id_chunk_index)
         original_indices: List of original chunk indices if merged (for tracking)
         raw_text: Original chunk text before any contextual enrichment (preserved for evidence display)
+        parent_window_start: Character offset into the source document where the parent window begins.
+            Populated by compute_parent_windows(); None for chunks not yet backfilled.
+        parent_window_end: Character offset into the source document where the parent window ends.
+        chunk_position: Sequential position of this chunk within its parent document (same as chunk_index
+            after merge post-processing).
     """
 
     text: str
@@ -36,6 +41,10 @@ class ProcessedChunk:
     chunk_uid: Optional[str] = None
     original_indices: List[int] = field(default_factory=list)
     raw_text: Optional[str] = None
+    # Parent-document retrieval fields (Issue #12)
+    parent_window_start: Optional[int] = None
+    parent_window_end: Optional[int] = None
+    chunk_position: Optional[int] = None
 
 
 class SemanticChunker:
@@ -597,3 +606,85 @@ class EmbeddingSemanticChunker:
             "chunk_elements requires async context. Use chunk_text instead or run in async context."
         )
         return []
+
+
+def compute_parent_windows(
+    chunks: List[ProcessedChunk],
+    source_text: str,
+    window_chars: int = 6000,
+) -> List[ProcessedChunk]:
+    """Compute parent window offsets for each chunk within the source document (Issue #12).
+
+    For each chunk, locates the chunk text inside *source_text* and records a
+    ``parent_window_start`` / ``parent_window_end`` that spans up to *window_chars*
+    characters centred on the chunk.  The matched small chunk is later rendered with
+    ``[[MATCH: …]]`` markers inside this window when ``parent_retrieval_enabled=True``.
+
+    Strategy:
+    - Search uses ``raw_text`` (pre-enrichment) when available, falling back to
+      ``text``.  Enriched text may include a contextual prefix that is not present
+      in the source, so raw_text is a safer search target.
+    - Searches forward from the previous chunk's found position to avoid O(n²) worst
+      case on large documents (chunks are ordered).
+    - If a chunk cannot be located (e.g. enriched text differs too much), the offsets
+      remain ``None``; parent retrieval degrades gracefully to the small-chunk text.
+
+    Args:
+        chunks: Processed chunks from the semantic chunker.
+        source_text: Full source document text (plain text, pre-enrichment).
+        window_chars: Target width of the parent window in characters.
+
+    Returns:
+        The same list of chunks, mutated in-place with parent_window_start/end and
+        chunk_position set.  Returns the list for chaining convenience.
+    """
+    if not chunks or not source_text:
+        return chunks
+
+    half = window_chars // 2
+    doc_len = len(source_text)
+    search_cursor = 0  # Advance forward to keep O(n) overall
+
+    for position, chunk in enumerate(chunks):
+        chunk.chunk_position = position
+
+        # Prefer raw_text for locating within source (contextual prefix not in source)
+        search_text = (chunk.raw_text or chunk.text or "").strip()
+        if not search_text:
+            continue
+
+        # Try to find the chunk text from the current cursor forward
+        idx = source_text.find(search_text, search_cursor)
+        if idx == -1 and search_cursor > 0:
+            # Retry from the beginning in case of out-of-order or overlap
+            idx = source_text.find(search_text, 0)
+
+        if idx == -1:
+            # Could not locate chunk in source — leave offsets as None
+            logger.debug(
+                "compute_parent_windows: chunk[%d] not found in source (len=%d); "
+                "offsets left as None",
+                position,
+                doc_len,
+            )
+            continue
+
+        chunk_end = idx + len(search_text)
+        chunk_mid = (idx + chunk_end) // 2
+
+        window_start = max(0, chunk_mid - half)
+        window_end = min(doc_len, chunk_mid + half)
+
+        # Widen if the chunk itself extends beyond the half-window
+        if idx < window_start:
+            window_start = max(0, idx - 100)
+        if chunk_end > window_end:
+            window_end = min(doc_len, chunk_end + 100)
+
+        chunk.parent_window_start = window_start
+        chunk.parent_window_end = window_end
+
+        # Advance cursor to the start of this chunk (next chunk will be at or after here)
+        search_cursor = idx
+
+    return chunks

--- a/backend/app/services/chunking.py
+++ b/backend/app/services/chunking.py
@@ -684,7 +684,7 @@ def compute_parent_windows(
         chunk.parent_window_start = window_start
         chunk.parent_window_end = window_end
 
-        # Advance cursor to the start of this chunk (next chunk will be at or after here)
-        search_cursor = idx
+        # Advance cursor past this match so the next chunk searches forward from here
+        search_cursor = chunk_end
 
     return chunks

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -801,6 +801,12 @@ class DocumentProcessor:
             # Compute parent window offsets for small-to-big retrieval (Issue #12)
             # Run after contextual chunking so raw_text is the pre-enrichment text.
             # Only meaningful when document_text is available (not spreadsheets/schemas).
+            if not document_text and chunks and settings.parent_retrieval_enabled:
+                logger.debug(
+                    "parent_retrieval_enabled but document_text unavailable for %s "
+                    "(schema/spreadsheet files do not support parent windows)",
+                    Path(file_path).name,
+                )
             if document_text and chunks:
                 try:
                     compute_parent_windows(

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -21,7 +21,7 @@ from ..config import settings
 from ..models.database import SQLiteConnectionPool, get_pool
 from ..utils.file_utils import compute_file_hash
 from ..utils.retry import with_retry
-from .chunking import SemanticChunker, ProcessedChunk
+from .chunking import SemanticChunker, ProcessedChunk, compute_parent_windows
 from .chunk_enrichment import ChunkEnrichmentService
 from .contextual_chunking import ContextualChunker
 from .embeddings import EmbeddingService
@@ -334,7 +334,7 @@ class DocumentProcessor:
         max_attempts=3, retry_exceptions=(sqlite3.Error,), raise_last_exception=True
     )
     def _check_duplicate(
-        self, file_hash: str, conn: sqlite3.Connection, vault_id: int = 1
+        self, file_hash: str, conn: sqlite3.Connection, vault_id: int
     ) -> Optional[sqlite3.Row]:
         """
         Check if a file with the given hash already exists and is indexed.
@@ -361,7 +361,7 @@ class DocumentProcessor:
         file_path: str,
         file_hash: str,
         conn: sqlite3.Connection,
-        vault_id: int = 1,
+        vault_id: int,
         source: str = "upload",
         email_subject: Optional[str] = None,
         email_sender: Optional[str] = None,
@@ -690,7 +690,7 @@ class DocumentProcessor:
     async def process_file(
         self,
         file_path: str,
-        vault_id: int = 1,
+        vault_id: int,
         source: str = "upload",
         email_subject: Optional[str] = None,
         email_sender: Optional[str] = None,
@@ -700,7 +700,7 @@ class DocumentProcessor:
 
         Args:
             file_path: Path to the file to process
-            vault_id: The vault ID to associate the file with (defaults to 1)
+            vault_id: The vault ID to associate the file with (required — no default)
             source: Source of the file ('upload', 'scan', 'email')
             email_subject: Subject line for email-sourced files
             email_sender: Sender address for email-sourced files
@@ -798,6 +798,23 @@ class DocumentProcessor:
                         )
                 # else: _get_contextual_chunker already logged a warning if needed
 
+            # Compute parent window offsets for small-to-big retrieval (Issue #12)
+            # Run after contextual chunking so raw_text is the pre-enrichment text.
+            # Only meaningful when document_text is available (not spreadsheets/schemas).
+            if document_text and chunks:
+                try:
+                    compute_parent_windows(
+                        chunks,
+                        document_text,
+                        window_chars=settings.parent_window_chars,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "compute_parent_windows failed for %s: %s — parent offsets will be None",
+                        Path(file_path).name,
+                        e,
+                    )
+
             if not chunks:
                 raise DocumentProcessingError(
                     "No extractable content found in document. "
@@ -892,13 +909,43 @@ class DocumentProcessor:
                         if hasattr(chunk, "raw_text") and chunk.raw_text:
                             chunk_metadata["raw_text"] = chunk.raw_text
 
+                        # Store parent window offsets + text in metadata (Issue #12)
+                        if chunk.parent_window_start is not None:
+                            chunk_metadata["parent_window_start"] = chunk.parent_window_start
+                        if chunk.parent_window_end is not None:
+                            chunk_metadata["parent_window_end"] = chunk.parent_window_end
+                        if chunk.chunk_position is not None:
+                            chunk_metadata["chunk_position"] = chunk.chunk_position
+                        # Store parent window text for fast retrieval-time expansion
+                        # (avoids re-parsing the document at query time)
+                        if (
+                            chunk.parent_window_start is not None
+                            and chunk.parent_window_end is not None
+                            and document_text
+                        ):
+                            chunk_metadata["parent_window_text"] = document_text[
+                                chunk.parent_window_start : chunk.parent_window_end
+                            ]
+
+                        # For safe re-upload, prefix chunk IDs with the new file hash
+                        # so old-generation chunks have distinguishable IDs (Issue #13)
+                        if settings.reupload_safe_order:
+                            record_id = f"{file_id}_{file_hash[:8]}_{chunk_scale}_{chunk.chunk_index}"
+                        else:
+                            record_id = chunk_uid
+
                         record = {
-                            "id": chunk_uid,
+                            "id": record_id,
                             "text": chunk.text,
                             "file_id": str(file_id),
                             "chunk_index": chunk.chunk_index,
                             "vault_id": str(vault_id),
                             "chunk_scale": chunk_scale,
+                            # Parent-document retrieval fields (Issue #12)
+                            "parent_doc_id": str(file_id),
+                            "parent_window_start": chunk.parent_window_start,
+                            "parent_window_end": chunk.parent_window_end,
+                            "chunk_position": chunk.chunk_position,
                             "metadata": json.dumps(chunk_metadata),
                             "embedding": embedding,
                         }
@@ -916,9 +963,26 @@ class DocumentProcessor:
                     # Initialize vector table with embedding dimension and add chunks
                     embedding_dim = len(embeddings[0])
                     await self.vector_store.init_table(embedding_dim)
-                    # Delete any previously orphaned chunks for idempotency on retry
-                    await self.vector_store.delete_by_file(str(file_id))
-                    await self.vector_store.add_chunks(records)
+
+                    if settings.reupload_safe_order:
+                        # Safe re-upload: insert new generation first, then delete old (Issue #13)
+                        # Step 1+2: Insert new-generation chunks (hash-prefixed IDs)
+                        await self.vector_store.add_chunks(records)
+                        # Step 3: Delete old-generation chunks for this file
+                        # (chunks whose IDs don't start with the new hash prefix)
+                        deleted = await self.vector_store.delete_old_generation_by_file(
+                            str(file_id), file_hash[:8]
+                        )
+                        if deleted > 0:
+                            logger.info(
+                                "Safe re-upload: deleted %d old-generation chunks for file_id=%s",
+                                deleted,
+                                file_id,
+                            )
+                    else:
+                        # Legacy: delete-then-insert (not crash-safe, kept for compat)
+                        await self.vector_store.delete_by_file(str(file_id))
+                        await self.vector_store.add_chunks(records)
         except Exception as e:
             # Phase 3: Update status to error on failure
             # Get connection again to update error status

--- a/backend/app/services/document_retrieval.py
+++ b/backend/app/services/document_retrieval.py
@@ -5,12 +5,30 @@ Handles document retrieval, filtering by relevance thresholds, and window expans
 
 import json
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
+
+# Matches the 8-hex-char hash produced by reupload_safe_order ID scheme
+_RE_HASH8 = re.compile(r"^[0-9a-f]{8}$")
 
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_reupload_hash(chunk_id: str, file_id: str) -> Optional[str]:
+    """Return the 8-hex hash from a reupload-safe chunk ID, or None for legacy IDs.
+
+    New format: {file_id}_{hash8}_{scale}_{idx}
+    Legacy format: {file_id}_{scale}_{idx} or {file_id}_{idx}
+    """
+    prefix = f"{file_id}_"
+    if not chunk_id.startswith(prefix):
+        return None
+    rest = chunk_id[len(prefix):]
+    candidate = rest.split("_", 1)[0]
+    return candidate if _RE_HASH8.fullmatch(candidate) else None
 
 
 def _normalize_uid_for_dedup(uid: str) -> str:
@@ -229,12 +247,16 @@ class DocumentRetrievalService:
                         record.get("id", "unknown"),
                     )
 
+            raw_meta = self._normalize_metadata(record.get("metadata"))
+            # Carry the actual stored chunk ID so expand_window can handle
+            # reupload-safe hash-prefixed IDs (e.g. "42_abc12345_default_0")
+            raw_meta["_chunk_id"] = record.get("id", "")
             sources.append(
                 RAGSource(
                     text=record.get("text", ""),
                     file_id=record.get("file_id", ""),
                     score=source_score,
-                    metadata=self._normalize_metadata(record.get("metadata")),
+                    metadata=raw_meta,
                 )
             )
 
@@ -340,12 +362,24 @@ class DocumentRetrievalService:
                 for s in file_sources
             ]
 
+            # Detect reupload-safe hash prefix from any source in this group.
+            # New-format IDs: {file_id}_{hash8}_{scale}_{idx}
+            # Legacy IDs: {file_id}_{scale}_{idx} or {file_id}_{idx}
+            hash_prefix: Optional[str] = None
+            for s in file_sources:
+                h = _extract_reupload_hash(s.metadata.get("_chunk_id", ""), file_id)
+                if h:
+                    hash_prefix = h
+                    break
+
             for chunk_index in indices:
                 start_idx = max(0, chunk_index - window)
                 end_idx = chunk_index + window
 
                 for idx in range(start_idx, end_idx + 1):
-                    if chunk_scale != "default":
+                    if hash_prefix:
+                        chunk_uid = f"{file_id}_{hash_prefix}_{chunk_scale}_{idx}"
+                    elif chunk_scale != "default":
                         chunk_uid = f"{file_id}_{chunk_scale}_{idx}"
                     else:
                         chunk_uid = f"{file_id}_{idx}"
@@ -413,9 +447,12 @@ class DocumentRetrievalService:
                     if chunk_scale:
                         metadata["chunk_scale"] = chunk_scale
 
+                    # Use file_id from the record, not parsed from the UID string
+                    # (UID parsing breaks with hash-prefixed new-format IDs)
+                    record_file_id = chunk.get("file_id") or file_id
                     expanded_source = RAGSource(
                         text=chunk.get("text", ""),
-                        file_id=file_id,
+                        file_id=record_file_id,
                         score=distance,
                         metadata=metadata,
                     )

--- a/backend/app/services/document_retrieval.py
+++ b/backend/app/services/document_retrieval.py
@@ -6,7 +6,7 @@ Handles document retrieval, filtering by relevance thresholds, and window expans
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from app.config import settings
 
@@ -44,6 +44,51 @@ def _normalize_uid_for_dedup(uid: str) -> str:
     return uid
 
 
+def _group_aware_dedup(
+    sources: List["RAGSource"],
+    per_doc_chunk_cap: int,
+    unique_docs_in_top_k: int,
+) -> List["RAGSource"]:
+    """Group-aware dedup for final result list (Issue #12).
+
+    Replaces UID-strip dedup that collapsed the best document's multiple strong
+    chunks to a single entry.  This policy:
+    - Preserves up to *per_doc_chunk_cap* chunks per document (default 2).
+    - Caps breadth at *unique_docs_in_top_k* distinct documents (default 5).
+
+    Sources are assumed to be in descending relevance order; iteration order is
+    preserved so the final list is still ranked.
+
+    Args:
+        sources: Candidate RAGSource list, ranked by relevance.
+        per_doc_chunk_cap: Maximum chunks allowed from the same document.
+        unique_docs_in_top_k: Maximum distinct documents in the output.
+
+    Returns:
+        Filtered list respecting both caps.
+    """
+    selected: List["RAGSource"] = []
+    count_per_doc: Dict[str, int] = {}
+    selected_docs: Set[str] = set()
+
+    for source in sources:
+        file_id = source.file_id
+        doc_count = count_per_doc.get(file_id, 0)
+
+        # Cap: too many chunks already from this document
+        if doc_count >= per_doc_chunk_cap:
+            continue
+        # Cap: already at max distinct docs and this is a new one
+        if len(selected_docs) >= unique_docs_in_top_k and file_id not in selected_docs:
+            continue
+
+        selected.append(source)
+        count_per_doc[file_id] = doc_count + 1
+        selected_docs.add(file_id)
+
+    return selected
+
+
 @dataclass
 class RAGSource:
     """Represents a retrieved document source."""
@@ -52,6 +97,9 @@ class RAGSource:
     file_id: str
     score: float
     metadata: Dict[str, Any]
+    # Parent-document retrieval field (Issue #12) — set by rag_engine when
+    # parent_retrieval_enabled=True and the chunk has a stored parent window.
+    parent_window_text: Optional[str] = None
 
 
 class DocumentRetrievalService:
@@ -88,6 +136,7 @@ class DocumentRetrievalService:
         results: List[Dict[str, Any]],
         top_k: Optional[int] = None,
         reranked: bool = False,
+        indexed_file_ids: Optional[Set[str]] = None,
     ) -> List[RAGSource]:
         """Filter retrieved documents by relevance threshold.
 
@@ -98,6 +147,10 @@ class DocumentRetrievalService:
         Args:
             results: List of raw search results from vector store
             top_k: Maximum number of results to return (defaults to retrieval_top_k)
+            reranked: If True, skip distance filtering (reranker score is the signal)
+            indexed_file_ids: If provided, filter out chunks whose file_id is not in
+                this set. Used to hide chunks belonging to files still being ingested
+                (status != 'indexed') — Issue #13 atomic visibility.
 
         Returns:
             List of filtered RAGSource objects
@@ -129,6 +182,16 @@ class DocumentRetrievalService:
         skip_distance_filter = reranked
 
         for record in results:
+            # Issue #13: Atomic visibility — skip chunks from non-indexed files
+            if indexed_file_ids is not None:
+                chunk_file_id = record.get("file_id", "")
+                if chunk_file_id and chunk_file_id not in indexed_file_ids:
+                    logger.debug(
+                        "Skipping chunk from non-indexed file_id=%s (status pending or processing)",
+                        chunk_file_id,
+                    )
+                    continue
+
             has_distance = "_distance" in record
             distance = record.get("_distance")
             if distance is None:
@@ -191,6 +254,23 @@ class DocumentRetrievalService:
                 mean_dist,
                 self.max_distance_threshold,
             )
+
+        # Apply group-aware dedup before window expansion (Issue #12)
+        if settings.new_dedup_policy and sources:
+            before_dedup = len(sources)
+            sources = _group_aware_dedup(
+                sources,
+                per_doc_chunk_cap=settings.per_doc_chunk_cap,
+                unique_docs_in_top_k=settings.unique_docs_in_top_k,
+            )
+            if len(sources) != before_dedup:
+                logger.debug(
+                    "Group-aware dedup: %d → %d sources (cap=%d per-doc, %d unique-docs)",
+                    before_dedup,
+                    len(sources),
+                    settings.per_doc_chunk_cap,
+                    settings.unique_docs_in_top_k,
+                )
 
         # Apply window expansion if enabled
         if self.retrieval_window > 0:

--- a/backend/app/services/prompt_builder.py
+++ b/backend/app/services/prompt_builder.py
@@ -153,6 +153,11 @@ class PromptBuilderService:
     def format_chunk(self, chunk: RAGSource, source_index: int) -> str:
         """Format a chunk for inclusion in the prompt context with a stable source label.
 
+        When ``parent_retrieval_enabled=True`` and the chunk has a pre-computed
+        ``parent_window_text``, the broader parent window is rendered with the
+        matched small chunk wrapped in ``[[MATCH: …]]`` markers so the LLM can see
+        both precise evidence and its surrounding context (Issue #12).
+
         Args:
             chunk: RAGSource to format
             source_index: 1-based index for the stable source label
@@ -177,6 +182,27 @@ class PromptBuilderService:
             header_parts.append(f"id: {chunk.file_id}")
 
         header = " | ".join(header_parts)
+
+        # Parent-window expansion (Issue #12): deliver wider context to LLM.
+        # The matched small chunk is bracketed with [[MATCH: …]] markers inside
+        # the parent window text so the LLM can orient the exact evidence.
+        if settings.parent_retrieval_enabled and chunk.parent_window_text:
+            # Use raw_text (pre-enrichment) for the MATCH region when available
+            match_text = (
+                chunk.metadata.get("raw_text") or chunk.text or ""
+            ).strip()
+            parent_text = chunk.parent_window_text
+
+            if match_text and match_text in parent_text:
+                marked = parent_text.replace(
+                    match_text, f"[[MATCH: {match_text}]]", 1
+                )
+            else:
+                # Fallback: append the small chunk as a MATCH annotation at the end
+                marked = f"{parent_text}\n\n[[MATCH: {match_text}]]"
+
+            return f"{header}\n{marked}"
+
         return f"{header}\n{chunk.text}"
 
     def build_system_prompt(self) -> str:

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 
 from app.config import settings
 from app.services.document_retrieval import DocumentRetrievalService, RAGSource
@@ -282,9 +282,23 @@ class RAGEngine:
                     "token_pack_truncated": 0,
                 }
 
+        # Fetch indexed file IDs for atomic visibility filter (Issue #13)
+        # Only chunks from fully-indexed files are returned — pending/processing files are hidden.
+        indexed_file_ids: Optional[Set[str]] = None
+        try:
+            indexed_file_ids = await asyncio.to_thread(
+                self._get_indexed_file_ids, vault_id
+            )
+        except Exception as _exc:
+            logger.warning(
+                "Failed to fetch indexed_file_ids (visibility filter disabled): %s", _exc
+            )
+
         # Filter relevant chunks using document retrieval service
         relevant_chunks = await self.document_retrieval.filter_relevant(
-            vector_results, reranked=rerank_success if rerank_success is not None else False
+            vector_results,
+            reranked=rerank_success if rerank_success is not None else False,
+            indexed_file_ids=indexed_file_ids,
         )
         logger.info(
             "[query] After filter_relevant: relevant_chunk_count=%d",
@@ -307,6 +321,12 @@ class RAGEngine:
                 )
             except Exception as exc:
                 logger.warning("Context distillation failed, continuing: %s", exc)
+
+        # Parent window expansion: deliver parent context to LLM (Issue #12)
+        # Reads pre-computed parent_window_text from chunk metadata and assigns it to
+        # source.parent_window_text; prompt_builder renders it with [[MATCH:]] markers.
+        if settings.parent_retrieval_enabled and relevant_chunks:
+            relevant_chunks = self._expand_parent_windows(relevant_chunks)
 
         # Check if distance filtering removed all results (no_match)
         if not relevant_chunks and self.document_retrieval.no_match:
@@ -1043,6 +1063,66 @@ class RAGEngine:
         except Exception as exc:
             logger.warning("Supersession check failed (suppressed): %s", exc)
         return None
+
+    def _get_indexed_file_ids(self, vault_id: Optional[int]) -> Optional[Set[str]]:
+        """Return the set of file IDs with status='indexed' from SQLite (Issue #13).
+
+        Used to filter out chunks belonging to files still being ingested (pending /
+        processing) so that partial-ingest state is never visible to the LLM.
+
+        Args:
+            vault_id: If provided, restrict to files in this vault.
+
+        Returns:
+            Set of str file IDs, or None if the lookup fails (caller falls back to
+            no filtering rather than blocking the query).
+        """
+        try:
+            pool = _get_pool()
+            conn = pool.get_connection()
+            try:
+                if vault_id is not None:
+                    cursor = conn.execute(
+                        "SELECT id FROM files WHERE status='indexed' AND vault_id=?",
+                        (vault_id,),
+                    )
+                else:
+                    cursor = conn.execute("SELECT id FROM files WHERE status='indexed'")
+                rows = cursor.fetchall()
+                return {str(row["id"]) for row in rows}
+            finally:
+                pool.release_connection(conn)
+        except Exception as exc:
+            logger.debug("_get_indexed_file_ids failed: %s", exc)
+            return None
+
+    def _expand_parent_windows(self, sources: List[RAGSource]) -> List[RAGSource]:
+        """Populate parent_window_text on each source when available (Issue #12).
+
+        Reads the pre-computed ``parent_window_text`` from chunk metadata (stored
+        at ingest time) and assigns it to ``source.parent_window_text``.  The
+        prompt_builder renders this wider context with ``[[MATCH: …]]`` markers
+        around the original small-chunk text so the LLM sees both the precise match
+        and its surrounding context.
+
+        Only active when ``PARENT_RETRIEVAL_ENABLED=True``.  If a chunk has no
+        stored parent window (legacy chunks, spreadsheets, schema files), the field
+        remains None and the chunk's own text is used as-is.
+        """
+        expanded = 0
+        for source in sources:
+            pw_text = source.metadata.get("parent_window_text")
+            if pw_text:
+                source.parent_window_text = pw_text
+                expanded += 1
+
+        if expanded:
+            logger.debug(
+                "_expand_parent_windows: expanded %d/%d chunks with parent window context",
+                expanded,
+                len(sources),
+            )
+        return sources
 
     async def _expand_window(self, sources: List[RAGSource]) -> List[RAGSource]:
         """Expand search results by fetching adjacent chunks (backward compatibility).

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -76,6 +76,8 @@ class VectorStore:
         self.table: Optional[lancedb.table.AsyncTable] = None
         self._embedding_dim: Optional[int] = None
         self._fts_exceptions: int = 0
+        # Track the row count at last IVF_PQ build to detect post-delete churn (Issue #13)
+        self._last_index_build_row_count: int = 0
 
     async def connect(self) -> "VectorStore":
         """Connect to LanceDB.
@@ -130,6 +132,11 @@ class VectorStore:
                     pa.string(),
                 ),  # JSON string for sparse vectors — retained for schema compat (unused post-Harrier migration)
                 ("metadata", pa.string()),  # JSON string for flexibility
+                # Parent-document retrieval columns (Issue #12) — nullable, backfilled by migration
+                pa.field("parent_doc_id", pa.string(), nullable=True),
+                pa.field("parent_window_start", pa.int32(), nullable=True),
+                pa.field("parent_window_end", pa.int32(), nullable=True),
+                pa.field("chunk_position", pa.int32(), nullable=True),
                 ("embedding", pa.list_(pa.float32(), embedding_dim)),
             ]
         )
@@ -262,6 +269,7 @@ class VectorStore:
                 ),
                 replace=True,
             )
+            self._last_index_build_row_count = row_count  # Track for post-delete churn check
             logger.info(
                 "Vector index creation completed in %.2fs", time.monotonic() - t0
             )
@@ -272,6 +280,84 @@ class VectorStore:
             )
         except (OSError, RuntimeError, ValueError) as e:
             logger.warning("Vector index creation failed: %s", e)
+
+    async def _maybe_rebuild_or_drop_vector_index(self, deleted_count: int) -> None:
+        """Post-delete ANN index lifecycle management (Issue #13).
+
+        After bulk deletes the IVF_PQ index may be stale because it was trained
+        on rows that no longer exist, or we may have crossed the 256-row threshold
+        downward and should fall back to brute-force search.
+
+        Rules:
+        - If current row count drops below VECTOR_INDEX_MIN_ROWS and an IVF_PQ
+          index exists, drop the index so LanceDB falls back to brute-force.
+        - If churn (deleted_count / last_build_row_count) >= INDEX_REBUILD_DELTA,
+          rebuild the index on the remaining rows.
+        """
+        if self.table is None or deleted_count == 0:
+            return
+
+        try:
+            current_rows = await self.table.count_rows()
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.debug("Could not count rows for post-delete index check: %s", e)
+            return
+
+        # Check if index exists
+        has_ivfpq = False
+        try:
+            indices = await self.table.list_indices()
+            has_ivfpq = any(idx.name == "embedding_idx" for idx in indices)
+        except (OSError, RuntimeError, ValueError):
+            pass
+
+        if not has_ivfpq:
+            return  # No index to manage
+
+        # Case 1: Dropped below brute-force threshold — drop the IVF_PQ index
+        if current_rows < VECTOR_INDEX_MIN_ROWS:
+            try:
+                await self.table.drop_index("embedding_idx")
+                self._last_index_build_row_count = 0
+                logger.info(
+                    "Dropped IVF_PQ index: row count (%d) fell below %d threshold; "
+                    "falling back to brute-force search.",
+                    current_rows,
+                    VECTOR_INDEX_MIN_ROWS,
+                )
+            except (OSError, RuntimeError, ValueError) as e:
+                logger.warning("Failed to drop IVF_PQ index after threshold crossed: %s", e)
+            return
+
+        # Case 2: Churn threshold exceeded — rebuild the index
+        if self._last_index_build_row_count > 0:
+            churn = deleted_count / self._last_index_build_row_count
+            if churn >= settings.index_rebuild_delta:
+                t0 = time.monotonic()
+                try:
+                    num_sub_vectors = settings.embedding_dim // 8
+                    await self.table.create_index(
+                        column="embedding",
+                        config=IvfPq(
+                            distance_type=cast(
+                                "Literal['l2', 'cosine', 'dot']", settings.vector_metric
+                            ),
+                            num_partitions=256,
+                            num_sub_vectors=num_sub_vectors,
+                        ),
+                        replace=True,
+                    )
+                    self._last_index_build_row_count = current_rows
+                    logger.info(
+                        "IVF_PQ index rebuilt after %.0f%% row churn (%d deleted, %d remaining) "
+                        "in %.2fs",
+                        churn * 100,
+                        deleted_count,
+                        current_rows,
+                        time.monotonic() - t0,
+                    )
+                except (OSError, RuntimeError, ValueError) as e:
+                    logger.warning("IVF_PQ index rebuild after delete churn failed: %s", e)
 
     async def add_chunks(self, records: List[Dict[str, Any]]) -> None:
         """
@@ -337,6 +423,11 @@ class VectorStore:
                     "sparse_embedding"
                 ),  # Retained for schema compat — unused post-Harrier migration
                 "metadata": record.get("metadata", "{}"),
+                # Parent-document retrieval fields (Issue #12) — None for legacy chunks
+                "parent_doc_id": record.get("parent_doc_id"),
+                "parent_window_start": record.get("parent_window_start"),
+                "parent_window_end": record.get("parent_window_end"),
+                "chunk_position": record.get("chunk_position"),
                 "embedding": embedding,
             }
 
@@ -352,6 +443,12 @@ class VectorStore:
             processed_records.append(processed_record)
 
         await self.table.add(processed_records)
+
+        # Compact the table after every ingest batch (Issue #13: ANN index lifecycle)
+        try:
+            await self.table.optimize()
+        except Exception as e:
+            logger.warning("table.optimize() after add_chunks failed (non-fatal): %s", e)
 
         # Check if we should create the vector index after adding chunks
         await self._maybe_create_vector_index()
@@ -741,6 +838,9 @@ class VectorStore:
         # LanceDB delete using filter expression
         await self.table.delete(f'file_id = "{safe_file_id}"')
 
+        # Manage ANN index lifecycle after delete (Issue #13)
+        await self._maybe_rebuild_or_drop_vector_index(count_before)
+
         return count_before
 
     async def delete_by_vault(self, vault_id: str) -> int:
@@ -786,7 +886,74 @@ class VectorStore:
             count_before = 0
 
         await self.table.delete(f"vault_id = '{safe_vault_id}'")
+
+        # Manage ANN index lifecycle after delete (Issue #13)
+        await self._maybe_rebuild_or_drop_vector_index(count_before)
+
         return count_before
+
+    async def delete_old_generation_by_file(
+        self, file_id: str, new_hash_short: str
+    ) -> int:
+        """Delete stale-generation chunks for a file after a safe re-upload (Issue #13).
+
+        During safe re-upload the new chunks are inserted with IDs of the form
+        ``{file_id}_{new_hash_short}_…``.  This method deletes every chunk for
+        *file_id* whose ``id`` does NOT start with ``{file_id}_{new_hash_short}_``,
+        i.e. chunks from the previous generation.
+
+        Called only when ``REUPLOAD_SAFE_ORDER=True`` and after the new-generation
+        chunks are already visible in the index.
+
+        Args:
+            file_id: The file ID whose old-generation chunks should be removed.
+            new_hash_short: First 8 characters of the new file hash used as
+                generation prefix for the newly inserted chunks.
+
+        Returns:
+            Number of stale-generation chunks deleted.
+        """
+        if self.db is None:
+            await self.connect()
+
+        if self.table is None:
+            try:
+                if self.db is not None:
+                    table_names = await self.db.table_names()
+                    if "chunks" not in table_names:
+                        return 0
+                    self.table = await self.db.open_table("chunks")
+            except (OSError, RuntimeError, ValueError):
+                return 0
+
+        if self.table is None:
+            return 0
+
+        safe_file_id = _lance_escape(file_id)
+        safe_hash = _lance_escape(new_hash_short)
+        # Keep only chunks whose id starts with "{file_id}_{hash_short}_"
+        new_prefix = f"{safe_file_id}_{safe_hash}_"
+        try:
+            count_before = await self.table.count_rows(
+                f"file_id = '{safe_file_id}'"
+            )
+            # Count how many we're keeping (new generation)
+            count_new = await self.table.count_rows(
+                f"file_id = '{safe_file_id}' AND id LIKE '{new_prefix}%'"
+            )
+            old_count = count_before - count_new
+            if old_count <= 0:
+                return 0
+            # Delete the old ones: file_id matches but id does NOT have new prefix
+            await self.table.delete(
+                f"file_id = '{safe_file_id}' AND NOT (id LIKE '{new_prefix}%')"
+            )
+            # Manage ANN index lifecycle after delete (Issue #13)
+            await self._maybe_rebuild_or_drop_vector_index(old_count)
+            return old_count
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.warning("delete_old_generation_by_file failed: %s", e)
+            return 0
 
     async def _safe_table_to_pandas(self, table, operation_name: str):
         """Load a LanceDB table into pandas with OOM protection.
@@ -1181,6 +1348,143 @@ class VectorStore:
             return migrated_count
         except (OSError, RuntimeError, ValueError) as e:
             logger.warning(f"LanceDB sparse_embedding migration failed: {e}")
+            return 0
+
+    async def migrate_add_parent_window(self, dry_run: bool = False) -> int:
+        """Migration: Add parent_doc_id, parent_window_start, parent_window_end, and
+        chunk_position columns to existing chunks that lack them (Issue #12).
+
+        Idempotent — safe to run multiple times. Existing rows receive:
+        - parent_doc_id = file_id (denormalized for query-time access)
+        - parent_window_start = None (backfilled to 0 for first chunk of each file)
+        - parent_window_end = None
+        - chunk_position = chunk_index (sequential index already stored)
+
+        Args:
+            dry_run: If True, report rows that would be updated but make no changes.
+
+        Returns:
+            Number of rows that were (or would be, in dry-run) updated.
+        """
+        if self.db is None:
+            await self.connect()
+
+        if self.db is None:
+            logger.info("LanceDB parent_window migration: no connection available")
+            return 0
+
+        try:
+            table_names = await self.db.table_names()
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.warning(f"LanceDB parent_window migration failed: {e}")
+            return 0
+
+        if "chunks" not in table_names:
+            logger.info("LanceDB parent_window migration: no table exists — nothing to migrate")
+            return 0
+
+        try:
+            table = await self.db.open_table("chunks")
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.warning(f"LanceDB parent_window migration failed to open table: {e}")
+            return 0
+
+        schema = await table.schema()
+        field_names = [schema.field(i).name for i in range(len(schema))]
+        new_cols = {"parent_doc_id", "parent_window_start", "parent_window_end", "chunk_position"}
+        missing_cols = new_cols - set(field_names)
+
+        if not missing_cols:
+            # All columns present — check if any rows still have null parent_doc_id
+            try:
+                df = await self._safe_table_to_pandas(table, "parent_window migration (check)")
+                null_count = int(df["parent_doc_id"].isna().sum())
+                if null_count == 0:
+                    logger.info("LanceDB parent_window migration: all rows already backfilled")
+                    return 0
+                if dry_run:
+                    logger.info(
+                        "[DRY RUN] parent_window migration: %d rows would be backfilled "
+                        "(parent_doc_id is null)", null_count
+                    )
+                    return null_count
+                # Backfill rows where parent_doc_id is null
+                mask = df["parent_doc_id"].isna()
+                df.loc[mask, "parent_doc_id"] = df.loc[mask, "file_id"]
+                df.loc[mask, "chunk_position"] = df.loc[mask, "chunk_index"]
+                # parent_window_start/end remain null — populated on next re-ingest
+                await self.db.drop_table("chunks")
+                self.table = await self.db.create_table("chunks", data=df)
+                logger.info(
+                    "LanceDB parent_window migration: backfilled parent_doc_id on %d rows",
+                    null_count,
+                )
+                return null_count
+            except (OSError, RuntimeError, ValueError) as e:
+                logger.warning(f"LanceDB parent_window migration check failed: {e}")
+                return 0
+
+        # Some columns are missing — add them all
+        try:
+            df = await self._safe_table_to_pandas(table, "parent_window migration (add columns)")
+            if len(df) == 0:
+                logger.info(
+                    "LanceDB parent_window migration: empty table — new schema will be "
+                    "applied on first ingest"
+                )
+                return 0
+
+            migrated_count = len(df)
+            if dry_run:
+                logger.info(
+                    "[DRY RUN] parent_window migration: %d rows would receive new columns: %s",
+                    migrated_count,
+                    ", ".join(sorted(missing_cols)),
+                )
+                return migrated_count
+
+            # Add missing columns with sensible defaults
+            if "parent_doc_id" in missing_cols:
+                df["parent_doc_id"] = df["file_id"]
+            if "chunk_position" in missing_cols:
+                df["chunk_position"] = df["chunk_index"]
+            # parent_window_start / end remain null — populated on next re-ingest
+            for col in ("parent_window_start", "parent_window_end"):
+                if col in missing_cols:
+                    df[col] = None
+
+            await self.db.drop_table("chunks")
+            try:
+                self.table = await self.db.create_table("chunks", data=df)
+                # Restore indices
+                await self.table.create_index(column="text", config=FTS(), replace=True)
+                num_sub_vectors = (self._embedding_dim or settings.embedding_dim) // 8
+                if migrated_count >= VECTOR_INDEX_MIN_ROWS:
+                    await self.table.create_index(
+                        column="embedding",
+                        config=IvfPq(
+                            distance_type=cast(
+                                "Literal['l2', 'cosine', 'dot']", settings.vector_metric
+                            ),
+                            num_partitions=256,
+                            num_sub_vectors=num_sub_vectors,
+                        ),
+                        replace=True,
+                    )
+                    self._last_index_build_row_count = migrated_count
+            except (OSError, RuntimeError, ValueError) as create_err:
+                logger.critical(
+                    "parent_window migration: table dropped but recreate failed: %s. "
+                    "Data may need manual recovery from backup.",
+                    create_err,
+                )
+                raise
+            logger.info(
+                "LanceDB parent_window migration: added columns to %d rows", migrated_count
+            )
+            return migrated_count
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.warning(f"LanceDB parent_window migration failed: {e}")
             return 0
 
     async def get_chunks_by_uid(self, chunk_uids: List[str]) -> List[Dict[str, Any]]:

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -147,6 +147,23 @@ class VectorStore:
             if "chunks" in table_names:
                 try:
                     self.table = await self.db.open_table("chunks")
+                    # Seed churn baseline so post-delete rebuild fires on existing indexes.
+                    # Without this, _last_index_build_row_count stays 0 after restart
+                    # and the churn-based rebuild path never triggers.
+                    try:
+                        existing_indices = await self.table.list_indices()
+                        has_ivfpq = any(
+                            "IVF_PQ" in str(getattr(idx, "index_type", ""))
+                            for idx in existing_indices
+                        )
+                        if has_ivfpq:
+                            self._last_index_build_row_count = await self.table.count_rows()
+                            logger.debug(
+                                "Seeded _last_index_build_row_count=%d from existing IVF_PQ index",
+                                self._last_index_build_row_count,
+                            )
+                    except Exception as _seed_exc:
+                        logger.debug("Could not seed index row count baseline: %s", _seed_exc)
                 except (OSError, RuntimeError, ValueError):
                     # Stale table reference — drop and recreate
                     try:

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -828,15 +828,15 @@ class VectorStore:
             return 0
 
         # Query count before delete to return accurate deletion count
-        safe_file_id = str(file_id).replace('"', '\\"')
+        safe_file_id = _lance_escape(file_id)
         try:
-            count_before = await self.table.count_rows(f'file_id = "{safe_file_id}"')
+            count_before = await self.table.count_rows(f"file_id = '{safe_file_id}'")
         except (OSError, RuntimeError, ValueError):
             # If count_rows fails, safely default to 0
             count_before = 0
 
         # LanceDB delete using filter expression
-        await self.table.delete(f'file_id = "{safe_file_id}"')
+        await self.table.delete(f"file_id = '{safe_file_id}'")
 
         # Manage ANN index lifecycle after delete (Issue #13)
         await self._maybe_rebuild_or_drop_vector_index(count_before)

--- a/backend/tests/test_ingestion_integrity.py
+++ b/backend/tests/test_ingestion_integrity.py
@@ -1,0 +1,581 @@
+"""Tests for ingestion integrity: ANN index lifecycle, visibility filter,
+safe re-upload, vault_id required, and audit migration (Issue #13 / #14)."""
+
+import asyncio
+import inspect
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.document_retrieval import DocumentRetrievalService
+from app.services.vector_store import VECTOR_INDEX_MIN_ROWS, VectorStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_record(file_id: str, chunk_index: int = 0, distance: float = 0.1) -> dict:
+    """Return a minimal search-result dict as returned by vector store search."""
+    return {
+        "id": f"{file_id}_{chunk_index}",
+        "text": f"text from {file_id} chunk {chunk_index}",
+        "file_id": file_id,
+        "vault_id": "1",
+        "chunk_index": chunk_index,
+        "chunk_scale": "default",
+        "metadata": "{}",
+        "_distance": distance,
+    }
+
+
+def _make_mock_table(row_count: int = 300, has_ivfpq: bool = False):
+    """Return a fully-mocked LanceDB table object."""
+    mock_idx = MagicMock()
+    mock_idx.name = "embedding_idx"
+
+    table = MagicMock()
+    table.count_rows = AsyncMock(return_value=row_count)
+    table.list_indices = AsyncMock(return_value=[mock_idx] if has_ivfpq else [])
+    table.drop_index = AsyncMock(return_value=None)
+    table.create_index = AsyncMock(return_value=None)
+    table.add = AsyncMock(return_value=None)
+    table.optimize = AsyncMock(return_value=None)
+    table.delete = AsyncMock(return_value=None)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# ANN index lifecycle tests (Issue #13)
+# ---------------------------------------------------------------------------
+
+class TestAnnIndexLifecycle:
+    """_maybe_rebuild_or_drop_vector_index behavior after bulk deletes."""
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_zero_deleted(self):
+        """deleted_count=0 → method returns immediately without any table ops."""
+        store = VectorStore(db_path=Path("/tmp/ann_test"))
+        store.table = _make_mock_table(row_count=300, has_ivfpq=True)
+        store._last_index_build_row_count = 300
+
+        await store._maybe_rebuild_or_drop_vector_index(deleted_count=0)
+
+        store.table.count_rows.assert_not_called()
+        store.table.drop_index.assert_not_called()
+        store.table.create_index.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drops_index_when_row_count_falls_below_threshold(self):
+        """After delete, if rows < 256 and IVF_PQ exists → index dropped."""
+        store = VectorStore(db_path=Path("/tmp/ann_test"))
+        # Current rows after delete: 100 (below 256)
+        store.table = _make_mock_table(row_count=100, has_ivfpq=True)
+        store._last_index_build_row_count = 300
+
+        await store._maybe_rebuild_or_drop_vector_index(deleted_count=200)
+
+        store.table.drop_index.assert_awaited_once_with("embedding_idx")
+        store.table.create_index.assert_not_called()
+        assert store._last_index_build_row_count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_drop_when_no_ivfpq_index(self):
+        """If no IVF_PQ index exists, nothing is dropped even below threshold."""
+        store = VectorStore(db_path=Path("/tmp/ann_test"))
+        store.table = _make_mock_table(row_count=50, has_ivfpq=False)
+        store._last_index_build_row_count = 300
+
+        await store._maybe_rebuild_or_drop_vector_index(deleted_count=250)
+
+        store.table.drop_index.assert_not_called()
+        store.table.create_index.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rebuilds_index_when_churn_exceeds_delta(self):
+        """When churn (deleted / last_build_count) >= index_rebuild_delta → rebuild."""
+        store = VectorStore(db_path=Path("/tmp/ann_test"))
+        # Last build: 300 rows.  Delete 60 → churn = 0.20 ≥ 0.20 default.
+        # Remaining 240 rows still above 256 threshold so no drop.
+        # Use 290 remaining (delete 10 from 300 = churn 0.033) — wait, we need
+        # rows > 256 AND churn >= 0.20.  Example: 300 → delete 70 → 230 remaining.
+        # 230 < 256 would still trigger drop.  Use 400 → delete 90 → 310 remaining.
+        store.table = _make_mock_table(row_count=310, has_ivfpq=True)
+        store._last_index_build_row_count = 400
+
+        with patch("app.services.vector_store.settings") as mock_settings, \
+             patch("app.services.vector_store.IvfPq") as mock_ivfpq:
+            mock_settings.index_rebuild_delta = 0.2
+            mock_settings.embedding_dim = 8
+            mock_settings.vector_metric = "cosine"
+            mock_ivfpq.return_value = MagicMock()
+            await store._maybe_rebuild_or_drop_vector_index(deleted_count=90)
+
+        store.table.create_index.assert_awaited_once()
+        # last_build count updated to current rows
+        assert store._last_index_build_row_count == 310
+
+    @pytest.mark.asyncio
+    async def test_no_rebuild_below_churn_threshold(self):
+        """When churn < index_rebuild_delta → no rebuild triggered."""
+        store = VectorStore(db_path=Path("/tmp/ann_test"))
+        # Last build: 300 rows.  Delete 10 → churn = 0.033 < 0.20
+        store.table = _make_mock_table(row_count=290, has_ivfpq=True)
+        store._last_index_build_row_count = 300
+
+        with patch("app.services.vector_store.settings") as mock_settings, \
+             patch("app.services.vector_store.IvfPq") as mock_ivfpq:
+            mock_settings.index_rebuild_delta = 0.2
+            mock_settings.embedding_dim = 8
+            mock_settings.vector_metric = "cosine"
+            mock_ivfpq.return_value = MagicMock()
+            await store._maybe_rebuild_or_drop_vector_index(deleted_count=10)
+
+        store.table.create_index.assert_not_called()
+        store.table.drop_index.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_rebuild_when_last_build_count_is_zero(self):
+        """If _last_index_build_row_count is 0 (no index was ever built), skip churn check."""
+        store = VectorStore(db_path=Path("/tmp/ann_test"))
+        store.table = _make_mock_table(row_count=290, has_ivfpq=True)
+        store._last_index_build_row_count = 0  # Never built
+
+        with patch("app.services.vector_store.settings") as mock_settings, \
+             patch("app.services.vector_store.IvfPq") as mock_ivfpq:
+            mock_settings.index_rebuild_delta = 0.2
+            mock_settings.embedding_dim = 8
+            mock_settings.vector_metric = "cosine"
+            mock_ivfpq.return_value = MagicMock()
+            await store._maybe_rebuild_or_drop_vector_index(deleted_count=50)
+
+        store.table.create_index.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# optimize() called after every add_chunks (Issue #13)
+# ---------------------------------------------------------------------------
+
+class TestAddChunksCallsOptimize:
+    """table.optimize() is called after every successful add_chunks batch."""
+
+    @pytest.mark.asyncio
+    async def test_optimize_called_after_table_add(self):
+        """Verify optimize() is awaited once per add_chunks call."""
+        store = VectorStore(db_path=Path("/tmp/opt_test"))
+        mock_table = _make_mock_table(row_count=1, has_ivfpq=False)
+        store.table = mock_table
+        store._embedding_dim = 4
+
+        records = [
+            {
+                "id": "f1_0",
+                "text": "hello",
+                "file_id": "1",
+                "chunk_index": 0,
+                "vault_id": "1",
+                "chunk_scale": "default",
+                "embedding": [0.1, 0.2, 0.3, 0.4],
+            }
+        ]
+
+        with patch("app.services.vector_store.settings") as mock_settings:
+            mock_settings.embedding_dim = 4
+            mock_settings.vector_metric = "cosine"
+            # Bypass dimension validation by mocking _get_expected_embedding_dim
+            store._get_expected_embedding_dim = AsyncMock(return_value=4)
+            await store.add_chunks(records)
+
+        mock_table.optimize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_optimize_failure_is_non_fatal(self):
+        """If optimize() raises, add_chunks should still succeed."""
+        store = VectorStore(db_path=Path("/tmp/opt_test"))
+        mock_table = _make_mock_table(row_count=1, has_ivfpq=False)
+        mock_table.optimize = AsyncMock(side_effect=RuntimeError("optimize failed"))
+        store.table = mock_table
+        store._embedding_dim = 4
+
+        records = [{
+            "id": "f1_0", "text": "hello", "file_id": "1",
+            "chunk_index": 0, "vault_id": "1", "chunk_scale": "default",
+            "embedding": [0.1, 0.2, 0.3, 0.4],
+        }]
+
+        with patch("app.services.vector_store.settings") as mock_settings:
+            mock_settings.embedding_dim = 4
+            mock_settings.vector_metric = "cosine"
+            store._get_expected_embedding_dim = AsyncMock(return_value=4)
+            # Should not raise
+            await store.add_chunks(records)
+
+        mock_table.add.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Atomic visibility filter tests (Issue #13)
+# ---------------------------------------------------------------------------
+
+class TestAtomicVisibilityFilter:
+    """Chunks from non-indexed files are hidden from filter_relevant."""
+
+    def _make_service(self) -> DocumentRetrievalService:
+        """Return a DocumentRetrievalService with dedup and window expansion disabled."""
+        service = DocumentRetrievalService()
+        service.max_distance_threshold = 1.0
+        service.retrieval_window = 0
+        return service
+
+    @pytest.mark.asyncio
+    async def test_pending_file_chunks_excluded(self):
+        """Chunks with file_id not in indexed_file_ids are excluded."""
+        service = self._make_service()
+
+        results = [
+            _make_record("indexed_file", 0, distance=0.1),
+            _make_record("pending_file", 0, distance=0.1),
+            _make_record("indexed_file", 1, distance=0.2),
+        ]
+        indexed = {"indexed_file"}
+
+        with patch("app.services.document_retrieval.settings") as ms:
+            ms.new_dedup_policy = False
+            sources = await service.filter_relevant(results, top_k=10, indexed_file_ids=indexed)
+
+        returned_file_ids = {s.file_id for s in sources}
+
+        assert "indexed_file" in returned_file_ids
+        assert "pending_file" not in returned_file_ids
+
+    @pytest.mark.asyncio
+    async def test_indexed_file_chunks_returned(self):
+        """Chunks whose file_id is in indexed_file_ids pass through."""
+        service = self._make_service()
+
+        results = [_make_record("doc1", i, distance=0.1) for i in range(3)]
+        indexed = {"doc1"}
+
+        with patch("app.services.document_retrieval.settings") as ms:
+            ms.new_dedup_policy = False
+            sources = await service.filter_relevant(results, top_k=10, indexed_file_ids=indexed)
+
+        assert len(sources) == 3
+        assert all(s.file_id == "doc1" for s in sources)
+
+    @pytest.mark.asyncio
+    async def test_none_indexed_file_ids_disables_filter(self):
+        """When indexed_file_ids is None, no visibility filtering is applied."""
+        service = self._make_service()
+
+        results = [
+            _make_record("file_a", 0),
+            _make_record("file_b", 0),
+        ]
+
+        with patch("app.services.document_retrieval.settings") as ms:
+            ms.new_dedup_policy = False
+            sources = await service.filter_relevant(results, top_k=10, indexed_file_ids=None)
+
+        returned_file_ids = {s.file_id for s in sources}
+
+        assert "file_a" in returned_file_ids
+        assert "file_b" in returned_file_ids
+
+    @pytest.mark.asyncio
+    async def test_empty_indexed_set_hides_all_chunks(self):
+        """When indexed_file_ids is an empty set, all chunks are hidden."""
+        service = self._make_service()
+
+        results = [_make_record("doc1", 0), _make_record("doc2", 0)]
+
+        with patch("app.services.document_retrieval.settings") as ms:
+            ms.new_dedup_policy = False
+            sources = await service.filter_relevant(results, top_k=10, indexed_file_ids=set())
+
+        assert sources == []
+
+
+# ---------------------------------------------------------------------------
+# Safe re-upload / delete_old_generation_by_file (Issue #13)
+# ---------------------------------------------------------------------------
+
+class TestSafeReupload:
+    """Old-generation chunks are deleted after new ones are inserted."""
+
+    def _make_store_with_mock_table(
+        self,
+        count_before: int,
+        count_new: int,
+    ) -> VectorStore:
+        """Return a VectorStore with a mocked table for delete_old_generation_by_file."""
+        store = VectorStore(db_path=Path("/tmp/reupload_test"))
+
+        call_number = [0]
+
+        async def mock_count_rows(filter_expr=""):
+            # First call = count_before (all chunks for file_id)
+            # Second call = count_new (only new-gen chunks)
+            call_number[0] += 1
+            return count_new if call_number[0] > 1 else count_before
+
+        table = MagicMock()
+        table.count_rows = AsyncMock(side_effect=mock_count_rows)
+        table.delete = AsyncMock(return_value=None)
+        table.list_indices = AsyncMock(return_value=[])  # No IVF_PQ index
+        store.table = table
+        store.db = MagicMock()  # Prevent real connect() call
+        store._last_index_build_row_count = 0
+        return store
+
+    @pytest.mark.asyncio
+    async def test_old_generation_chunks_deleted(self):
+        """delete_old_generation_by_file returns the number of stale chunks removed."""
+        # 2 total chunks, 1 new-gen → 1 old-gen should be deleted
+        store = self._make_store_with_mock_table(count_before=2, count_new=1)
+
+        deleted = await store.delete_old_generation_by_file("42", "abc12345")
+
+        assert deleted == 1
+        store.table.delete.assert_awaited_once()
+        # The delete filter should target file_id='42' excluding new prefix
+        delete_call_args = store.table.delete.call_args[0][0]
+        assert "42" in delete_call_args
+        assert "abc12345" in delete_call_args
+
+    @pytest.mark.asyncio
+    async def test_new_generation_chunks_preserved(self):
+        """delete_old_generation_by_file does not delete when count_new == count_before."""
+        # All chunks are already new-gen (nothing to delete)
+        store = self._make_store_with_mock_table(count_before=1, count_new=1)
+
+        deleted = await store.delete_old_generation_by_file("10", "deadbeef")
+
+        assert deleted == 0
+        store.table.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_zero_chunk_state(self):
+        """New-gen chunks inserted BEFORE old-gen deleted → always ≥1 chunk visible.
+
+        This tests that the delete_old_generation_by_file pattern preserves a
+        positive chunk count by having new chunks exist before calling delete.
+        Since we mock table.count_rows to reflect 2 chunks (new + old), the
+        count during the transition is always ≥1.
+        """
+        # 2 total (new + old), 1 new-gen → after delete: 1 new-gen remains
+        store = self._make_store_with_mock_table(count_before=2, count_new=1)
+
+        deleted = await store.delete_old_generation_by_file("99", "cafef00d")
+
+        # During delete: count_before was 2 (new + old gen coexist → no zero-chunk gap)
+        assert deleted == 1
+        # Verify delete was called (old gen removed)
+        store.table.delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_filter_targets_correct_file_id(self):
+        """The delete filter uses the correct file_id and new hash prefix."""
+        store = self._make_store_with_mock_table(count_before=3, count_new=2)
+
+        await store.delete_old_generation_by_file("file_abc", "h4sh5678")
+
+        delete_call_args = store.table.delete.call_args[0][0]
+        assert "file_abc" in delete_call_args
+        assert "h4sh5678" in delete_call_args
+
+
+# ---------------------------------------------------------------------------
+# Upload API: vault_id required → 422 on missing (Issue #14)
+# ---------------------------------------------------------------------------
+
+class TestUploadApiVaultIdRequired:
+    """Upload endpoints declare vault_id as required (Query with no default)."""
+
+    def _read_documents_route_source(self) -> str:
+        """Return the source of documents.py without importing it."""
+        src_path = (
+            Path(__file__).parent.parent / "app" / "api" / "routes" / "documents.py"
+        )
+        return src_path.read_text()
+
+    def test_upload_root_uses_query_ellipsis_for_vault_id(self):
+        """upload_document_root declares vault_id=Query(...) — no default value."""
+        source = self._read_documents_route_source()
+        # FastAPI Query(...) with Ellipsis makes a query param required (returns 422 if absent).
+        # The old code used Query(1, ...) or Query(default=1).
+        # We verify the required pattern is present.
+        assert "vault_id: int = Query(...," in source or 'vault_id: int = Query(...)' in source, (
+            "upload_document_root should declare vault_id with Query(...) — no default"
+        )
+
+    def test_upload_root_does_not_have_default_vault_id_1(self):
+        """vault_id must NOT default to 1 in the upload endpoints."""
+        source = self._read_documents_route_source()
+        # Old pattern was Query(1, ...) or default=1 for vault_id in upload endpoints
+        # Ensure the breaking change is present
+        upload_section = source[source.find("async def upload_document_root"):]
+        # Only look in the first ~20 lines of the function definition
+        first_lines = "\n".join(upload_section.splitlines()[:20])
+        assert "vault_id: int = Query(1" not in first_lines, (
+            "vault_id must not default to 1 — it should be required (Query(...))"
+        )
+
+    def test_upload_endpoint_does_not_have_default_vault_id_1(self):
+        """vault_id must NOT default to 1 in upload_document endpoint."""
+        source = self._read_documents_route_source()
+        upload_section = source[source.find("async def upload_document"):]
+        first_lines = "\n".join(upload_section.splitlines()[:20])
+        assert "vault_id: int = Query(1" not in first_lines, (
+            "vault_id must not default to 1 in upload_document — it should be required"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Audit migration (Issue #13)
+# ---------------------------------------------------------------------------
+
+class TestAuditVaultDefaults:
+    """audit_vault_defaults.run_audit flags vault-1 auto-assigned documents."""
+
+    def _create_db(self, tmp_path: Path, rows: list[dict]) -> Path:
+        """Create a temp SQLite db with a files table and given rows."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE files ("
+            "id TEXT PRIMARY KEY, file_name TEXT, file_path TEXT, "
+            "vault_id INTEGER, source TEXT, status TEXT, created_at TEXT)"
+        )
+        for row in rows:
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, vault_id, source, status, created_at) "
+                "VALUES (:id, :file_name, :file_path, :vault_id, :source, :status, :created_at)",
+                row,
+            )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_flags_vault1_upload_indexed_documents(self):
+        """Docs with vault_id=1, source='upload', status='indexed' are flagged."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = self._create_db(Path(tmp), [
+                {"id": "1", "file_name": "a.pdf", "file_path": "/a.pdf",
+                 "vault_id": 1, "source": "upload", "status": "indexed",
+                 "created_at": "2025-01-01"},
+                {"id": "2", "file_name": "b.pdf", "file_path": "/b.pdf",
+                 "vault_id": 1, "source": "upload", "status": "indexed",
+                 "created_at": "2025-01-02"},
+            ])
+            results = run_audit(db_path=db_path)
+
+        assert len(results) == 2
+        assert all(r["vault_id"] == 1 for r in results)
+
+    def test_ignores_documents_in_other_vaults(self):
+        """Docs with vault_id != 1 are not flagged."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = self._create_db(Path(tmp), [
+                {"id": "3", "file_name": "c.pdf", "file_path": "/c.pdf",
+                 "vault_id": 2, "source": "upload", "status": "indexed",
+                 "created_at": "2025-01-01"},
+            ])
+            results = run_audit(db_path=db_path)
+
+        assert len(results) == 0
+
+    def test_ignores_non_indexed_status(self):
+        """Docs with status != 'indexed' are not flagged."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = self._create_db(Path(tmp), [
+                {"id": "4", "file_name": "d.pdf", "file_path": "/d.pdf",
+                 "vault_id": 1, "source": "upload", "status": "processing",
+                 "created_at": "2025-01-01"},
+                {"id": "5", "file_name": "e.pdf", "file_path": "/e.pdf",
+                 "vault_id": 1, "source": "upload", "status": "failed",
+                 "created_at": "2025-01-02"},
+            ])
+            results = run_audit(db_path=db_path)
+
+        assert len(results) == 0
+
+    def test_ignores_non_upload_source(self):
+        """Docs with source != 'upload' (e.g., auto-scan) are not flagged."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = self._create_db(Path(tmp), [
+                {"id": "6", "file_name": "f.pdf", "file_path": "/f.pdf",
+                 "vault_id": 1, "source": "auto_scan", "status": "indexed",
+                 "created_at": "2025-01-01"},
+            ])
+            results = run_audit(db_path=db_path)
+
+        assert len(results) == 0
+
+    def test_returns_empty_for_clean_db(self):
+        """Empty files table returns empty list."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = self._create_db(Path(tmp), [])
+            results = run_audit(db_path=db_path)
+
+        assert results == []
+
+    def test_returns_empty_when_db_missing(self):
+        """Non-existent db file returns empty list without error."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        results = run_audit(db_path=Path("/nonexistent/path/db.sqlite"))
+        assert results == []
+
+    def test_missing_source_column_falls_back(self):
+        """Old schema without 'source' column uses fallback query (flags all vault-1 indexed)."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = tmp + "/test.db"
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "CREATE TABLE files ("
+                "id TEXT PRIMARY KEY, file_name TEXT, file_path TEXT, "
+                "vault_id INTEGER, status TEXT, created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, vault_id, status, created_at) "
+                "VALUES ('7', 'g.pdf', '/g.pdf', 1, 'indexed', '2025-01-01')"
+            )
+            conn.commit()
+            conn.close()
+
+            results = run_audit(db_path=Path(db_path))
+
+        # Should flag the row even without source column
+        assert len(results) == 1
+        assert results[0]["id"] == "7"
+
+    def test_audit_is_idempotent(self):
+        """Running audit twice produces the same result."""
+        from app.migrations.audit_vault_defaults import run_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = self._create_db(Path(tmp), [
+                {"id": "8", "file_name": "h.pdf", "file_path": "/h.pdf",
+                 "vault_id": 1, "source": "upload", "status": "indexed",
+                 "created_at": "2025-01-01"},
+            ])
+            results1 = run_audit(db_path=db_path)
+            results2 = run_audit(db_path=db_path)
+
+        assert len(results1) == len(results2) == 1

--- a/backend/tests/test_parent_retrieval.py
+++ b/backend/tests/test_parent_retrieval.py
@@ -1,0 +1,374 @@
+"""Tests for parent-document retrieval: schema migration, ingestion, dedup, and prompt expansion (Issue #12)."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from dataclasses import asdict
+
+from app.services.chunking import ProcessedChunk, compute_parent_windows
+from app.services.document_retrieval import RAGSource, _group_aware_dedup
+
+
+# ---------------------------------------------------------------------------
+# compute_parent_windows tests
+# ---------------------------------------------------------------------------
+
+class TestComputeParentWindows:
+    def _make_chunk(self, text: str, index: int, raw_text: str = None) -> ProcessedChunk:
+        return ProcessedChunk(
+            text=text,
+            metadata={"chunk_index": index},
+            chunk_index=index,
+            raw_text=raw_text,
+        )
+
+    def test_basic_window_computation(self):
+        source_text = "A" * 1000 + "HELLO WORLD" + "B" * 1000
+        chunk = self._make_chunk("HELLO WORLD", 0)
+        chunks = compute_parent_windows([chunk], source_text, window_chars=200)
+
+        assert chunks[0].parent_window_start is not None
+        assert chunks[0].parent_window_end is not None
+        assert chunks[0].chunk_position == 0
+        # The match text should be inside the window
+        assert "HELLO WORLD" in source_text[
+            chunks[0].parent_window_start : chunks[0].parent_window_end
+        ]
+
+    def test_window_does_not_exceed_document_bounds(self):
+        source_text = "SHORT DOC"
+        chunk = self._make_chunk("SHORT DOC", 0)
+        chunks = compute_parent_windows([chunk], source_text, window_chars=10000)
+
+        assert chunks[0].parent_window_start == 0
+        assert chunks[0].parent_window_end == len(source_text)
+
+    def test_uses_raw_text_when_available(self):
+        source_text = "original raw chunk text sits here"
+        chunk = self._make_chunk(
+            text="[CONTEXT PREFIX] original raw chunk text sits here",
+            index=0,
+            raw_text="original raw chunk text sits here",
+        )
+        chunks = compute_parent_windows([chunk], source_text, window_chars=200)
+
+        # Should find raw_text in source
+        assert chunks[0].parent_window_start is not None
+        assert chunks[0].chunk_position == 0
+
+    def test_chunk_not_found_leaves_offsets_none(self):
+        source_text = "completely different text"
+        chunk = self._make_chunk("this text does not appear in the source", 0)
+        chunks = compute_parent_windows([chunk], source_text, window_chars=200)
+
+        assert chunks[0].parent_window_start is None
+        assert chunks[0].parent_window_end is None
+
+    def test_10000_char_source_covers_source(self):
+        """10000-char source with 3 chunks — parent windows should collectively cover the source."""
+        source_text = "X" * 3000 + "CHUNK_A" + "X" * 3000 + "CHUNK_B" + "X" * 3000 + "CHUNK_C" + "X" * 1000
+        chunks = [
+            self._make_chunk("CHUNK_A", 0),
+            self._make_chunk("CHUNK_B", 1),
+            self._make_chunk("CHUNK_C", 2),
+        ]
+        window_chars = 6000
+        compute_parent_windows(chunks, source_text, window_chars=window_chars)
+
+        # All three chunks should have valid offsets
+        for c in chunks:
+            assert c.parent_window_start is not None
+            assert c.parent_window_end is not None
+            assert c.parent_window_end > c.parent_window_start
+
+    def test_chunk_position_assigned_sequentially(self):
+        source_text = "abc def ghi"
+        chunks = [
+            self._make_chunk("abc", 0),
+            self._make_chunk("def", 1),
+            self._make_chunk("ghi", 2),
+        ]
+        compute_parent_windows(chunks, source_text, window_chars=50)
+
+        for i, c in enumerate(chunks):
+            assert c.chunk_position == i
+
+    def test_empty_chunks_list(self):
+        result = compute_parent_windows([], "some text", window_chars=100)
+        assert result == []
+
+    def test_empty_source_text(self):
+        chunk = self._make_chunk("hello", 0)
+        result = compute_parent_windows([chunk], "", window_chars=100)
+        assert result[0].parent_window_start is None
+
+
+# ---------------------------------------------------------------------------
+# _group_aware_dedup tests (Issue #12)
+# ---------------------------------------------------------------------------
+
+class TestGroupAwareDedup:
+    def _make_source(self, file_id: str, score: float = 0.9) -> RAGSource:
+        return RAGSource(
+            text=f"text from {file_id}",
+            file_id=file_id,
+            score=score,
+            metadata={},
+        )
+
+    def test_single_doc_two_strong_chunks_both_survive(self):
+        """Two strong chunks from the same doc should both survive with cap=2."""
+        sources = [
+            self._make_source("doc1", 0.95),
+            self._make_source("doc1", 0.90),
+        ]
+        result = _group_aware_dedup(sources, per_doc_chunk_cap=2, unique_docs_in_top_k=5)
+
+        assert len(result) == 2
+        assert all(s.file_id == "doc1" for s in result)
+
+    def test_third_chunk_same_doc_dropped_with_cap_2(self):
+        """A document with 3 chunks only contributes 2 when PER_DOC_CHUNK_CAP=2."""
+        sources = [
+            self._make_source("doc1", 0.95),
+            self._make_source("doc1", 0.90),
+            self._make_source("doc1", 0.85),
+        ]
+        result = _group_aware_dedup(sources, per_doc_chunk_cap=2, unique_docs_in_top_k=5)
+        assert len(result) == 2
+
+    def test_top_k_contains_at_most_unique_docs_in_top_k_distinct_file_ids(self):
+        """Result should have at most UNIQUE_DOCS_IN_TOP_K distinct file_ids."""
+        sources = [self._make_source(f"doc{i}") for i in range(10)]
+        result = _group_aware_dedup(sources, per_doc_chunk_cap=1, unique_docs_in_top_k=5)
+
+        distinct_file_ids = {s.file_id for s in result}
+        assert len(distinct_file_ids) <= 5
+        assert len(result) == 5
+
+    def test_doc_with_6_strong_chunks_contributes_2_not_6_not_1(self):
+        """Issue #12 core scenario: best doc contributes 2, not 1 (UID-strip bug) or 6."""
+        sources = [self._make_source("best_doc", 1.0 - i * 0.01) for i in range(6)]
+        sources += [self._make_source(f"other_doc_{i}", 0.5) for i in range(5)]
+        result = _group_aware_dedup(sources, per_doc_chunk_cap=2, unique_docs_in_top_k=5)
+
+        best_doc_chunks = [s for s in result if s.file_id == "best_doc"]
+        assert len(best_doc_chunks) == 2
+
+    def test_ranking_order_preserved(self):
+        """The relative order of selected sources should be preserved."""
+        sources = [
+            self._make_source("doc1", 0.9),
+            self._make_source("doc2", 0.8),
+            self._make_source("doc1", 0.7),
+        ]
+        result = _group_aware_dedup(sources, per_doc_chunk_cap=2, unique_docs_in_top_k=5)
+        file_ids = [s.file_id for s in result]
+        assert file_ids == ["doc1", "doc2", "doc1"]
+
+    def test_empty_input(self):
+        result = _group_aware_dedup([], per_doc_chunk_cap=2, unique_docs_in_top_k=5)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# RAGSource parent_window_text field tests (Issue #12)
+# ---------------------------------------------------------------------------
+
+class TestRAGSourceParentWindowText:
+    def test_parent_window_text_default_none(self):
+        src = RAGSource(text="hello", file_id="1", score=0.9, metadata={})
+        assert src.parent_window_text is None
+
+    def test_parent_window_text_can_be_set(self):
+        src = RAGSource(text="hello", file_id="1", score=0.9, metadata={})
+        src.parent_window_text = "broader context [[MATCH: hello]] more context"
+        assert src.parent_window_text is not None
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder [[MATCH:]] rendering tests (Issue #12)
+# ---------------------------------------------------------------------------
+
+class TestPromptBuilderParentWindow:
+    """Test that format_chunk renders [[MATCH:]] markers when parent window is available."""
+
+    def _make_source_with_parent(
+        self, chunk_text: str, parent_text: str, raw_text: str = None
+    ) -> RAGSource:
+        src = RAGSource(
+            text=chunk_text,
+            file_id="42",
+            score=0.85,
+            metadata={
+                "source_file": "test.pdf",
+                "raw_text": raw_text or chunk_text,
+                "parent_window_text": parent_text,
+            },
+        )
+        src.parent_window_text = parent_text
+        return src
+
+    def test_match_marker_inserted_when_parent_retrieval_enabled(self):
+        from app.services.prompt_builder import PromptBuilderService
+
+        src = self._make_source_with_parent(
+            chunk_text="the quick brown fox",
+            parent_text="once upon a time the quick brown fox jumped over the lazy dog",
+        )
+
+        with patch("app.services.prompt_builder.settings") as mock_settings:
+            mock_settings.parent_retrieval_enabled = True
+            mock_settings.anchor_best_chunk = False
+            mock_settings.primary_evidence_count = 0
+            mock_settings.context_max_tokens = 6000
+
+            builder = PromptBuilderService()
+            formatted = builder.format_chunk(src, source_index=1)
+
+        assert "[[MATCH: the quick brown fox]]" in formatted
+        assert "once upon a time" in formatted
+
+    def test_no_match_marker_when_parent_retrieval_disabled(self):
+        from app.services.prompt_builder import PromptBuilderService
+
+        src = self._make_source_with_parent(
+            chunk_text="the quick brown fox",
+            parent_text="once upon a time the quick brown fox jumped over the lazy dog",
+        )
+
+        with patch("app.services.prompt_builder.settings") as mock_settings:
+            mock_settings.parent_retrieval_enabled = False
+            mock_settings.anchor_best_chunk = False
+
+            builder = PromptBuilderService()
+            formatted = builder.format_chunk(src, source_index=1)
+
+        assert "[[MATCH:" not in formatted
+        assert "the quick brown fox" in formatted
+
+    def test_fallback_when_match_text_not_in_parent(self):
+        """If match text not found in parent window, append as annotation."""
+        from app.services.prompt_builder import PromptBuilderService
+
+        src = self._make_source_with_parent(
+            chunk_text="exact match phrase",
+            parent_text="completely unrelated parent context",
+        )
+
+        with patch("app.services.prompt_builder.settings") as mock_settings:
+            mock_settings.parent_retrieval_enabled = True
+            mock_settings.anchor_best_chunk = False
+
+            builder = PromptBuilderService()
+            formatted = builder.format_chunk(src, source_index=1)
+
+        # Fallback: both parent text and match annotation present
+        assert "completely unrelated parent context" in formatted
+        assert "[[MATCH:" in formatted
+
+
+# ---------------------------------------------------------------------------
+# VectorStore schema migration tests (Issue #12)
+# ---------------------------------------------------------------------------
+
+class TestMigrateAddParentWindow:
+    """Test migrate_add_parent_window idempotency and dry-run behavior (mocked)."""
+
+    def _make_store_with_all_columns_no_nulls(self) -> "VectorStore":
+        """Return a mocked VectorStore where all parent_window columns exist and
+        parent_doc_id has no nulls — migration should be a no-op."""
+        import pyarrow as pa
+        from unittest.mock import AsyncMock, MagicMock
+        from app.services.vector_store import VectorStore
+        from pathlib import Path
+
+        store = VectorStore(db_path=Path("/tmp/mig_test"))
+
+        # Simulate a schema that already includes all 4 parent-window columns
+        field_names = [
+            "id", "text", "file_id", "vault_id", "chunk_index", "chunk_scale",
+            "sparse_embedding", "metadata",
+            "parent_doc_id", "parent_window_start", "parent_window_end",
+            "chunk_position", "embedding",
+        ]
+
+        class FakeField:
+            def __init__(self, name):
+                self.name = name
+
+        class FakeSchema:
+            def __init__(self):
+                self._fields = [FakeField(n) for n in field_names]
+
+            def __len__(self):
+                return len(self._fields)
+
+            def field(self, i):
+                return self._fields[i]
+
+        mock_table = MagicMock()
+        mock_table.schema = AsyncMock(return_value=FakeSchema())
+        mock_table.count_rows = AsyncMock(return_value=1)
+
+        # Simulate a pandas-like DataFrame where parent_doc_id has zero nulls.
+        # We avoid importing pandas to keep the test self-contained.
+        class FakeColumn:
+            def isna(self):
+                return self
+            def sum(self):
+                return 0  # No nulls
+
+        class FakeDF:
+            def __getitem__(self, key):
+                return FakeColumn()
+            def __len__(self):
+                return 1
+
+        df = FakeDF()
+
+        mock_db = MagicMock()
+        mock_db.table_names = AsyncMock(return_value=["chunks"])
+        mock_db.open_table = AsyncMock(return_value=mock_table)
+
+        store.db = mock_db
+        store.table = mock_table
+        store._embedding_dim = 4
+
+        # Monkeypatch _safe_table_to_pandas to return the prepared df
+        async def _fake_safe_to_pandas(table, op_name):
+            return df
+
+        store._safe_table_to_pandas = _fake_safe_to_pandas
+        return store
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_zero_when_all_rows_backfilled(self):
+        """Dry run returns 0 when no rows have null parent_doc_id."""
+        store = self._make_store_with_all_columns_no_nulls()
+        count = await store.migrate_add_parent_window(dry_run=True)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_migration_is_idempotent_when_no_nulls(self):
+        """Running migration twice when already up-to-date returns 0 both times."""
+        store = self._make_store_with_all_columns_no_nulls()
+        count1 = await store.migrate_add_parent_window(dry_run=False)
+        count2 = await store.migrate_add_parent_window(dry_run=False)
+        assert count1 == 0
+        assert count2 == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_table_exists(self):
+        """If 'chunks' table doesn't exist, migration returns 0 (nothing to migrate)."""
+        from unittest.mock import AsyncMock, MagicMock
+        from app.services.vector_store import VectorStore
+        from pathlib import Path
+
+        store = VectorStore(db_path=Path("/tmp/mig_test"))
+        mock_db = MagicMock()
+        mock_db.table_names = AsyncMock(return_value=[])  # No "chunks" table
+        store.db = mock_db
+
+        count = await store.migrate_add_parent_window(dry_run=True)
+        assert count == 0

--- a/backend/tests/test_parent_retrieval.py
+++ b/backend/tests/test_parent_retrieval.py
@@ -93,6 +93,21 @@ class TestComputeParentWindows:
         for i, c in enumerate(chunks):
             assert c.chunk_position == i
 
+    def test_duplicate_chunk_text_advances_cursor(self):
+        """Repeated chunk text: second occurrence should be matched past the first."""
+        # Build source with the same phrase appearing twice at distinct offsets
+        repeated = "the answer is 42"
+        padding = "x" * 100
+        source_text = padding + repeated + padding + repeated + padding
+        chunk0 = self._make_chunk(repeated, 0)
+        chunk1 = self._make_chunk(repeated, 1)
+        compute_parent_windows([chunk0, chunk1], source_text, window_chars=60)
+        # Both chunks must get non-None offsets
+        assert chunk0.parent_window_start is not None
+        assert chunk1.parent_window_start is not None
+        # The two windows must not be identical — they should point to different occurrences
+        assert chunk0.parent_window_start != chunk1.parent_window_start
+
     def test_empty_chunks_list(self):
         result = compute_parent_windows([], "some text", window_chars=100)
         assert result == []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,13 @@ services:
       - ADMIN_SECRET_TOKEN=${ADMIN_SECRET_TOKEN}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-change-me-to-a-random-64-char-string}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - PARENT_RETRIEVAL_ENABLED=${PARENT_RETRIEVAL_ENABLED:-false}
+      - PARENT_WINDOW_CHARS=${PARENT_WINDOW_CHARS:-6000}
+      - NEW_DEDUP_POLICY=${NEW_DEDUP_POLICY:-true}
+      - PER_DOC_CHUNK_CAP=${PER_DOC_CHUNK_CAP:-2}
+      - UNIQUE_DOCS_IN_TOP_K=${UNIQUE_DOCS_IN_TOP_K:-5}
+      - INDEX_REBUILD_DELTA=${INDEX_REBUILD_DELTA:-0.2}
+      - REUPLOAD_SAFE_ORDER=${REUPLOAD_SAFE_ORDER:-true}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docs/release.md
+++ b/docs/release.md
@@ -634,6 +634,77 @@ groups:
 
 ## Release Notes
 
+### Version 0.2.0 (Phase 7 — Issues #2, #12, #13, #14)
+
+#### Breaking Changes
+
+**vault_id is now required on document upload (Issue #14)**
+The `/api/documents` and `/api/documents/upload` POST endpoints no longer default
+`vault_id` to `1`. Requests without `vault_id` receive HTTP 422. Update any upload
+clients to pass `?vault_id=<id>` explicitly.
+
+#### Re-embedding Required for Existing Deployments (Issue #2)
+
+Deployments upgrading from BGE-M3 (768-dim) to Harrier (1024-dim) must re-embed all
+documents. Existing LanceDB vectors are incompatible with the new embedding dimension
+and will produce empty search results.
+
+**Migration steps:**
+1. Backup LanceDB and SQLite data.
+2. Run `python scripts/migrate_embeddings.py` (wipes LanceDB, resets file statuses).
+3. Restart the service — the background processor re-indexes all documents.
+
+The `/api/health?deep=true` endpoint now returns `"stale_embeddings": true` in the
+`vector_store` section when a dimension mismatch is detected, surfacing this issue
+without a silent failure mode.
+
+#### New Features
+
+- **Parent-document retrieval / small-to-big (Issue #12):** When `PARENT_RETRIEVAL_ENABLED=true`,
+  the RAG engine retrieves a ±3000-character window around each matched chunk and surfaces
+  it to the LLM with a `[[MATCH: ...]]` anchor so the model sees precise evidence in context.
+  Feature-flagged off by default. New config: `PARENT_RETRIEVAL_ENABLED`, `PARENT_WINDOW_CHARS`.
+
+- **Group-aware dedup (Issue #12):** Replaces the UID-strip dedup that collapsed multiple
+  strong chunks from the same document into a single result. The best document now contributes
+  up to 2 chunks (configurable via `PER_DOC_CHUNK_CAP`), preserving evidence density. Up to
+  5 distinct documents are returned (`UNIQUE_DOCS_IN_TOP_K`).
+
+- **Atomic ingestion visibility (Issue #13):** Chunks from documents still being processed
+  (status `pending` or `processing`) are hidden from RAG search results until the file
+  reaches `indexed` status, preventing partial-document answers.
+
+- **Safe re-upload ordering (Issue #13):** When `REUPLOAD_SAFE_ORDER=true` (default), new
+  chunk generations are inserted before old ones are deleted, eliminating the zero-chunk
+  window during re-upload that could produce empty results.
+
+- **ANN index lifecycle management (Issue #13):** The IVF_PQ vector index is now automatically
+  rebuilt after ≥20% row churn from deletes, and dropped when row count falls below 256
+  (brute-force threshold). `INDEX_REBUILD_DELTA` controls the churn threshold.
+
+- **Schema migration — parent window columns (Issue #12):** LanceDB schema now includes
+  `parent_doc_id`, `parent_window_start`, `parent_window_end`, and `chunk_position` columns.
+  Run `python -m app.migrations.add_parent_window` to backfill existing databases.
+
+- **Vault-1 default audit (Issue #13):** `python -m app.migrations.audit_vault_defaults`
+  reports documents that were silently assigned to vault 1 before the vault_id-required change.
+
+#### Configuration Changes
+
+New environment variables (all optional, sensible defaults):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PARENT_RETRIEVAL_ENABLED` | `false` | Enable small-to-big context expansion |
+| `PARENT_WINDOW_CHARS` | `6000` | Characters per parent window (±3000 around chunk) |
+| `NEW_DEDUP_POLICY` | `true` | Use group-aware dedup (replaces UID-strip) |
+| `PER_DOC_CHUNK_CAP` | `2` | Max chunks per document in final result set |
+| `UNIQUE_DOCS_IN_TOP_K` | `5` | Max distinct documents in final result set |
+| `INDEX_REBUILD_DELTA` | `0.2` | Churn fraction (deletes/last_build) to trigger ANN rebuild |
+| `REUPLOAD_SAFE_ORDER` | `true` | Insert new chunks before deleting old on re-upload |
+
+---
+
 ### Version 0.1.0 (Phase 6)
 
 - Added comprehensive integration test suite

--- a/scripts/migrate_embeddings.py
+++ b/scripts/migrate_embeddings.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Embedding dimension migration script — wipe stale LanceDB vectors and queue re-indexing.
+
+Use this script when upgrading to a new embedding model that produces a different vector
+dimension (e.g., BGE-M3 768-dim → Harrier 1024-dim). The LanceDB vector store cannot
+hold embeddings of mixed dimensions, so the entire index must be cleared and rebuilt.
+
+What this script does
+---------------------
+1. Detects whether a dimension mismatch exists between the configured
+   ``EMBEDDING_DIM`` and the dimension stored in the current LanceDB table.
+2. Wipes the LanceDB directory (irreversible without a backup — see ``--dry-run``).
+3. Resets all ``indexed`` files in SQLite to ``pending`` so the background
+   processor will re-embed them on next startup.
+
+Properties
+----------
+- **Idempotent**: safe to run on a fresh deployment (no-op when LanceDB is empty).
+- **Dry-run mode**: ``--dry-run`` reports what would change without modifying data.
+- **Irreversible**: deletes the LanceDB directory.  Back up first if you need rollback.
+
+Usage
+-----
+    # Dry run — report only, no changes
+    python scripts/migrate_embeddings.py --dry-run
+
+    # Live run — wipe LanceDB, reset file statuses
+    python scripts/migrate_embeddings.py
+
+    # Specify paths manually (if running outside Docker)
+    python scripts/migrate_embeddings.py \\
+        --lancedb-path /data/knowledgevault/lancedb \\
+        --sqlite-path  /data/knowledgevault/app.db
+
+After running
+-------------
+Restart the application so the background processor picks up pending files:
+
+    docker compose restart knowledgevault
+"""
+
+import argparse
+import logging
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dimension detection
+# ---------------------------------------------------------------------------
+
+def _detect_stored_dim(lancedb_path: Path) -> int | None:
+    """Return the embedding dimension stored in the LanceDB chunks table, or None.
+
+    Uses pyarrow directly rather than lancedb to avoid async complexity in a
+    plain sync script.
+    """
+    lance_dir = lancedb_path / "chunks.lance"
+    if not lance_dir.exists():
+        return None
+
+    try:
+        import pyarrow.dataset as ds
+
+        dataset = ds.dataset(str(lance_dir), format="lance")
+        schema = dataset.schema
+        embedding_field = schema.field("embedding")
+        # LanceDB stores fixed-size list embeddings as FixedSizeList type
+        if hasattr(embedding_field.type, "list_size"):
+            return embedding_field.type.list_size
+        # Fallback: list type length from value_type hint
+        if hasattr(embedding_field.type, "list_size"):
+            return embedding_field.type.list_size
+    except Exception as exc:
+        logger.debug("Could not read stored embedding dim via pyarrow: %s", exc)
+
+    # Fallback: read first row via lancedb sync API
+    try:
+        import lancedb as _ldb  # type: ignore
+        db = _ldb.connect(str(lancedb_path))
+        if "chunks" not in db.table_names():
+            return None
+        tbl = db.open_table("chunks")
+        df = tbl.to_pandas(columns=["embedding"]).head(1)
+        if not df.empty:
+            first_emb = df["embedding"].iloc[0]
+            if hasattr(first_emb, "__len__"):
+                return len(first_emb)
+    except Exception as exc:
+        logger.debug("Fallback dimension detection failed: %s", exc)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Migration steps
+# ---------------------------------------------------------------------------
+
+def _wipe_lancedb(lancedb_path: Path, dry_run: bool) -> bool:
+    """Delete the LanceDB directory. Returns True if action was (or would be) taken."""
+    if not lancedb_path.exists():
+        logger.info("LanceDB directory does not exist — nothing to wipe: %s", lancedb_path)
+        return False
+
+    if dry_run:
+        logger.info("[DRY RUN] Would delete LanceDB directory: %s", lancedb_path)
+        return True
+
+    shutil.rmtree(lancedb_path)
+    lancedb_path.mkdir(parents=True, exist_ok=True)
+    logger.info("Deleted and recreated LanceDB directory: %s", lancedb_path)
+    return True
+
+
+def _reset_file_statuses(sqlite_path: Path, dry_run: bool) -> int:
+    """Reset all indexed files to pending. Returns the count of affected rows."""
+    if not sqlite_path.exists():
+        logger.warning("SQLite database not found at %s — skipping status reset.", sqlite_path)
+        return 0
+
+    conn = sqlite3.connect(str(sqlite_path))
+    try:
+        # Check the files table exists
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='files'"
+        )
+        if cursor.fetchone() is None:
+            logger.info("'files' table not found — nothing to reset.")
+            return 0
+
+        cursor = conn.execute(
+            "SELECT COUNT(*) FROM files WHERE status = 'indexed'"
+        )
+        indexed_count = cursor.fetchone()[0]
+
+        if indexed_count == 0:
+            logger.info("No indexed files found — status reset is a no-op.")
+            return 0
+
+        if dry_run:
+            logger.info(
+                "[DRY RUN] Would reset %d indexed file(s) to 'pending'.", indexed_count
+            )
+            return indexed_count
+
+        conn.execute(
+            """
+            UPDATE files
+            SET status = 'pending',
+                chunk_count = 0,
+                processed_at = NULL,
+                modified_at = CURRENT_TIMESTAMP
+            WHERE status = 'indexed'
+            """
+        )
+        conn.commit()
+        logger.info("Reset %d file(s) from 'indexed' to 'pending'.", indexed_count)
+        return indexed_count
+
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run_migration(
+    lancedb_path: Path,
+    sqlite_path: Path,
+    dry_run: bool = False,
+    force: bool = False,
+) -> int:
+    """Run the embedding migration.
+
+    Args:
+        lancedb_path: Path to the LanceDB directory.
+        sqlite_path: Path to the SQLite database file.
+        dry_run: Report changes without writing.
+        force: Skip the dimension-mismatch check and always migrate.
+
+    Returns:
+        Number of files that were (or would be) reset to 'pending'.
+    """
+    print()
+    print("=" * 60)
+    print("  KnowledgeVault — Embedding Dimension Migration")
+    print("=" * 60)
+    print(f"  LanceDB path : {lancedb_path}")
+    print(f"  SQLite path  : {sqlite_path}")
+    print(f"  Dry run      : {dry_run}")
+    print("=" * 60)
+    print()
+
+    # ── Step 1: Detect dimension mismatch ──────────────────────────────────
+    stored_dim = _detect_stored_dim(lancedb_path)
+
+    if stored_dim is None:
+        if lancedb_path.exists() and any(lancedb_path.iterdir()):
+            logger.info("Could not detect stored embedding dimension — assuming migration needed.")
+        else:
+            logger.info("LanceDB directory is empty or absent — no migration needed.")
+            if not force:
+                print("\nNothing to migrate. If you want to force a reset, use --force.\n")
+                return 0
+
+    try:
+        # Load settings to get configured embedding_dim
+        ROOT = Path(__file__).resolve().parents[1]
+        sys.path.insert(0, str(ROOT / "backend"))
+        from app.config import settings  # noqa: PLC0415
+        configured_dim = settings.embedding_dim
+    except Exception as exc:
+        logger.warning("Could not load settings (EMBEDDING_DIM): %s", exc)
+        configured_dim = None
+
+    if stored_dim and configured_dim and stored_dim == configured_dim and not force:
+        print(
+            f"Embedding dimensions match ({stored_dim}-dim). No migration needed.\n"
+            "To force a reset anyway, use --force.\n"
+        )
+        return 0
+
+    if stored_dim and configured_dim:
+        print(
+            f"Dimension mismatch detected:\n"
+            f"  Stored in LanceDB : {stored_dim}-dim\n"
+            f"  Configured        : {configured_dim}-dim\n"
+            f"  Action            : Wipe LanceDB and reset file statuses.\n"
+        )
+    elif force:
+        print("Running forced migration (--force flag set).\n")
+    else:
+        print("Could not detect stored dimension. Proceeding with migration.\n")
+
+    if not dry_run:
+        print(
+            "WARNING: This will permanently delete all LanceDB vectors.\n"
+            "         Back up /your/data/lancedb before continuing.\n"
+        )
+
+    # ── Step 2: Wipe LanceDB ───────────────────────────────────────────────
+    print("[1/2] Wiping LanceDB vector index...")
+    _wipe_lancedb(lancedb_path, dry_run=dry_run)
+
+    # ── Step 3: Reset file statuses ────────────────────────────────────────
+    print("[2/2] Resetting file statuses to 'pending'...")
+    reset_count = _reset_file_statuses(sqlite_path, dry_run=dry_run)
+
+    # ── Summary ────────────────────────────────────────────────────────────
+    print()
+    if dry_run:
+        print(
+            f"[DRY RUN] Migration summary:\n"
+            f"  LanceDB wipe         : {'yes' if lancedb_path.exists() else 'no (already empty)'}\n"
+            f"  Files to reset       : {reset_count}\n"
+            f"\nRe-run without --dry-run to apply changes."
+        )
+    else:
+        print(
+            f"Migration complete:\n"
+            f"  LanceDB wiped        : yes\n"
+            f"  Files reset          : {reset_count}\n"
+            f"\nNext step: restart the application to begin re-indexing.\n"
+            f"  docker compose restart knowledgevault\n"
+            f"\nThe background processor will re-embed all {reset_count} file(s) automatically."
+        )
+    print()
+    return reset_count
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Wipe stale LanceDB embeddings and reset file statuses for "
+            "embedding model migration (e.g., BGE-M3 768-dim → Harrier 1024-dim)."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without making any modifications.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip dimension-mismatch detection and force migration.",
+    )
+    parser.add_argument(
+        "--lancedb-path",
+        type=Path,
+        default=None,
+        help="Path to LanceDB directory. Defaults to settings.lancedb_path.",
+    )
+    parser.add_argument(
+        "--sqlite-path",
+        type=Path,
+        default=None,
+        help="Path to SQLite database file. Defaults to settings.sqlite_path.",
+    )
+    args = parser.parse_args()
+
+    # Resolve paths
+    lancedb_path = args.lancedb_path
+    sqlite_path = args.sqlite_path
+
+    if lancedb_path is None or sqlite_path is None:
+        ROOT = Path(__file__).resolve().parents[1]
+        sys.path.insert(0, str(ROOT / "backend"))
+        try:
+            from app.config import settings  # noqa: PLC0415
+            if lancedb_path is None:
+                lancedb_path = settings.lancedb_path
+            if sqlite_path is None:
+                sqlite_path = settings.sqlite_path
+        except Exception as exc:
+            print(
+                f"ERROR: Could not load settings: {exc}\n"
+                "Pass --lancedb-path and --sqlite-path explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    run_migration(
+        lancedb_path=lancedb_path,
+        sqlite_path=sqlite_path,
+        dry_run=args.dry_run,
+        force=args.force,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/resolve-swarm-issues/SPEC.md
+++ b/specs/resolve-swarm-issues/SPEC.md
@@ -1,0 +1,190 @@
+# Resolve Swarm Issues #2, #12, #13, #14
+
+## Problem Statement
+
+Four open GitHub issues representing significant tech debt and missing features in the KnowledgeVault RAG pipeline:
+
+- **#14**: Upload API silently defaulted `vault_id=1` when no vault was specified, causing documents to land in the orphan vault without operator awareness.
+- **#12**: The retrieval pipeline retrieved small chunks for precision but only sent those small chunks to the LLM, discarding surrounding context. Additionally, the UID-strip deduplication logic collapsed multiple strong chunks from the same document into a single result.
+- **#13**: Multiple ingestion integrity gaps: chunks from files still being indexed were visible to queries (partial-document answers); re-uploading a file created a zero-chunk window during the delete-then-insert sequence; the ANN vector index was never rebuilt after large deletes, degrading search quality silently.
+- **#2**: After the Harrier embedding migration (BGE-M3 768-dim → Harrier 1024-dim), no tooling or documentation existed to guide operators through re-indexing their document corpus. The health endpoint gave no warning when stale embeddings were detected.
+
+## Goals
+
+Ship all four issues fully wired and production-ready with no deferred work.
+
+## Non-Goals
+
+- Frontend changes
+- Migration auto-run on startup (operators trigger manually)
+- Streaming parent window content
+
+---
+
+## Acceptance Criteria
+
+### Issue #14 — vault_id required on upload
+
+- [x] `POST /api/documents` and `POST /api/documents/upload` return HTTP 422 when `vault_id` query parameter is absent
+- [x] No silent assignment to vault 1
+- [x] Source verification: `vault_id: int = Query(...)` (Ellipsis, no default) on both endpoints
+
+### Issue #12 — Parent-document retrieval (small-to-big)
+
+- [x] LanceDB schema includes `parent_doc_id`, `parent_window_start`, `parent_window_end`, `chunk_position` columns (nullable, backwards-compatible)
+- [x] `compute_parent_windows()` in `chunking.py` locates each chunk's text in the source document and computes a ±3000-char window (default 6000 chars total), clamped to document bounds
+- [x] `compute_parent_windows` prefers `raw_text` (pre-enrichment text) over enriched `text` when locating matches in source
+- [x] Parent window text is stored in chunk metadata at ingest time (no file I/O at retrieval time)
+- [x] When `PARENT_RETRIEVAL_ENABLED=true`, the RAG engine reads `parent_window_text` from metadata and attaches it to `RAGSource` objects
+- [x] `prompt_builder.format_chunk` renders `[[MATCH: <chunk_text>]]` anchor within the parent window when `parent_retrieval_enabled=True`
+- [x] When match text is not found in parent window, falls back to appending `[[MATCH: ...]]` annotation after parent text
+- [x] Group-aware dedup replaces UID-strip dedup: max `PER_DOC_CHUNK_CAP` (default 2) chunks per document, max `UNIQUE_DOCS_IN_TOP_K` (default 5) distinct documents in result set
+- [x] `app/migrations/add_parent_window.py` CLI migration is idempotent, supports `--dry-run`, backfills existing rows with `parent_doc_id=file_id` and `chunk_position=chunk_index`
+- [x] All new behaviour behind feature flags with safe defaults (`PARENT_RETRIEVAL_ENABLED=false`, `NEW_DEDUP_POLICY=true`)
+
+### Issue #13 — Ingestion integrity
+
+- [x] Chunks from files with `status != 'indexed'` are excluded from `filter_relevant` results (atomic visibility via `indexed_file_ids` set)
+- [x] When `REUPLOAD_SAFE_ORDER=true` (default): new chunks are inserted before old chunks are deleted, eliminating the zero-chunk window on re-upload
+- [x] New-generation chunks use hash-prefixed IDs (`{file_id}_{hash8}_{scale}_{idx}`); `delete_old_generation_by_file` removes only old-generation rows
+- [x] `table.optimize()` is called after every `add_chunks` batch (non-fatal on failure)
+- [x] `_maybe_rebuild_or_drop_vector_index(deleted_count)` is called after every `delete_by_file` and `delete_by_vault`: drops IVF_PQ index when rows fall below 256; rebuilds when churn ≥ `INDEX_REBUILD_DELTA` (default 0.20)
+- [x] `app/migrations/audit_vault_defaults.py` CLI audit identifies vault-1 auto-assigned uploads (read-only, idempotent, `--output-csv` support)
+
+### Issue #2 — Embedding dimension migration tooling
+
+- [x] `README.md` includes an "Upgrading" section with step-by-step re-embedding instructions
+- [x] `docs/release.md` documents the Harrier migration as a breaking change requiring re-embedding
+- [x] `scripts/migrate_embeddings.py` detects dimension mismatch, wipes LanceDB, resets file statuses to `pending`, supports `--dry-run` and `--force`; is a no-op on fresh deployments
+- [x] `/api/health?deep=true` returns `"stale_embeddings": true` in `vector_store` when stored embedding dimension ≠ `EMBEDDING_DIM`; logs a `WARNING`
+
+---
+
+## Technical Design
+
+### Parent window storage strategy
+Parent window text is computed at ingest time and stored in `chunk.metadata["parent_window_text"]`. This avoids re-opening PDF/DOCX files at query time. The `compute_parent_windows()` function runs a single linear scan over all chunks for O(n) performance.
+
+### Safe re-upload ID scheme
+New chunks get IDs of the form `{file_id}_{hash8}_{scale}_{index}`. The `delete_old_generation_by_file(file_id, hash8)` method deletes rows matching `file_id = X AND NOT (id LIKE '{file_id}_{hash8}_%')`. This allows new and old generation chunks to coexist momentarily, eliminating the zero-chunk gap.
+
+### Atomic visibility
+`rag_engine.py` fetches `indexed_file_ids` from SQLite via `asyncio.to_thread` before each query. The set is passed to `filter_relevant`, which skips any chunk whose `file_id` is not in the set. On failure, `indexed_file_ids=None` disables filtering gracefully.
+
+### Group-aware dedup
+Two-pass cap: `count_per_doc[file_id] >= PER_DOC_CHUNK_CAP` skips over-represented docs; `len(selected_docs) >= UNIQUE_DOCS_IN_TOP_K and file_id not in selected_docs` caps breadth. Iteration order preserved (descending relevance).
+
+### ANN index lifecycle
+`_last_index_build_row_count` tracked at every IVF_PQ build. On delete: if `current_rows < 256` → drop index (brute-force fallback); if `deleted_count / last_build_count >= INDEX_REBUILD_DELTA` → rebuild. Zero-row `last_build_count` skips the churn check.
+
+### Health check stale embedding detection
+`VectorStore._get_expected_embedding_dim()` reads the embedding field's `list_size` from the LanceDB schema. Compared against `settings.embedding_dim` in the deep health check.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `PARENT_RETRIEVAL_ENABLED` | `false` | Enable small-to-big context expansion |
+| `PARENT_WINDOW_CHARS` | `6000` | Total window size in characters (±3000 around match) |
+| `NEW_DEDUP_POLICY` | `true` | Use group-aware dedup |
+| `PER_DOC_CHUNK_CAP` | `2` | Max chunks per document |
+| `UNIQUE_DOCS_IN_TOP_K` | `5` | Max distinct documents in result set |
+| `INDEX_REBUILD_DELTA` | `0.2` | Delete churn fraction to trigger ANN rebuild |
+| `REUPLOAD_SAFE_ORDER` | `true` | Insert new chunks before deleting old on re-upload |
+
+---
+
+## Test Cases
+
+### Issue #14
+- Upload without `vault_id` → HTTP 422
+- Route source confirms `Query(...)` with no default (verified via source inspection)
+
+### Issue #12 — `compute_parent_windows`
+- Basic window computation: match text found inside window bounds
+- Window clamped to document bounds (no overflow)
+- `raw_text` used preferentially for locating match in source
+- Chunk not found in source → offsets remain `None`
+- 10,000-char source with 3 chunks → all get valid windows
+- Sequential `chunk_position` assignment
+- Empty chunk list → empty result
+- Empty source text → offsets `None`
+
+### Issue #12 — `_group_aware_dedup`
+- Two strong chunks from same doc both survive with `cap=2`
+- Third chunk from same doc dropped
+- Max `unique_docs_in_top_k` distinct file_ids enforced
+- Core scenario: doc with 6 chunks contributes exactly 2
+- Ranking order preserved in output
+- Empty input → empty output
+
+### Issue #12 — Prompt builder
+- `[[MATCH: ...]]` inserted when `parent_retrieval_enabled=True`
+- No marker when `parent_retrieval_enabled=False`
+- Fallback annotation when match text not found in parent window
+
+### Issue #12 — Migration
+- Dry run returns 0 when all rows already have `parent_doc_id`
+- Idempotent: two runs both return 0 when up-to-date
+- Returns 0 when no `chunks` table exists
+
+### Issue #13 — ANN index lifecycle
+- `deleted_count=0` → no table ops called
+- `rows < 256` with IVF_PQ → index dropped, `_last_index_build_row_count` reset
+- No drop when no IVF_PQ index exists
+- Churn ≥ delta → index rebuilt, `_last_index_build_row_count` updated
+- Churn < delta → no rebuild
+- `_last_index_build_row_count=0` → churn check skipped
+
+### Issue #13 — optimize()
+- `optimize()` awaited once per `add_chunks` call
+- `optimize()` failure is non-fatal (no exception propagated)
+
+### Issue #13 — Visibility filter
+- Chunks from non-indexed files excluded when `indexed_file_ids` provided
+- Chunks from indexed files returned
+- `indexed_file_ids=None` disables filter
+- Empty `indexed_file_ids` set hides all chunks
+
+### Issue #13 — Safe re-upload
+- `delete_old_generation_by_file` returns correct deleted count
+- New-generation chunks preserved (0 deleted when all match prefix)
+- During transition: both generations coexist (no zero-chunk window)
+- Delete filter targets correct file_id and hash prefix
+
+### Issue #13 — Audit migration
+- Flags `vault_id=1 AND source='upload' AND status='indexed'` docs
+- Ignores other vaults
+- Ignores non-indexed status
+- Ignores non-upload source
+- Empty files table → empty result
+- Non-existent db → empty result (no crash)
+- Missing `source` column → fallback query (flags all vault-1 indexed)
+- Idempotent: two runs return same count
+
+---
+
+## Files Changed
+
+### Modified
+- `backend/app/api/routes/documents.py` — vault_id required
+- `backend/app/api/routes/health.py` — stale embedding warning
+- `backend/app/config.py` — 7 new config fields + validators
+- `backend/app/services/chunking.py` — `compute_parent_windows()`, `ProcessedChunk` fields
+- `backend/app/services/document_processor.py` — parent window ingest, safe re-upload
+- `backend/app/services/document_retrieval.py` — `_group_aware_dedup()`, `RAGSource.parent_window_text`, `indexed_file_ids` filter
+- `backend/app/services/prompt_builder.py` — `[[MATCH:]]` rendering
+- `backend/app/services/rag_engine.py` — `indexed_file_ids` lookup, parent window expansion
+- `backend/app/services/vector_store.py` — schema, ANN lifecycle, optimize, safe re-upload delete, migration
+- `docs/release.md` — v0.2.0 release notes
+- `README.md` — Upgrading section
+
+### Created
+- `backend/app/migrations/__init__.py`
+- `backend/app/migrations/add_parent_window.py`
+- `backend/app/migrations/audit_vault_defaults.py`
+- `backend/tests/test_parent_retrieval.py` (22 tests)
+- `backend/tests/test_ingestion_integrity.py` (27 tests)
+- `scripts/migrate_embeddings.py`


### PR DESCRIPTION
## Summary

Closes #2, #12, #13, #14. Four issues representing significant tech debt and missing features in the KnowledgeVault RAG pipeline, shipped fully wired with no deferred work.

- **#14 — vault_id required on upload**: Both `POST /api/documents` and `POST /api/documents/upload` now use `vault_id: int = Query(...)` (Ellipsis, no default). Requests without `vault_id` return HTTP 422. Silent assignment to vault 1 is eliminated.
- **#12 — Parent-document retrieval (small-to-big)**: Chunks store a `parent_window_text` in metadata at ingest time (±3000 chars around the match, clamped to document bounds). When `PARENT_RETRIEVAL_ENABLED=true`, the RAG engine attaches the parent window to `RAGSource` objects and the prompt builder renders a `[[MATCH: ...]]` anchor within the window. Group-aware dedup (`PER_DOC_CHUNK_CAP=2`, `UNIQUE_DOCS_IN_TOP_K=5`) replaces the UID-strip dedup that collapsed strong chunks from the same document.
- **#13 — Ingestion integrity**: Three gaps closed: (1) atomic visibility — chunks from non-indexed files are filtered out of results via `indexed_file_ids` set; (2) safe re-upload — new generation chunks use hash-prefixed IDs and are inserted *before* old generation is deleted, eliminating the zero-chunk window; (3) ANN index lifecycle — `_maybe_rebuild_or_drop_vector_index` drops the IVF_PQ index below 256 rows and rebuilds when delete churn ≥ `INDEX_REBUILD_DELTA` (default 20%).
- **#2 — Embedding dimension migration tooling**: `scripts/migrate_embeddings.py` detects dimension mismatch, wipes LanceDB, resets file statuses to `pending`, with `--dry-run` and `--force` flags. `/api/health?deep=true` now returns `"stale_embeddings": true` when stored dimension ≠ `EMBEDDING_DIM`, with a WARNING log. README and `docs/release.md` include step-by-step upgrade instructions.

## What changed

| Area | Files |
|---|---|
| API — vault_id enforcement | `backend/app/api/routes/documents.py` |
| Health — stale embedding detection | `backend/app/api/routes/health.py` |
| Config — 7 new feature flags | `backend/app/config.py` |
| Chunking — parent window computation | `backend/app/services/chunking.py` |
| Document processor — parent window ingest, safe re-upload | `backend/app/services/document_processor.py` |
| Retrieval — group-aware dedup, visibility filter, parent window | `backend/app/services/document_retrieval.py` |
| Prompt builder — `[[MATCH:]]` rendering | `backend/app/services/prompt_builder.py` |
| RAG engine — indexed_file_ids lookup, parent window expansion | `backend/app/services/rag_engine.py` |
| Vector store — schema, ANN lifecycle, optimize, safe delete | `backend/app/services/vector_store.py` |
| Migration scripts | `backend/app/migrations/add_parent_window.py`, `backend/app/migrations/audit_vault_defaults.py` |
| Embedding migration CLI | `scripts/migrate_embeddings.py` |
| Docker compose — 7 new env vars wired | `docker-compose.yml` |
| Docs | `README.md`, `docs/release.md` |
| Tests (50 new) | `backend/tests/test_parent_retrieval.py` (23), `backend/tests/test_ingestion_integrity.py` (27) |

## Bugs fixed during review

A swarm-mode PR review identified and fixed three issues before merge:

1. **`compute_parent_windows` cursor bug** — `search_cursor` was advanced to `idx` (start of match) instead of `chunk_end` (end of match), so duplicate chunk text in a document would map all matching chunks to the first occurrence. Fixed: cursor now advances to `chunk_end`. A new test (`test_duplicate_chunk_text_advances_cursor`) covers this case and would have caught it.

2. **`delete_by_file` filter escaping** — Used manual double-quote escaping (`replace('"', '\\"')`) instead of `_lance_escape()` with single quotes, inconsistent with all other LanceDB filter expressions in the file. Fixed: now uses `_lance_escape()` and single-quote delimiters uniformly.

3. **docker-compose.yml missing 7 env vars** — The 7 new v0.2.0 config variables were not wired into the container, making them impossible to configure via `.env`. Fixed: all 7 added with `${VAR:-default}` pattern.

## Configuration

All new behaviour is feature-flagged with safe defaults:

| Variable | Default | Description |
|---|---|---|
| `PARENT_RETRIEVAL_ENABLED` | `false` | Enable small-to-big context expansion |
| `PARENT_WINDOW_CHARS` | `6000` | Total window size in characters |
| `NEW_DEDUP_POLICY` | `true` | Use group-aware dedup |
| `PER_DOC_CHUNK_CAP` | `2` | Max chunks per document in results |
| `UNIQUE_DOCS_IN_TOP_K` | `5` | Max distinct documents in result set |
| `INDEX_REBUILD_DELTA` | `0.2` | Delete churn fraction to trigger ANN rebuild |
| `REUPLOAD_SAFE_ORDER` | `true` | Insert new chunks before deleting old on re-upload |

## Breaking changes

**Embedding dimension change (Harrier migration):** If upgrading from BGE-M3 (768-dim) to Harrier (1024-dim), run the migration script before restarting:

```bash
# Dry run first
python scripts/migrate_embeddings.py --dry-run

# Apply
python scripts/migrate_embeddings.py
docker compose restart knowledgevault
```

See `README.md` → Upgrading and `docs/release.md` → v0.2.0 for full instructions.

## Known design trade-offs (not blocking)

- **ANN index churn check is per-call, not cumulative**: multiple small deletes (each below `INDEX_REBUILD_DELTA` individually) won't trigger a rebuild even if cumulative churn exceeds the threshold. The current design favours simplicity; operators can force a rebuild via `migrate_embeddings.py --force` if needed.
- **Parent windows not computed for schema/spreadsheet files**: `document_text` is empty for `.sql`/`.ddl` files and reconstructed text for spreadsheets, so `compute_parent_windows` is skipped. A debug log is emitted when `PARENT_RETRIEVAL_ENABLED=true` and the file type doesn't support windows.

## Test plan

- [x] `pytest tests/test_parent_retrieval.py tests/test_ingestion_integrity.py` — 50/50 passed
- [x] `POST /api/documents` without `vault_id` → HTTP 422 (verified via source: `Query(...)` no default)
- [x] `compute_parent_windows` — 9 test cases including duplicate chunk text cursor advancement
- [x] `_group_aware_dedup` — 6 test cases
- [x] Prompt builder `[[MATCH:]]` — 3 test cases
- [x] Migration dry-run idempotency — 3 test cases
- [x] ANN index lifecycle — 6 test cases
- [x] optimize() non-fatal — 2 test cases
- [x] Atomic visibility filter — 4 test cases
- [x] Safe re-upload — 4 test cases
- [x] vault_id required — 3 test cases
- [x] Audit migration — 8 test cases

https://claude.ai/code/session_011CsZuyJLVPhg4Yq1P75kPi