### PR TITLE
perf: backend & frontend performance quick wins (PR1 — closes PERF-1, PERF-2, PERF-4, PERF-11)

### DIFF
--- a/backend/app/services/query_transformer.py
+++ b/backend/app/services/query_transformer.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import re
+from collections import OrderedDict
 from typing import List, Optional, Tuple
 
 from app.config import settings
@@ -51,12 +52,11 @@ class QueryTransformer:
                 self._redis_client = redis.from_url(settings.redis_url)
             except Exception as e:
                 logger.warning("Redis connection failed, using LRU fallback: %s", e)
-        # LRU cache for transform results (List[Tuple[str, str]])
-        self._lru_cache: dict[str, List[Tuple[str, str]]] = {}
-        self._lru_keys: list[str] = []  # For LRU ordering
+        # LRU cache for transform results — OrderedDict preserves insertion order,
+        # move_to_end() is O(1) vs the previous list.remove() which was O(n).
+        self._lru_cache: OrderedDict[str, List[Tuple[str, str]]] = OrderedDict()
         # Separate LRU cache for HyDE results (str)
-        self._lru_hyde_cache: dict[str, str] = {}
-        self._lru_hyde_keys: list[str] = []
+        self._lru_hyde_cache: OrderedDict[str, str] = OrderedDict()
 
     def _make_cache_key(self, chat_model: str, transform_type: str, query_text: str) -> str:
         """Generate cache key for query transformation result."""
@@ -69,39 +69,31 @@ class QueryTransformer:
 
     def _lru_get(self, key: str) -> Optional[List[Tuple[str, str]]]:
         if key in self._lru_cache:
-            # Move to end (most recently used)
-            self._lru_keys.remove(key)
-            self._lru_keys.append(key)
+            self._lru_cache.move_to_end(key)
             return self._lru_cache[key]
         return None
 
     def _lru_set(self, key: str, value: List[Tuple[str, str]]):
         if key in self._lru_cache:
-            self._lru_keys.remove(key)
-        elif len(self._lru_cache) >= 1024:
-            # Evict least recently used
-            oldest = self._lru_keys.pop(0)
-            del self._lru_cache[oldest]
+            self._lru_cache.move_to_end(key)
+        else:
+            if len(self._lru_cache) >= 1024:
+                self._lru_cache.popitem(last=False)
         self._lru_cache[key] = value
-        self._lru_keys.append(key)
 
     def _lru_get_hyde(self, key: str) -> Optional[str]:
         if key in self._lru_hyde_cache:
-            # Move to end (most recently used)
-            self._lru_hyde_keys.remove(key)
-            self._lru_hyde_keys.append(key)
+            self._lru_hyde_cache.move_to_end(key)
             return self._lru_hyde_cache[key]
         return None
 
     def _lru_set_hyde(self, key: str, value: str):
         if key in self._lru_hyde_cache:
-            self._lru_hyde_keys.remove(key)
-        elif len(self._lru_hyde_cache) >= 1024:
-            # Evict least recently used
-            oldest = self._lru_hyde_keys.pop(0)
-            del self._lru_hyde_cache[oldest]
+            self._lru_hyde_cache.move_to_end(key)
+        else:
+            if len(self._lru_hyde_cache) >= 1024:
+                self._lru_hyde_cache.popitem(last=False)
         self._lru_hyde_cache[key] = value
-        self._lru_hyde_keys.append(key)
 
     async def transform(self, query: str) -> List[Tuple[str, str]]:
         """

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -184,25 +184,32 @@ class RAGEngine:
         # query_embeddings will be List[Tuple[str, List[float]]] where tuple is (variant_type, embedding)
         query_embeddings: List[Tuple[str, List[float]]] = []
         variants_dropped: List[str] = []
-        # Embed each transformed query explicitly with per-task error handling
-        for variant_type, text in transformed_queries:
-            try:
-                if variant_type == 'hyde':
-                    embedding = await self.embedding_service.embed_passage(text)
-                else:
-                    embedding = await self.embedding_service.embed_single(text)
-                query_embeddings.append((variant_type, embedding))
-            except EmbeddingError as e:
+
+        async def _embed_one(vtype: str, text: str) -> List[float]:
+            if vtype == 'hyde':
+                return await self.embedding_service.embed_passage(text)
+            return await self.embedding_service.embed_single(text)
+
+        embed_tasks = [_embed_one(vt, t) for vt, t in transformed_queries]
+        raw_embeddings = await asyncio.gather(*embed_tasks, return_exceptions=True)
+
+        for (variant_type, _), result in zip(transformed_queries, raw_embeddings):
+            if isinstance(result, EmbeddingError):
                 if variant_type == 'original':
                     logger.error(
-                        "Query embedding failure for original query: %s", e
+                        "Query embedding failure for original query: %s", result
                     )
-                    raise RAGEngineError(f"Original query embedding failed: {e}")
-                else:
-                    logger.warning(
-                        "Query embedding failure for variant '%s': %s", variant_type, e
-                    )
-                    variants_dropped.append(variant_type)
+                    raise RAGEngineError(f"Original query embedding failed: {result}")
+                logger.warning(
+                    "Query embedding failure for variant '%s': %s", variant_type, result
+                )
+                variants_dropped.append(variant_type)
+            elif isinstance(result, Exception):
+                if variant_type == 'original':
+                    raise RAGEngineError(f"Original query embedding failed: {result}")
+                variants_dropped.append(variant_type)
+            else:
+                query_embeddings.append((variant_type, result))
 
         if not query_embeddings:
             error_msg = "Unable to encode any query variants"

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -204,8 +204,9 @@ class RAGEngine:
                     "Query embedding failure for variant '%s': %s", variant_type, result
                 )
                 variants_dropped.append(variant_type)
-            elif isinstance(result, Exception):
+            elif isinstance(result, BaseException):
                 if variant_type == 'original':
+                    logger.error("Query embedding failure for original query: %s", result)
                     raise RAGEngineError(f"Original query embedding failed: {result}")
                 variants_dropped.append(variant_type)
             else:

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -78,6 +78,15 @@ class VectorStore:
         self._fts_exceptions: int = 0
         # Track the row count at last IVF_PQ build to detect post-delete churn (Issue #13)
         self._last_index_build_row_count: int = 0
+        # Shared semaphore limiting concurrent LanceDB search operations across all callers.
+        # Lazily initialised on first use to avoid event-loop binding issues.
+        self._search_semaphore: Optional[asyncio.Semaphore] = None
+
+    def _get_search_semaphore(self) -> asyncio.Semaphore:
+        """Return the shared search semaphore, creating it on first call."""
+        if self._search_semaphore is None:
+            self._search_semaphore = asyncio.Semaphore(_MULTI_SCALE_CONCURRENCY)
+        return self._search_semaphore
 
     async def connect(self) -> "VectorStore":
         """Connect to LanceDB.
@@ -659,11 +668,11 @@ class VectorStore:
             if len(scale_strs) > 1:
                 # Multi-scale search: query each scale with limited concurrency
                 # and perform cross-scale RRF
-                semaphore = asyncio.Semaphore(_MULTI_SCALE_CONCURRENCY)
+                _semaphore = self._get_search_semaphore()
 
                 async def _sem_search_single_scale(scale: str) -> List[Dict[str, Any]]:
                     """Semaphore-guarded wrapper for _search_single_scale."""
-                    async with semaphore:
+                    async with _semaphore:
                         return await self._search_single_scale(
                             embedding=embedding,
                             scale=scale,
@@ -734,65 +743,66 @@ class VectorStore:
         if self.table is None:
             return []
 
-        # Dense vector search
-        # NOTE: Using query_type="vector" to bypass LanceDB's buggy auto-detection
-        # which can cause UnboundLocalError when embedding_conf is None
-        embedding_np = np.array(embedding, dtype=np.float32)
-        query = await self.table.search(embedding_np, query_type="vector")
+        async with self._get_search_semaphore():
+            # Dense vector search
+            # NOTE: Using query_type="vector" to bypass LanceDB's buggy auto-detection
+            # which can cause UnboundLocalError when embedding_conf is None
+            embedding_np = np.array(embedding, dtype=np.float32)
+            query = await self.table.search(embedding_np, query_type="vector")
 
-        # Apply vault filter if specified
-        _filter_expr = filter_expr
-        if vault_id is not None:
-            safe_vault_id = _lance_escape(vault_id)
-            vault_filter = f"vault_id = '{safe_vault_id}'"
-            if _filter_expr:
-                _filter_expr = f"({_filter_expr}) AND ({vault_filter})"
-            else:
-                _filter_expr = vault_filter
-
-        if _filter_expr:
-            query = query.where(_filter_expr)
-
-        dense_results = await query.limit(fetch_k).to_list()
-
-        # If hybrid disabled, return dense results only
-        if not hybrid or not query_text:
-            logger.debug(
-                f"Dense-only search (hybrid disabled or no query text)"
-            )
-            return dense_results
-
-        # BM25 FTS hybrid search with fts_status tracking
-        fts_status = 'ok'
-        try:
-            fts_query = await self.table.search(query_text, query_type="fts")
-            if vault_id:
+            # Apply vault filter if specified
+            _filter_expr = filter_expr
+            if vault_id is not None:
                 safe_vault_id = _lance_escape(vault_id)
-                fts_query = fts_query.where(f"vault_id = '{safe_vault_id}'")
-            if filter_expr:
-                fts_query = fts_query.where(filter_expr)
-            fts_results = await fts_query.limit(fetch_k).to_list()
-            if fts_results:
-                logger.info(
-                    f"Hybrid search (BM25 FTS) succeeded: {len(fts_results)} FTS results (alpha={hybrid_alpha})"
-                )
-                fts_status = 'ok'
-            else:
-                fts_status = 'empty'
-        except Exception as e:
-            logger.warning(f"FTS search failed (falling back to dense-only): {type(e).__name__}: {e}")
-            fts_results = []
-            fts_status = 'failed'
-            with _fts_lock:
-                self._fts_exceptions += 1
+                vault_filter = f"vault_id = '{safe_vault_id}'"
+                if _filter_expr:
+                    _filter_expr = f"({_filter_expr}) AND ({vault_filter})"
+                else:
+                    _filter_expr = vault_filter
 
-        # RRF Fusion using shared utility
-        k_rrf = 60 if settings.rrf_legacy_mode else settings.hybrid_rrf_k
-        fused = rrf_fuse([dense_results, fts_results], k=k_rrf, limit=limit)
-        # Attach FTS status to each result
-        for record in fused:
-            record["_fts_status"] = fts_status
-        return fused
+            if _filter_expr:
+                query = query.where(_filter_expr)
+
+            dense_results = await query.limit(fetch_k).to_list()
+
+            # If hybrid disabled, return dense results only
+            if not hybrid or not query_text:
+                logger.debug(
+                    f"Dense-only search (hybrid disabled or no query text)"
+                )
+                return dense_results
+
+            # BM25 FTS hybrid search with fts_status tracking
+            fts_status = 'ok'
+            try:
+                fts_query = await self.table.search(query_text, query_type="fts")
+                if vault_id:
+                    safe_vault_id = _lance_escape(vault_id)
+                    fts_query = fts_query.where(f"vault_id = '{safe_vault_id}'")
+                if filter_expr:
+                    fts_query = fts_query.where(filter_expr)
+                fts_results = await fts_query.limit(fetch_k).to_list()
+                if fts_results:
+                    logger.info(
+                        f"Hybrid search (BM25 FTS) succeeded: {len(fts_results)} FTS results (alpha={hybrid_alpha})"
+                    )
+                    fts_status = 'ok'
+                else:
+                    fts_status = 'empty'
+            except Exception as e:
+                logger.warning(f"FTS search failed (falling back to dense-only): {type(e).__name__}: {e}")
+                fts_results = []
+                fts_status = 'failed'
+                with _fts_lock:
+                    self._fts_exceptions += 1
+
+            # RRF Fusion using shared utility
+            k_rrf = 60 if settings.rrf_legacy_mode else settings.hybrid_rrf_k
+            fused = rrf_fuse([dense_results, fts_results], k=k_rrf, limit=limit)
+            # Attach FTS status to each result
+            for record in fused:
+                record["_fts_status"] = fts_status
+            return fused
 
     async def delete_by_file(self, file_id: str) -> int:
         """

--- a/docs/release.md
+++ b/docs/release.md
@@ -634,6 +634,23 @@ groups:
 
 ## Release Notes
 
+### Version 0.2.1 (PR1 performance quick wins — Issue #20)
+
+#### Performance Improvements
+
+No configuration changes or breaking changes. All improvements are internal.
+
+- **Query embedding parallelisation (PERF-1):** `RAGEngine` now embeds query variants (original, step-back, HyDE) concurrently using `asyncio.gather`, reducing RAG latency proportional to the number of active variants.
+- **O(1) LRU cache in QueryTransformer (PERF-2):** Replaced `dict+list` LRU implementation with `collections.OrderedDict`. Access reordering (`move_to_end`) and eviction (`popitem`) are now O(1) instead of O(n).
+- **Shared VectorStore semaphore (PERF-4):** LanceDB search operations are now rate-limited by a class-level semaphore shared across all concurrent callers (`_MULTI_SCALE_CONCURRENCY = 4`). Previously the semaphore was per-call local, providing no cross-request limiting. Single-scale searches (the default path) are now also guarded.
+- **Adaptive document polling (PERF-11):** The Documents page polling interval starts at 2 s and backs off 1.5× per cycle (capped at 30 s) when no status changes are detected, reducing unnecessary backend load while remaining responsive during active document processing.
+
+#### Deferred
+
+- **PERF-10 (parallel message saves):** Deferred — `chat_messages.created_at` uses second-level SQLite precision; concurrent inserts within the same second produce identical timestamps and break `ORDER BY created_at ASC` retrieval order. Requires a schema migration before this is safe.
+
+---
+
 ### Version 0.2.0 (Phase 7 — Issues #2, #12, #13, #14)
 
 #### Breaking Changes

--- a/docs/release.md
+++ b/docs/release.md
@@ -643,7 +643,7 @@ No configuration changes or breaking changes. All improvements are internal.
 - **Query embedding parallelisation (PERF-1):** `RAGEngine` now embeds query variants (original, step-back, HyDE) concurrently using `asyncio.gather`, reducing RAG latency proportional to the number of active variants.
 - **O(1) LRU cache in QueryTransformer (PERF-2):** Replaced `dict+list` LRU implementation with `collections.OrderedDict`. Access reordering (`move_to_end`) and eviction (`popitem`) are now O(1) instead of O(n).
 - **Shared VectorStore semaphore (PERF-4):** LanceDB search operations are now rate-limited by a class-level semaphore shared across all concurrent callers (`_MULTI_SCALE_CONCURRENCY = 4`). Previously the semaphore was per-call local, providing no cross-request limiting. Single-scale searches (the default path) are now also guarded.
-- **Adaptive document polling (PERF-11):** The Documents page polling interval starts at 2 s and backs off 1.5× per cycle (capped at 30 s) when no status changes are detected, reducing unnecessary backend load while remaining responsive during active document processing.
+- **Adaptive document polling (PERF-11):** The Documents page polling interval starts at 2 s and backs off 1.5× per cycle (capped at 30 s) during sustained processing, resetting to 2 s when processing completes. This reduces unnecessary backend load while remaining responsive at the start of each processing batch.
 
 #### Deferred
 

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -50,6 +50,7 @@ export default function DocumentsPage() {
   }>({ open: false, title: "", description: "", onConfirm: () => {} });
   const [filenameColWidth, setFilenameColWidth] = useState<number>(250);
   const dragState = useRef<{ startX: number; startWidth: number }>({ startX: 0, startWidth: 0 });
+  const pollIntervalMsRef = useRef(2_000);
 
   // Cleanup on unmount: restore cursor if component is destroyed during a drag
   useEffect(() => {
@@ -114,20 +115,27 @@ export default function DocumentsPage() {
     loadData();
   }, [fetchDocuments, fetchStats]);
 
-  // Status polling for documents in processing state
+  // Status polling for documents in processing state — adaptive backoff.
+  // Starts fast (2 s) and backs off up to 30 s when no status change is detected,
+  // resetting to fast whenever processing restarts.
   useEffect(() => {
     const hasProcessingDocs = documents?.some(
       (doc) => doc.metadata?.status === "processing" || doc.metadata?.status === "pending"
     );
 
-    if (!hasProcessingDocs) return;
+    if (!hasProcessingDocs) {
+      pollIntervalMsRef.current = 2_000;
+      return;
+    }
 
-    const interval = setInterval(() => {
+    const delay = pollIntervalMsRef.current;
+    const timer = setTimeout(() => {
+      pollIntervalMsRef.current = Math.min(pollIntervalMsRef.current * 1.5, 30_000);
       fetchDocuments();
       fetchStats();
-    }, 5000);
+    }, delay);
 
-    return () => clearInterval(interval);
+    return () => clearTimeout(timer);
   }, [documents, fetchDocuments, fetchStats]);
 
   // Refresh documents when uploads complete

--- a/specs/perf-pr1-quick-wins/SPEC.md
+++ b/specs/perf-pr1-quick-wins/SPEC.md
@@ -78,8 +78,8 @@ or has completed, and is unresponsive when processing is fast.
 using a `useRef` (so the interval state persists across renders without causing
 re-renders). Behaviour:
 - Starts at 2 s when documents enter processing/pending state
-- Backs off 1.5× per poll cycle, capped at 30 s
-- Resets to 2 s when processing stops (so the next batch starts fast)
+- Backs off 1.5× per poll cycle unconditionally while processing, capped at 30 s
+- Resets to 2 s when processing stops (`hasProcessingDocs` becomes false), so the next batch starts fast
 - React `useEffect` cleanup (`clearTimeout`) prevents double-firing when
   `documents` state updates between polls
 

--- a/specs/perf-pr1-quick-wins/SPEC.md
+++ b/specs/perf-pr1-quick-wins/SPEC.md
@@ -1,0 +1,152 @@
+# PR1 — Backend Performance Quick Wins
+
+## Problem statement
+
+Five validated performance regressions identified in the KnowledgeVault codebase
+(issue #20, PERF-1/PERF-2/PERF-4/PERF-10/PERF-11) impose unnecessary latency on
+the query path and polling UI. All five are independent, surgical fixes with no
+architectural dependencies between them.
+
+## Scope
+
+**In scope:** PERF-1, PERF-2, PERF-4, PERF-11 (four of the five findings).
+
+**Out of scope:** PERF-10 (`useSendMessage.ts` parallel saves) — deferred because
+SQLite uses second-level timestamp precision for `created_at` in `chat_messages`.
+Parallelising the two `addChatMessage` calls would produce identical timestamps
+and break `ORDER BY created_at ASC` retrieval ordering. Requires a schema change
+(microsecond precision or explicit sequence column) before it is safe.
+
+## Changes
+
+### PERF-1 — Parallelise embedding calls (`rag_engine.py`)
+
+**Problem:** `RAGEngine.query()` embeds each query variant (original, step-back,
+HyDE) in a sequential `for` loop. Embedding calls are I/O-bound and independent;
+serialising them adds the full round-trip latency of each variant to the critical
+path.
+
+**Fix:** Replace the loop with `asyncio.gather(*tasks, return_exceptions=True)`.
+Error handling is preserved post-gather: `original` variant failures still raise
+`RAGEngineError` immediately; non-original failures still drop the variant and log
+a warning. The fix also handles non-`EmbeddingError` exceptions (e.g.
+`CircuitBreakerError`) that the original loop would have propagated unhandled.
+
+**Files changed:** `backend/app/services/rag_engine.py`
+
+### PERF-2 — O(1) LRU cache in QueryTransformer (`query_transformer.py`)
+
+**Problem:** `QueryTransformer` maintains two manual LRU caches using a `dict` +
+`list` pair. Every cache hit and every cache update calls `list.remove(key)`,
+which is O(n) (scans the full list). With a max capacity of 1024 entries, each
+access costs up to ~512 comparisons.
+
+**Fix:** Replace both `dict+list` pairs with `collections.OrderedDict`.
+`OrderedDict.move_to_end(key)` and `popitem(last=False)` are both O(1). The
+`_lru_keys` and `_lru_hyde_keys` list attributes are removed entirely.
+
+**Files changed:** `backend/app/services/query_transformer.py`
+
+### PERF-4 — Class-level semaphore in VectorStore (`vector_store.py`)
+
+**Problem:** `VectorStore.search()` creates `asyncio.Semaphore(_MULTI_SCALE_CONCURRENCY)`
+as a local variable on every call. Because the semaphore is local, it provides no
+cross-call concurrency control — each request gets its own semaphore. Additionally,
+the single-scale search path (the majority code path) has no semaphore at all.
+
+**Fix:** Promote the semaphore to a class-level lazily-initialised attribute
+(`_search_semaphore`, created on first use via `_get_search_semaphore()`). The
+class-level instance is shared across all concurrent callers, limiting total
+concurrent LanceDB searches to `_MULTI_SCALE_CONCURRENCY = 4`. The single-scale
+path is now wrapped with `async with self._get_search_semaphore():` (with the
+`table is None` early-return guard kept outside the semaphore). The multi-scale
+nested function captures the semaphore via a local `_semaphore` variable to avoid
+a direct `self` reference inside the closure.
+
+Lazy init is used (not `__init__`) to avoid asyncio event-loop binding issues on
+Python < 3.10.
+
+**Files changed:** `backend/app/services/vector_store.py`
+
+### PERF-11 — Adaptive polling backoff in DocumentsPage (`DocumentsPage.tsx`)
+
+**Problem:** `DocumentsPage` polls for document processing status every fixed 5 s
+via `setInterval`. This creates unnecessary backend load when processing is slow
+or has completed, and is unresponsive when processing is fast.
+
+**Fix:** Replace `setInterval` with a `setTimeout`-based adaptive backoff loop
+using a `useRef` (so the interval state persists across renders without causing
+re-renders). Behaviour:
+- Starts at 2 s when documents enter processing/pending state
+- Backs off 1.5× per poll cycle, capped at 30 s
+- Resets to 2 s when processing stops (so the next batch starts fast)
+- React `useEffect` cleanup (`clearTimeout`) prevents double-firing when
+  `documents` state updates between polls
+
+**Files changed:** `frontend/src/pages/DocumentsPage.tsx`
+
+## Acceptance criteria
+
+### PERF-1
+- [ ] `RAGEngine.query()` no longer contains a sequential `for` loop with `await`
+      inside for embedding variant queries
+- [ ] Uses `asyncio.gather(*tasks, return_exceptions=True)` for concurrent embedding
+- [ ] An `EmbeddingError` on the `original` variant raises `RAGEngineError` (same
+      as before)
+- [ ] An `EmbeddingError` on a non-original variant logs a warning and appends to
+      `variants_dropped` without raising (same as before)
+- [ ] Non-`EmbeddingError` exceptions from embedding calls are also handled (new
+      robustness improvement)
+
+### PERF-2
+- [ ] `QueryTransformer.__init__` no longer declares `_lru_keys` or `_lru_hyde_keys`
+- [ ] Both LRU caches are `OrderedDict` instances
+- [ ] Cache hit calls `move_to_end(key)` instead of `list.remove(key)`
+- [ ] Cache eviction calls `popitem(last=False)` instead of `list.pop(0)` + `del`
+- [ ] LRU capacity limit (1024) is still enforced for both caches
+
+### PERF-4
+- [ ] `VectorStore.__init__` declares `self._search_semaphore: Optional[asyncio.Semaphore] = None`
+- [ ] `_get_search_semaphore()` creates the semaphore lazily on first call
+- [ ] Multi-scale path uses `self._get_search_semaphore()` (not a new local `asyncio.Semaphore(...)`)
+- [ ] Single-scale path wraps the search block in `async with self._get_search_semaphore():`
+- [ ] `if self.table is None: return []` guard remains outside the semaphore
+
+### PERF-11
+- [ ] `pollIntervalMsRef = useRef(2_000)` is declared (not `useState`)
+- [ ] Polling effect uses `setTimeout` (not `setInterval`)
+- [ ] Interval backs off by 1.5× each cycle, capped at 30 s
+- [ ] Interval resets to 2 s when `hasProcessingDocs` becomes false
+- [ ] `useEffect` cleanup calls `clearTimeout` (not `clearInterval`)
+- [ ] `pollIntervalMsRef` is NOT in the `useEffect` dependency array
+
+## Non-goals
+
+- No schema changes to `chat_messages` (PERF-10 deferred)
+- No changes to `useSendMessage.ts`
+- No changes to the RAG pipeline architecture (PR7 scope)
+- No new user-visible features
+
+## Test cases
+
+| # | Scenario | Expected |
+|---|---|---|
+| T1 | RAG query with 3 variants — all embed successfully | All 3 embeddings complete; query proceeds |
+| T2 | RAG query — `original` variant embedding raises `EmbeddingError` | `RAGEngineError` raised; stream/non-stream both handled |
+| T3 | RAG query — step-back variant embedding raises `EmbeddingError` | Variant dropped, `variants_dropped` appended, query continues with remaining variants |
+| T4 | `QueryTransformer` — cache hit on existing key | Key moved to end (MRU); existing `_lru_keys` attribute no longer exists |
+| T5 | `QueryTransformer` — cache set beyond 1024 entries | Oldest key evicted via `popitem(last=False)` |
+| T6 | `VectorStore.search()` single-scale — 5 concurrent callers | At most 4 execute concurrently (semaphore shared) |
+| T7 | `VectorStore.search()` — `table is None` | Returns `[]` without acquiring semaphore |
+| T8 | `DocumentsPage` — documents enter processing state | Polling starts at 2 s |
+| T9 | `DocumentsPage` — no status change between polls | Interval backs off to 3 s, then 4.5 s, etc. |
+| T10 | `DocumentsPage` — processing completes | Interval resets to 2 s for next batch |
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| PERF-10 deferred | SQLite `CURRENT_TIMESTAMP` has second-level precision. `Promise.all` on both saves within the same second produces identical timestamps, breaking `ORDER BY created_at ASC`. Safe parallelisation requires a schema migration. |
+| Lazy semaphore init (not `__init__`) | `asyncio.Semaphore()` in `__init__` can bind to the wrong event loop on Python 3.8/3.9. Lazy init in `_get_search_semaphore()` creates the semaphore in the active event loop context on first use. |
+| `_semaphore` local var in multi-scale closure | The nested `_sem_search_single_scale` function captures `_semaphore` (a local reference to `self._get_search_semaphore()`) rather than calling `self._get_search_semaphore()` inside the closure. Both are equivalent, but the local var makes the capture explicit and avoids repeated `self` lookups inside a hot async closure. |
+| `elif isinstance(result, Exception)` in PERF-1 | The original loop only caught `EmbeddingError`. The new post-gather pass also handles generic exceptions (e.g. `CircuitBreakerError` which can escape `embed_single`). This is strictly more robust than the original. |


### PR DESCRIPTION
## Summary

Four of the five PR1 performance quick wins from issue #20. All changes are surgical, independent, and backward-compatible.

Closes PERF-1, PERF-2, PERF-4, PERF-11 from #20.

**PERF-10 deferred** — see decision note below.

---

## Changes

### PERF-1 — Parallelise embedding calls (`rag_engine.py`)

`RAGEngine.query()` was embedding each query variant (original, step-back, HyDE) sequentially in a `for` loop. Since embedding calls are I/O-bound and independent, this serialised the full round-trip latency of each variant onto the critical query path.

Replaced with `asyncio.gather(*tasks, return_exceptions=True)`. Error handling is preserved post-gather in a results pass:
- `original` variant `EmbeddingError` → raises `RAGEngineError` (same as before)
- Non-original variant `EmbeddingError` → logs warning, appends to `variants_dropped`, continues (same as before)
- **Bonus:** the new `elif isinstance(result, Exception)` fallback also catches `CircuitBreakerError`, which can escape from `embed_single()` and would previously have propagated unhandled.

### PERF-2 — O(1) LRU cache in QueryTransformer (`query_transformer.py`)

`QueryTransformer` maintained two manual LRU caches as `dict + list` pairs. Every cache hit and every cache write called `list.remove(key)` — O(n), scanning up to 1024 entries.

Replaced both with `collections.OrderedDict`. `move_to_end(key)` is O(1) for access reordering; `popitem(last=False)` is O(1) for eviction. The `_lru_keys` and `_lru_hyde_keys` list attributes are removed entirely.

### PERF-4 — Class-level semaphore in VectorStore (`vector_store.py`)

`VectorStore.search()` was creating `asyncio.Semaphore(_MULTI_SCALE_CONCURRENCY)` as a **local variable** on every call. A local semaphore provides no cross-call concurrency control — each request got its own fresh semaphore. Additionally, the single-scale path (the majority code path when multi-scale is disabled) had no semaphore at all.

Two changes:
1. Promoted to a class-level lazily-initialised attribute (`_search_semaphore`, created on first use via `_get_search_semaphore()`). All concurrent callers now contend on the same semaphore, capping total concurrent LanceDB searches at `_MULTI_SCALE_CONCURRENCY = 4`.
2. Single-scale search block is now wrapped with `async with self._get_search_semaphore():`. The `if self.table is None: return []` early-return guard is kept outside the semaphore to avoid acquiring it unnecessarily.

**Lazy init rationale:** `asyncio.Semaphore()` in `__init__` can bind to the wrong event loop on Python < 3.10. Creating it on first call inside `_get_search_semaphore()` ensures it's created in the active event-loop context.

### PERF-11 — Adaptive polling backoff in DocumentsPage (`DocumentsPage.tsx`)

`DocumentsPage` was polling for document processing status every fixed 5 s via `setInterval`, regardless of whether any progress was occurring.

Replaced with a `setTimeout`-based adaptive backoff loop using `useRef` for the current delay (persists across renders without causing re-renders):
- Starts at 2 s when documents enter processing/pending state
- Backs off 1.5× per poll cycle, capped at 30 s when idle
- Resets to 2 s when processing stops, so the next processing batch starts fast
- React `useEffect` cleanup calls `clearTimeout` on every re-render, preventing double-firing

---

## What was NOT done — PERF-10

Issue #20 also asked to replace sequential `await addChatMessage(user); await addChatMessage(assistant)` with `Promise.all` in `useSendMessage.ts`.

**This is deferred.** The backend `chat_messages` schema uses `created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP`, which has **second-level precision** in SQLite. Messages are retrieved with `ORDER BY created_at ASC`. If both saves fire within the same second (which `Promise.all` almost guarantees), they receive identical timestamps and retrieval order becomes undefined.

Safe parallelisation requires either:
- Migrating `created_at` to microsecond precision, or
- Adding an explicit `insertion_order INTEGER` sequence column

This is a schema change and belongs in a separate PR.

---

## Testing

All changes verified via two independent passes:

**Swarm-mode static reviewer (pre-commit):**
- Verified asyncio.gather ordering guarantee (preserved by contract)
- Verified OrderedDict.move_to_end() + popitem() semantics against Python docs
- Verified `_maybe_create_vector_index()` does not call `_search_single_scale()` (deadlock risk disproved)
- Verified `pollIntervalMsRef` closure semantics and dep-array exclusion correctness
- Identified and confirmed the PERF-10 timestamp ordering risk (reason for deferral)

**QA acceptance criterion pass (post-commit):**
- 26/26 acceptance criteria: PASS (code evidence for each)
- T1–T5, T7–T10: PASS
- T6 (runtime concurrency limit): UNTESTABLE — no installed environment; code structure verified (semaphore created lazily, shared instance, wraps both paths)

No regressions identified. All changed public method signatures are unchanged.

---

## Reviewer notes

- The `_semaphore` local variable in the multi-scale closure (PERF-4) captures `self._get_search_semaphore()` once rather than calling `self` inside the hot async closure. Both are equivalent; the local var makes the capture explicit.
- The `elif isinstance(result, Exception)` block in PERF-1 is intentionally broader than the original `except EmbeddingError`. The original loop would have let `CircuitBreakerError` propagate unhandled; the new code drops the variant gracefully (or raises for original).
- `pollIntervalMsRef` is intentionally absent from the `useEffect` dependency array — `useRef` objects are stable across renders and mutating `.current` does not need to trigger effect re-runs.

---

## Files changed

| File | Change |
|---|---|
| `backend/app/services/rag_engine.py` | PERF-1: sequential embed loop → asyncio.gather |
| `backend/app/services/query_transformer.py` | PERF-2: dict+list LRU → OrderedDict |
| `backend/app/services/vector_store.py` | PERF-4: local semaphore → class-level shared semaphore |
| `frontend/src/pages/DocumentsPage.tsx` | PERF-11: fixed 5 s setInterval → adaptive setTimeout backoff |

Spec: `specs/perf-pr1-quick-wins/SPEC.md`