### PR TITLE
feat(chat): UI/UX polish across chat module

### DIFF
--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { motion } from "framer-motion";
-import { Bot, Copy, Check, RotateCcw, Bug, ChevronRight, FileText, ThumbsUp, ThumbsDown } from "lucide-react";
+import { Bot, Copy, Check, RotateCcw, Bug, ChevronRight, FileText, ThumbsUp, ThumbsDown, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -153,8 +153,8 @@ function CitationChip({ source, index, onClick }: CitationChipProps) {
       onClick={onClick}
       className={cn(
         "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs",
-        "bg-primary/10 text-primary hover:bg-primary/20 transition-colors",
-        "border border-primary/20"
+        "bg-primary/10 text-primary hover:bg-primary/25 active:scale-95 transition-all duration-150",
+        "border border-primary/20 hover:border-primary/40 hover:shadow-sm"
       )}
       aria-label={`Source ${index + 1}: ${source.filename}`}
     >
@@ -330,7 +330,7 @@ function ActionBar({
   }, [feedback, externalFeedback, onFeedback, saveFeedbackToStorage]);
 
   return (
-    <div className="flex items-center gap-1 mt-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 sm:max-md:opacity-100 transition-opacity">
+    <div className="flex items-center gap-1 mt-3 opacity-30 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
       <TooltipProvider>
         {showCopy && (
           <Tooltip>
@@ -400,7 +400,7 @@ function ActionBar({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={cn("h-7 w-7", feedback === "up" && "bg-accent text-accent-foreground")}
+                  className={cn("h-7 w-7 transition-all duration-150", feedback === "up" && "bg-accent text-accent-foreground scale-110")}
                   onClick={() => handleFeedback("up")}
                   aria-label="Good response"
                   aria-pressed={feedback === "up"}
@@ -418,7 +418,7 @@ function ActionBar({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={cn("h-7 w-7", feedback === "down" && "bg-accent text-accent-foreground")}
+                  className={cn("h-7 w-7 transition-all duration-150", feedback === "down" && "bg-accent text-accent-foreground scale-110")}
                   onClick={() => handleFeedback("down")}
                   aria-label="Bad response"
                   aria-pressed={feedback === "down"}
@@ -551,7 +551,7 @@ export function AssistantMessage({
     >
       {/* Avatar */}
       <div
-        className="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-muted"
+        className="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-primary/10 text-primary"
         aria-hidden="true"
       >
         <Bot className="h-4 w-4" />
@@ -563,7 +563,14 @@ export function AssistantMessage({
         <div className="flex items-center gap-2 mb-1">
           <span className="font-semibold text-sm">Assistant</span>
           {isStreaming && (
-            <span className="text-xs text-muted-foreground animate-pulse">thinking...</span>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs font-medium text-primary/70">Thinking</span>
+              <span className="flex items-center gap-0.5">
+                <span className="h-1.5 w-1.5 rounded-full bg-primary/60 animate-bounce" style={{ animationDelay: "0ms" }} aria-hidden="true" />
+                <span className="h-1.5 w-1.5 rounded-full bg-primary/60 animate-bounce" style={{ animationDelay: "150ms" }} aria-hidden="true" />
+                <span className="h-1.5 w-1.5 rounded-full bg-primary/60 animate-bounce" style={{ animationDelay: "300ms" }} aria-hidden="true" />
+              </span>
+            </div>
           )}
         </div>
 
@@ -595,12 +602,20 @@ export function AssistantMessage({
 
         {/* Error State */}
         {message.error && (
-          <div className="mt-2 text-sm text-destructive">{message.error}</div>
+          <div className="mt-3 flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/30 p-3">
+            <AlertCircle className="h-4 w-4 text-destructive flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-destructive">Error</p>
+              <p className="text-xs text-destructive/80 mt-0.5">{message.error}</p>
+            </div>
+          </div>
         )}
 
         {/* Stopped State */}
         {message.stopped && !message.error && (
-          <div className="mt-2 text-sm text-muted-foreground italic">Generation stopped</div>
+          <div className="mt-3 inline-flex items-center gap-2 rounded-md bg-muted border border-border px-3 py-1.5">
+            <span className="text-xs font-medium text-muted-foreground">Stopped</span>
+          </div>
         )}
 
         {/* Action Bar */}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { User, Bot } from "lucide-react";
+import { User, Bot, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MessageContent } from "./MessageContent";
 import type { Message } from "@/stores/useChatStore";
@@ -19,13 +19,13 @@ export function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
       transition={{ duration: 0.3 }}
       className={cn(
         "flex gap-3 p-4",
-        isUser ? "bg-primary/5" : "bg-muted/30"
+        isUser ? "bg-primary/10" : "bg-muted/30"
       )}
     >
       <div
         className={cn(
           "flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center",
-          isUser ? "bg-primary text-primary-foreground" : "bg-muted"
+          isUser ? "bg-primary text-primary-foreground" : "bg-primary/10 text-primary"
         )}
       >
         {isUser ? (
@@ -49,12 +49,18 @@ export function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
         />
 
         {message.error && (
-          <div className="mt-2 text-sm text-destructive">{message.error}</div>
+          <div className="mt-3 flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/30 p-3">
+            <AlertCircle className="h-4 w-4 text-destructive flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-destructive">Error</p>
+              <p className="text-xs text-destructive/80 mt-0.5">{message.error}</p>
+            </div>
+          </div>
         )}
 
         {message.stopped && !message.error && (
-          <div className="mt-2 text-sm text-muted-foreground italic">
-            Generation stopped
+          <div className="mt-3 inline-flex items-center gap-2 rounded-md bg-muted border border-border px-3 py-1.5">
+            <span className="text-xs font-medium text-muted-foreground">Stopped</span>
           </div>
         )}
       </div>

--- a/frontend/src/components/chat/RightPane.tsx
+++ b/frontend/src/components/chat/RightPane.tsx
@@ -198,7 +198,7 @@ function SourceListItem({
         "w-full text-left p-3 rounded-lg border transition-all",
         "hover:bg-accent/50 hover:border-accent",
         isSelected
-          ? "bg-accent border-primary ring-1 ring-primary"
+          ? "bg-primary/10 border-primary ring-2 ring-primary/30"
           : "bg-card border-border"
       )}
     >

--- a/frontend/src/components/chat/SessionRail.tsx
+++ b/frontend/src/components/chat/SessionRail.tsx
@@ -46,6 +46,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { toast } from "sonner";
 import {
   listChatSessions,
   deleteChatSession,
@@ -324,8 +325,9 @@ export const SessionItem = forwardRef<HTMLDivElement, SessionItemProps>(
         ref={ref}
         className={`
           group relative flex items-center gap-2 rounded-md px-2 py-2 text-sm
-          cursor-pointer transition-colors
-          ${isActive ? "bg-accent/50" : "hover:bg-muted"}
+          cursor-pointer transition-all duration-150
+          border border-transparent
+          ${isActive ? "bg-accent/50 border-border/30" : "hover:bg-muted hover:border-border/50"}
           focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2
         `}
         onClick={() => !isEditing && onClick()}
@@ -881,8 +883,6 @@ export function SessionRail({ vaultId, className }: SessionRailProps) {
       try {
         await updateChatSession(_session.id, newTitle);
       } catch (err) {
-        // Revert on failure — do NOT call setError() here because rename
-        // failure is non-blocking; the reverted title is visible to the user.
         setSessions((prev) =>
           prev.map((s) =>
             s.id === _session.id ? { ...s, title: originalTitle } : s
@@ -890,6 +890,7 @@ export function SessionRail({ vaultId, className }: SessionRailProps) {
         );
         const message = err instanceof Error ? err.message : "Failed to rename session";
         console.warn("Rename failed, reverted:", message);
+        toast.error("Failed to rename session. Reverted to original title.");
       }
     },
     []

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -130,10 +130,10 @@ function EmptyTranscript({
       >
         {/* App branding icon */}
         <div
-          className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10"
+          className="mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-primary/15 shadow-md shadow-primary/10"
           aria-hidden="true"
         >
-          <Sparkles className="h-8 w-8 text-primary" />
+          <Sparkles className="h-10 w-10 text-primary" />
         </div>
 
         <h2 className="mb-2 text-xl font-semibold text-foreground">
@@ -157,7 +157,7 @@ function EmptyTranscript({
               <button
                 key={index}
                 onClick={() => onPromptClick(prompt)}
-                className="group flex items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="group flex items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-all duration-200 hover:bg-accent hover:text-accent-foreground hover:border-accent hover:shadow-sm hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 aria-label={`Use prompt: ${prompt}`}
               >
                 <Sparkles
@@ -300,7 +300,6 @@ function Composer({ onSend, onStop, isStreaming, className, inputRef }: Composer
           >
             <Database className="h-3 w-3" aria-hidden="true" />
             {activeVault.name}
-            <ChevronDown className="h-3 w-3 opacity-50" aria-hidden="true" />
           </Badge>
         </div>
       )}
@@ -326,7 +325,7 @@ function Composer({ onSend, onStop, isStreaming, className, inputRef }: Composer
 
         {/* Slash command menu */}
         <AnimatePresence>
-          {showSlashMenu && filteredCommands.length > 0 && (
+          {showSlashMenu && (
             <motion.div
               initial={{ opacity: 0, y: -8 }}
               animate={{ opacity: 1, y: 0 }}
@@ -338,45 +337,51 @@ function Composer({ onSend, onStop, isStreaming, className, inputRef }: Composer
               className="absolute bottom-full left-0 z-50 mb-2 w-72 overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
             >
               <div className="max-h-64 overflow-y-auto py-1">
-                {filteredCommands.map((command, index) => (
-                  <button
-                    key={command.id}
-                    onClick={() => insertCommand(command)}
-                    onMouseEnter={() => setSelectedCommandIndex(index)}
-                    role="option"
-                    aria-selected={index === selectedCommandIndex}
-                    className={cn(
-                      "flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors",
-                      index === selectedCommandIndex
-                        ? "bg-accent text-accent-foreground"
-                        : "text-popover-foreground hover:bg-accent/50"
-                    )}
-                  >
-                    <span
+                {filteredCommands.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                    No matching commands
+                  </div>
+                ) : (
+                  filteredCommands.map((command, index) => (
+                    <button
+                      key={command.id}
+                      onClick={() => insertCommand(command)}
+                      onMouseEnter={() => setSelectedCommandIndex(index)}
+                      role="option"
+                      aria-selected={index === selectedCommandIndex}
                       className={cn(
-                        "flex h-8 w-8 items-center justify-center rounded-md",
+                        "flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors",
                         index === selectedCommandIndex
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted text-muted-foreground"
+                          ? "bg-accent text-accent-foreground"
+                          : "text-popover-foreground hover:bg-accent/50"
                       )}
                     >
-                      {command.icon}
-                    </span>
-                    <div className="flex flex-col">
-                      <span className="font-medium">{command.label}</span>
                       <span
                         className={cn(
-                          "text-xs",
+                          "flex h-8 w-8 items-center justify-center rounded-md",
                           index === selectedCommandIndex
-                            ? "text-accent-foreground/70"
-                            : "text-muted-foreground"
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-muted-foreground"
                         )}
                       >
-                        {command.description}
+                        {command.icon}
                       </span>
-                    </div>
-                  </button>
-                ))}
+                      <div className="flex flex-col">
+                        <span className="font-medium">{command.label}</span>
+                        <span
+                          className={cn(
+                            "text-xs",
+                            index === selectedCommandIndex
+                              ? "text-accent-foreground/70"
+                              : "text-muted-foreground"
+                          )}
+                        >
+                          {command.description}
+                        </span>
+                      </div>
+                    </button>
+                  ))
+                )}
               </div>
             </motion.div>
           )}
@@ -483,7 +488,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const navigate = useNavigate();
-  const { messages, isStreaming, setInput, clearMessages } = useChatStore();
+  const { messages, isStreaming, setInput, setMessages } = useChatStore();
   const { getActiveVault } = useVaultStore();
   const activeVault = getActiveVault();
   const vaultId = useVaultStore((state) => state.activeVaultId);
@@ -610,12 +615,13 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
     navigate('/documents');
   };
 
-  // Handle retry - find last user message, clear messages, set input, and send
+  // Handle retry - remove last assistant response and re-send the user message
+  // Preserves activeChatId so retry stays in the same session
   const handleRetry = () => {
-    const lastUserMessage = [...messages].reverse().find((msg) => msg.role === "user");
-    if (lastUserMessage) {
-      clearMessages();
-      setInput(lastUserMessage.content);
+    const lastUserIdx = messages.map((m, i) => ({ m, i })).reverse().find(({ m }) => m.role === "user")?.i;
+    if (lastUserIdx !== undefined) {
+      setMessages(messages.slice(0, lastUserIdx));
+      setInput(messages[lastUserIdx].content);
       handleSend();
     }
   };

--- a/frontend/src/hooks/useSendMessage.ts
+++ b/frontend/src/hooks/useSendMessage.ts
@@ -155,6 +155,7 @@ export function useSendMessage(
 
   const handleStop = useCallback(() => {
     useChatStore.getState().stopStreaming();
+    sendingRef.current = false;
   }, []);
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
## Summary

- **Bug fixes**: Stop button lockout (`sendingRef` never reset on abort); retry session fragmentation (`clearMessages` nuked `activeChatId`, creating orphaned sessions on every retry)
- **Visual consistency**: Assistant avatar themed to primary color across `MessageBubble` and `AssistantMessage`; error/stopped states upgraded to styled cards with icons
- **Interaction polish**: Animated thinking dots replace static "thinking..." text; action bar always 30% visible for discoverability; feedback buttons animate on press; prompt cards lift on hover
- **Slash command UX**: Menu now shows "No matching commands" empty state instead of silently hiding
- **Feedback on failure**: Rename failures in `SessionRail` now surface a `toast.error()` instead of silently reverting
- **Source selection**: `RightPane` selected source uses coherent `bg-primary/10 ring-primary/30` instead of mismatched `bg-accent` + `ring-primary`

## Files changed

| File | Change |
|------|--------|
| `hooks/useSendMessage.ts` | Reset `sendingRef` on stop to prevent send lockout |
| `components/chat/TranscriptPane.tsx` | Fix `handleRetry` session fragmentation; slash command empty state; prompt card hover lift |
| `components/chat/AssistantMessage.tsx` | Animated thinking dots; persistent action bar; tactile feedback buttons; themed avatar; styled error/stopped |
| `components/chat/MessageBubble.tsx` | Themed assistant avatar; styled error/stopped states |
| `components/chat/SessionRail.tsx` | `toast.error` on rename failure; richer session item hover border |
| `components/chat/RightPane.tsx` | Coherent source selection style |

## Test plan

- [ ] Send a message, click Stop mid-stream — verify send button re-enables immediately
- [ ] Send a message with an error response, click Retry — verify it retries in the same session (same URL/chat ID)
- [ ] Type `/xyz` in the composer — verify "No matching commands" appears in the slash menu
- [ ] Rename a session while offline — verify a toast error appears and title reverts
- [ ] Click a source in the Sources tab — verify it highlights with primary blue ring (not terracotta)
- [ ] Hover a session in the rail — verify subtle border appears on hover
- [ ] Observe assistant message while streaming — verify animated dots appear

https://claude.ai/code/session_01Qd5EBQHQJyk4w5Zg6CYWEL