### PR TITLE
Fix chat UI issues: double thinking, copy fallback, auto-scroll, overlap, add forking

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -84,6 +84,12 @@ class UpdateSessionRequest(BaseModel):
     title: str
 
 
+class ForkSessionRequest(BaseModel):
+    """Request model for forking a chat session from a specific message index."""
+
+    message_index: int = Field(..., ge=0, description="Index of the last message to include in the fork (0-based)")
+
+
 def stream_chat_response(
     message: str,
     history: List[Dict[str, Any]],
@@ -315,7 +321,7 @@ async def list_sessions(
     # Build single JOIN query with optional vault_id filter to avoid N+1
     if vault_id is not None:
         query = """
-            SELECT s.id, s.vault_id, s.title, s.created_at, s.updated_at, COUNT(m.id) as message_count
+            SELECT s.id, s.vault_id, s.title, s.created_at, s.updated_at, COUNT(m.id) as message_count, s.forked_from_session_id, s.fork_message_index
             FROM chat_sessions s
             LEFT JOIN chat_messages m ON m.session_id = s.id
             WHERE s.vault_id = ?
@@ -325,7 +331,7 @@ async def list_sessions(
         params = (vault_id,)
     else:
         query = """
-            SELECT s.id, s.vault_id, s.title, s.created_at, s.updated_at, COUNT(m.id) as message_count
+            SELECT s.id, s.vault_id, s.title, s.created_at, s.updated_at, COUNT(m.id) as message_count, s.forked_from_session_id, s.fork_message_index
             FROM chat_sessions s
             LEFT JOIN chat_messages m ON m.session_id = s.id
             GROUP BY s.id
@@ -336,7 +342,7 @@ async def list_sessions(
     result = await asyncio.to_thread(conn.execute, query, params)
     rows = await asyncio.to_thread(result.fetchall)
 
-    # Map rows to dicts (message_count is now the 6th column, index 5)
+    # Map rows to dicts
     sessions_with_count = []
     for row in rows:
         sessions_with_count.append(
@@ -347,6 +353,8 @@ async def list_sessions(
                 "created_at": row[3],
                 "updated_at": row[4],
                 "message_count": row[5],
+                "forked_from_session_id": row[6],
+                "fork_message_index": row[7],
             }
         )
 
@@ -458,6 +466,82 @@ async def create_session(
         "title": row[2],
         "created_at": row[3],
         "updated_at": row[4],
+    }
+
+
+@router.post("/chat/sessions/{session_id}/fork")
+async def fork_session(
+    session_id: int,
+    request: ForkSessionRequest,
+    conn: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    """
+    Fork a chat session from a specific message index.
+
+    Creates a new session containing messages 0..message_index (inclusive)
+    from the original session, preserving vault context.
+    """
+    # Fetch original session
+    session_result = await asyncio.to_thread(
+        conn.execute,
+        "SELECT id, vault_id, title FROM chat_sessions WHERE id = ?",
+        (session_id,),
+    )
+    session_row = await asyncio.to_thread(session_result.fetchone)
+    if session_row is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    vault_id = session_row[1]
+    if not await evaluate_policy(user, "vault", vault_id, "write"):
+        raise HTTPException(status_code=403, detail="No write access to this vault")
+
+    # Fetch messages up to message_index
+    messages_result = await asyncio.to_thread(
+        conn.execute,
+        "SELECT role, content, sources, created_at FROM chat_messages WHERE session_id = ? ORDER BY created_at ASC, id ASC",
+        (session_id,),
+    )
+    all_rows = await asyncio.to_thread(messages_result.fetchall)
+    forked_rows = all_rows[: request.message_index + 1]
+
+    # Create new forked session
+    fork_title = f"Branch of {session_row[2] or 'conversation'}"
+    cursor = await asyncio.to_thread(
+        conn.execute,
+        "INSERT INTO chat_sessions (vault_id, title, forked_from_session_id, fork_message_index, created_at, updated_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        (vault_id, fork_title, session_id, request.message_index),
+    )
+    await asyncio.to_thread(conn.commit)
+    new_session_id = cursor.lastrowid
+
+    # Copy messages into the new session
+    for row in forked_rows:
+        await asyncio.to_thread(
+            conn.execute,
+            "INSERT INTO chat_messages (session_id, role, content, sources, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            (new_session_id, row[0], row[1], row[2]),
+        )
+    await asyncio.to_thread(conn.commit)
+
+    # Return new session info with copied messages
+    messages = []
+    for row in forked_rows:
+        sources = None
+        if row[2]:
+            try:
+                sources = json.loads(row[2])
+            except json.JSONDecodeError:
+                sources = []
+        messages.append({"role": row[0], "content": row[1], "sources": sources})
+
+    return {
+        "id": new_session_id,
+        "vault_id": vault_id,
+        "title": fork_title,
+        "forked_from_session_id": session_id,
+        "fork_message_index": request.message_index,
+        "messages": messages,
     }
 
 

--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -503,6 +503,11 @@ async def fork_session(
         (session_id,),
     )
     all_rows = await asyncio.to_thread(messages_result.fetchall)
+    if request.message_index >= len(all_rows):
+        raise HTTPException(
+            status_code=400,
+            detail=f"message_index {request.message_index} is out of bounds for session with {len(all_rows)} messages",
+        )
     forked_rows = all_rows[: request.message_index + 1]
 
     # Create new forked session

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -343,6 +343,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_vault_permission_columns(sqlite_path)
     migrate_vault_paths(sqlite_path)
     migrate_add_org_slug_column(sqlite_path)
+    migrate_add_fork_columns(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
     # Wrapped in IntegrityError handler: existing databases may have duplicate
@@ -653,6 +654,25 @@ def migrate_vault_paths(sqlite_path: str) -> None:
             except (OSError, shutil.Error) as e:
                 logger.warning(f"Failed to migrate vault '{name}' (ID {vault_id}): {e}")
                 # Continue with other vaults, don't raise
+    finally:
+        conn.close()
+
+
+def migrate_add_fork_columns(sqlite_path: str) -> None:
+    """Migration: Add forked_from_session_id and fork_message_index to chat_sessions."""
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        cursor = conn.execute("PRAGMA table_info(chat_sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if "forked_from_session_id" not in columns:
+            conn.execute(
+                "ALTER TABLE chat_sessions ADD COLUMN forked_from_session_id INTEGER"
+            )
+        if "fork_message_index" not in columns:
+            conn.execute(
+                "ALTER TABLE chat_sessions ADD COLUMN fork_message_index INTEGER"
+            )
+        conn.commit()
     finally:
         conn.close()
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledgevault-frontend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledgevault-frontend",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-checkbox": "^1.1.2",

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { motion } from "framer-motion";
-import { Bot, Copy, Check, RotateCcw, Bug, ChevronRight, FileText, ThumbsUp, ThumbsDown, AlertCircle } from "lucide-react";
+import { Bot, Copy, Check, RotateCcw, Bug, ChevronRight, FileText, ThumbsUp, ThumbsDown, AlertCircle, GitBranch } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -41,6 +41,8 @@ interface AssistantMessageProps {
   feedback?: "up" | "down" | null;
   /** Callback when feedback is changed */
   onFeedback?: (feedback: "up" | "down" | null) => void;
+  /** Callback to fork the conversation from this message */
+  onFork?: () => void;
 }
 
 interface CitationChipProps {
@@ -246,6 +248,8 @@ interface ActionBarProps {
   onFeedback?: (feedback: "up" | "down" | null) => void;
   /** Message ID for localStorage key */
   messageId?: string;
+  /** Callback to fork the conversation from this message */
+  onFork?: () => void;
 }
 
 function ActionBar({
@@ -261,8 +265,10 @@ function ActionBar({
   feedback: externalFeedback,
   onFeedback,
   messageId,
+  onFork,
 }: ActionBarProps) {
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const [internalFeedback, setInternalFeedback] = useState<"up" | "down" | null>(null);
 
   // Use external feedback if provided, otherwise use internal state
@@ -308,12 +314,25 @@ function ActionBar({
 
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(content);
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(content);
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = content;
+        ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        if (!ok) throw new Error('execCommand failed');
+      }
       setCopied(true);
       onCopy?.();
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Silently fail if clipboard is not available
+      setCopyFailed(true);
+      setTimeout(() => setCopyFailed(false), 2000);
     }
   }, [content, onCopy]);
 
@@ -340,17 +359,19 @@ function ActionBar({
                 size="icon"
                 className="h-7 w-7"
                 onClick={handleCopy}
-                aria-label={copied ? "Copied" : "Copy message"}
+                aria-label={copied ? "Copied" : copyFailed ? "Copy failed" : "Copy message"}
               >
                 {copied ? (
                   <Check className="h-3.5 w-3.5 text-success" />
+                ) : copyFailed ? (
+                  <AlertCircle className="h-3.5 w-3.5 text-destructive" />
                 ) : (
                   <Copy className="h-3.5 w-3.5" />
                 )}
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{copied ? "Copied!" : "Copy"}</p>
+              <p>{copied ? "Copied!" : copyFailed ? "Copy failed" : "Copy"}</p>
             </TooltipContent>
           </Tooltip>
         )}
@@ -370,6 +391,25 @@ function ActionBar({
             </TooltipTrigger>
             <TooltipContent>
               <p>Retry</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+
+        {onFork && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={onFork}
+                aria-label="Branch conversation from here"
+              >
+                <GitBranch className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Branch from here</p>
             </TooltipContent>
           </Tooltip>
         )}
@@ -452,6 +492,7 @@ export function AssistantMessage({
   onDebugToggle,
   feedback: externalFeedback,
   onFeedback,
+  onFork,
 }: AssistantMessageProps) {
   const [isDebugActive, setIsDebugActive] = useState(false);
   const { openRightPane, setSelectedEvidenceSource, setActiveRightTab } = useChatShellStore();
@@ -562,7 +603,7 @@ export function AssistantMessage({
         {/* Header */}
         <div className="flex items-center gap-2 mb-1">
           <span className="font-semibold text-sm">Assistant</span>
-          {isStreaming && (
+          {isStreaming && !message.content && (
             <div className="flex items-center gap-1.5">
               <span className="text-xs font-medium text-primary/70">Thinking</span>
               <span className="flex items-center gap-0.5">
@@ -630,6 +671,7 @@ export function AssistantMessage({
             feedback={externalFeedback}
             onFeedback={onFeedback}
             messageId={message.id}
+            onFork={onFork}
           />
         )}
 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,15 +1,18 @@
 import { motion } from "framer-motion";
-import { User, Bot, AlertCircle } from "lucide-react";
+import { User, Bot, AlertCircle, GitBranch } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MessageContent } from "./MessageContent";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Message } from "@/stores/useChatStore";
 
 interface MessageBubbleProps {
   message: Message;
   isStreaming?: boolean;
+  onFork?: () => void;
 }
 
-export function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
+export function MessageBubble({ message, isStreaming, onFork }: MessageBubbleProps) {
   const isUser = message.role === "user";
 
   return (
@@ -18,7 +21,7 @@ export function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
       className={cn(
-        "flex gap-3 p-4",
+        "group flex gap-3 p-4",
         isUser ? "bg-primary/10" : "bg-muted/30"
       )}
     >
@@ -61,6 +64,29 @@ export function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
         {message.stopped && !message.error && (
           <div className="mt-3 inline-flex items-center gap-2 rounded-md bg-muted border border-border px-3 py-1.5">
             <span className="text-xs font-medium text-muted-foreground">Stopped</span>
+          </div>
+        )}
+
+        {onFork && (
+          <div className="flex items-center mt-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={onFork}
+                    aria-label="Branch conversation from here"
+                  >
+                    <GitBranch className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Branch from here</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         )}
       </div>

--- a/frontend/src/components/chat/SessionRail.tsx
+++ b/frontend/src/components/chat/SessionRail.tsx
@@ -17,6 +17,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  GitBranch,
 } from "lucide-react";
 import { useChatShellStore } from "@/stores/useChatShellStore";
 import { useChatStore } from "@/stores/useChatStore";
@@ -392,6 +393,9 @@ export const SessionItem = forwardRef<HTMLDivElement, SessionItemProps>(
           ) : (
             <div className="flex items-center gap-2">
               <span className="truncate font-medium">{truncatedTitle}</span>
+              {session.forked_from_session_id != null && (
+                <GitBranch className="h-3 w-3 text-muted-foreground flex-shrink-0" aria-hidden="true" title="Branched conversation" />
+              )}
               {isPinned && (
                 <Pin className="h-3 w-3 text-muted-foreground flex-shrink-0" aria-hidden="true" />
               )}

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -25,11 +25,11 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { cn } from "@/lib/utils";
 import { MessageBubble } from "./MessageBubble";
 import { AssistantMessage } from "./AssistantMessage";
-import { WaitingIndicator } from "./WaitingIndicator";
 import { useChatStore } from "@/stores/useChatStore";
 import { useVaultStore } from "@/stores/useVaultStore";
 import { useSendMessage, MAX_INPUT_LENGTH } from "@/hooks/useSendMessage";
 import { useChatHistory } from "@/hooks/useChatHistory";
+import { forkChatSession } from "@/lib/api";
 
 // =============================================================================
 // TYPES & INTERFACES
@@ -488,7 +488,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const navigate = useNavigate();
-  const { messages, isStreaming, setInput, setMessages } = useChatStore();
+  const { messages, isStreaming, setInput, setMessages, loadChat } = useChatStore();
   const { getActiveVault } = useVaultStore();
   const activeVault = getActiveVault();
   const vaultId = useVaultStore((state) => state.activeVaultId);
@@ -502,10 +502,6 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [showDebug, setShowDebug] = useState(false);
 
-  // Waiting indicator state with anti-flicker debounce
-  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
-  const waitingDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   // Check if vault has indexed documents (using file_count from Vault interface)
   const hasIndexedDocs = activeVault ? activeVault.file_count > 0 : false;
 
@@ -518,59 +514,14 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
     measureElement: (el) => el?.getBoundingClientRect().height ?? 0,
   });
 
-  // Auto-scroll to bottom on new messages only if user is already at bottom
+  // Auto-scroll to bottom on new messages/content if user is already at bottom
   useEffect(() => {
-    if (isAtBottom && messages.length > 0 && scrollRef.current) {
+    if (isAtBottom && messages.length > 0) {
       requestAnimationFrame(() => {
-        virtualizer.scrollToIndex(messages.length - 1, { align: 'end' });
+        virtualizer.scrollToIndex(messages.length - 1, { align: 'end', behavior: 'auto' });
       });
     }
-  }, [messages, isStreaming, isAtBottom, virtualizer]);
-
-  // Scroll to bottom when waiting indicator appears
-  useEffect(() => {
-    if (isWaitingForResponse && isAtBottom && messages.length > 0 && scrollRef.current) {
-      requestAnimationFrame(() => {
-        if (scrollRef.current) {
-          scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-        }
-      });
-    }
-  }, [isWaitingForResponse, isAtBottom, messages.length]);
-
-  // Re-measure virtual items during streaming to handle growing content
-  useEffect(() => {
-    if (isStreaming) {
-      virtualizer.measure();
-    }
-  }, [isStreaming, messages, virtualizer]);
-
-  // Anti-flicker: only show waiting indicator after 100ms of streaming
-  // Use hasShownWaitingRef to prevent rapid toggles from preventing indicator from showing
-  const hasShownWaitingRef = useRef(false);
-
-  useEffect(() => {
-    if (isStreaming) {
-      if (!hasShownWaitingRef.current) {
-        waitingDebounceRef.current = setTimeout(() => {
-          setIsWaitingForResponse(true);
-          hasShownWaitingRef.current = true;
-        }, 100);
-      }
-    } else {
-      if (waitingDebounceRef.current && !hasShownWaitingRef.current) {
-        clearTimeout(waitingDebounceRef.current);
-        waitingDebounceRef.current = null;
-      }
-      setIsWaitingForResponse(false);
-      hasShownWaitingRef.current = false;
-    }
-    return () => {
-      if (waitingDebounceRef.current) {
-        clearTimeout(waitingDebounceRef.current);
-      }
-    };
-  }, [isStreaming]);
+  }, [messages, isAtBottom, virtualizer]);
 
   // Auto-focus chat input on mount (only if no dialog/modal is open)
   useEffect(() => {
@@ -586,7 +537,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
 
     const { scrollTop, scrollHeight, clientHeight } = container;
     const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-    const atBottom = distanceFromBottom < 100;
+    const atBottom = distanceFromBottom < 150;
 
     setIsAtBottom(atBottom);
     setShowScrollButton(!atBottom);
@@ -625,6 +576,26 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
       handleSend();
     }
   };
+
+  // Handle fork - create a new session branching from a specific message index
+  const handleFork = useCallback(async (messageIndex: number) => {
+    const { activeChatId } = useChatStore.getState();
+    if (!activeChatId) return;
+    try {
+      const forked = await forkChatSession(parseInt(activeChatId), messageIndex);
+      const forkMessages = forked.messages.map((m, i) => ({
+        id: String(i),
+        role: m.role as "user" | "assistant",
+        content: m.content,
+        sources: m.sources ?? undefined,
+      }));
+      loadChat(String(forked.id), forkMessages);
+      await refreshHistory();
+      navigate(`/chat/${forked.id}`);
+    } catch (err) {
+      console.error("Fork failed:", err);
+    }
+  }, [loadChat, refreshHistory, navigate]);
 
   // Handle debug toggle
   const handleDebugToggle = () => {
@@ -695,34 +666,21 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
                             message={message}
                             isStreaming={isAssistantStreaming}
                             showDebug={showDebug}
-                            onCopy={() => { navigator.clipboard.writeText(message.content); }}
+                            onCopy={undefined}
                             onRetry={handleRetry}
                             onDebugToggle={handleDebugToggle}
+                            onFork={!isStreaming ? () => handleFork(virtualItem.index) : undefined}
                           />
                         ) : (
                           <MessageBubble
                             message={message}
                             isStreaming={isAssistantStreaming}
+                            onFork={!isStreaming ? () => handleFork(virtualItem.index) : undefined}
                           />
                         )}
                       </div>
                     );
                   })}
-                    {/* WaitingIndicator positioned at the bottom of the virtualized content */}
-                    <AnimatePresence>
-                      {isWaitingForResponse && messages.length > 0 && messages[messages.length - 1].role === "assistant" && !messages[messages.length - 1].content && (
-                        <div
-                          style={{
-                            position: 'absolute',
-                            top: virtualizer.getTotalSize(),
-                            left: 0,
-                            width: '100%',
-                          }}
-                        >
-                          <WaitingIndicator />
-                        </div>
-                      )}
-                    </AnimatePresence>
                   </div>
               </>
             )}

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -30,6 +30,7 @@ import { useVaultStore } from "@/stores/useVaultStore";
 import { useSendMessage, MAX_INPUT_LENGTH } from "@/hooks/useSendMessage";
 import { useChatHistory } from "@/hooks/useChatHistory";
 import { forkChatSession } from "@/lib/api";
+import { toast } from "sonner";
 
 // =============================================================================
 // TYPES & INTERFACES
@@ -594,6 +595,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
       navigate(`/chat/${forked.id}`);
     } catch (err) {
       console.error("Fork failed:", err);
+      toast.error("Failed to branch conversation. Please try again.");
     }
   }, [loadChat, refreshHistory, navigate]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -479,6 +479,8 @@ export interface ChatSession {
   created_at: string;
   updated_at: string;
   message_count?: number;
+  forked_from_session_id?: number | null;
+  fork_message_index?: number | null;
 }
 
 export interface ChatSessionMessage {
@@ -846,6 +848,19 @@ export async function updateChatSession(sessionId: number, title: string): Promi
 
 export async function deleteChatSession(sessionId: number): Promise<void> {
   await apiClient.delete(`/chat/sessions/${sessionId}`);
+}
+
+export interface ForkSessionResponse extends ChatSessionDetail {
+  forked_from_session_id: number;
+  fork_message_index: number;
+}
+
+export async function forkChatSession(sessionId: number, messageIndex: number): Promise<ForkSessionResponse> {
+  const response = await apiClient.post<ForkSessionResponse>(
+    `/chat/sessions/${sessionId}/fork`,
+    { message_index: messageIndex }
+  );
+  return response.data;
 }
 
 // ============================================================================

--- a/specs/fix-chat-ui/SPEC.md
+++ b/specs/fix-chat-ui/SPEC.md
@@ -1,0 +1,148 @@
+# Chat UI Bug Fixes + Conversation Forking
+
+## Problem Statement
+
+The chat UI had five distinct, user-reported issues that degraded the experience relative to the stated goal of matching modern AI chat UX (ChatGPT / Claude):
+
+1. **Double thinking bubbles** — two simultaneous "Thinking •••" indicators appeared while waiting for the assistant's first response token. One was rendered inline in `AssistantMessage`, the other by a separate `WaitingIndicator` in `TranscriptPane` positioned outside the virtualizer's measured layout.
+
+2. **Copy button silently failed** — `navigator.clipboard.writeText()` requires a secure context (HTTPS or localhost). On HTTP deployments the API is undefined; the silent `try/catch` gave no feedback. Additionally, `TranscriptPane` passed a duplicate clipboard write as the `onCopy` prop, creating two fire-and-forget calls.
+
+3. **Auto-scroll unreliable during streaming** — three competing `useEffect` scroll hooks ran simultaneously: one via `virtualizer.scrollToIndex`, one via raw `scrollTop = scrollHeight`, and a third that called `virtualizer.measure()` on every streaming render (redundant: `@tanstack/react-virtual` v3 uses ResizeObserver automatically when `measureElement` ref is set). The 100px `isAtBottom` threshold was also too tight.
+
+4. **Messages visually overlapped** — the `WaitingIndicator` was positioned at `top: virtualizer.getTotalSize()` inside the virtual container but was not measured by the virtualizer. The container's declared height did not include the indicator, causing scroll miscalculation and visual overlap during streaming transitions.
+
+5. **No conversation forking** — users had no way to branch from a previous message and explore an alternate direction. No backend, store, or UI support existed.
+
+## Goals
+
+- Eliminate double thinking indicator
+- Make copy work on both HTTP and HTTPS with visible failure feedback
+- Make auto-scroll reliable and jitter-free during streaming
+- Eliminate message overlap
+- Implement full-stack conversation forking: branch from any message, navigate to the new fork, show fork indicator in session sidebar
+
+## Non-Goals
+
+- Redesigning the chat layout or visual language
+- Changing streaming protocol or LLM integration
+- Adding message editing in place
+
+---
+
+## Technical Design
+
+### Bug Fixes
+
+#### Double thinking / overlap (Issues 1 & 4)
+- Remove `WaitingIndicator`, `isWaitingForResponse` state, `waitingDebounceRef`, `hasShownWaitingRef`, and the associated debounce + scroll `useEffect` hooks from `TranscriptPane.tsx`
+- The `WaitingIndicator` rendered outside the virtualizer container, breaking layout. Its removal also resolves the overlap bug.
+- In `AssistantMessage.tsx`: gate the inline "Thinking" label on `isStreaming && !message.content` (was `isStreaming` only), so it disappears once content starts flowing
+
+#### Copy fallback (Issue 2)
+- `handleCopy` in `ActionBar` tries `navigator.clipboard` first; if absent or rejects, falls back to `document.execCommand('copy')` via a hidden `<textarea>`
+- On total failure: show `AlertCircle` icon + "Copy failed" tooltip for 2 s instead of silently swallowing the error
+- Remove the duplicate `navigator.clipboard.writeText` call from `TranscriptPane`'s `onCopy` prop
+
+#### Auto-scroll (Issue 3)
+- Remove the `WaitingIndicator` scroll effect (gone with Issue 1 fix)
+- Remove the `virtualizer.measure()` streaming effect (redundant with ResizeObserver via `measureElement` ref in v3)
+- Consolidate to one auto-scroll effect: `virtualizer.scrollToIndex(messages.length - 1, { align: 'end', behavior: 'auto' })` triggered by `[messages, isAtBottom, virtualizer]`
+- Increase `isAtBottom` threshold from 100 px → 150 px
+
+### Conversation Forking (Issue 5)
+
+#### Database
+```sql
+ALTER TABLE chat_sessions ADD COLUMN forked_from_session_id INTEGER;
+ALTER TABLE chat_sessions ADD COLUMN fork_message_index INTEGER;
+```
+Migration is idempotent via `PRAGMA table_info` check.
+
+#### API
+`POST /api/chat/sessions/{session_id}/fork`
+- Body: `{ "message_index": int }` (Pydantic: `ge=0`)
+- Auth: requires write access to the session's vault
+- Validates `message_index < len(messages)` — returns HTTP 400 on out-of-bounds
+- Creates new `chat_session` with `forked_from_session_id` and `fork_message_index` set
+- Copies messages `0..message_index` (inclusive) into new session
+- Returns new session id, title, vault_id, and copied messages
+
+`GET /api/chat/sessions` — updated to include `forked_from_session_id` and `fork_message_index` in session list rows.
+
+#### Frontend
+- `api.ts`: `forkChatSession(sessionId, messageIndex)` → `ForkSessionResponse`
+- `ChatSession` interface gains optional `forked_from_session_id` and `fork_message_index`
+- `TranscriptPane`: `handleFork(messageIndex)` — calls API, loads forked session into store, refreshes sidebar, navigates to `/chat/{newId}`; shows `toast.error()` on failure
+- `AssistantMessage` / `ActionBar`: `onFork` prop; `GitBranch` button (hover-visible, same `opacity-30 group-hover:opacity-100` pattern as existing buttons)
+- `MessageBubble`: `onFork` prop; `GitBranch` button with `group-hover:opacity-100`; `group` class added to wrapper
+- `SessionRail`: `GitBranch` icon inline with session title when `forked_from_session_id != null`
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Single thinking indicator
+- [ ] When a message is sent, exactly one "Thinking •••" animation appears
+- [ ] The animation disappears once the first content token arrives
+- [ ] The streaming cursor (pulsing block) continues while content streams
+
+### AC-2: Copy works on HTTP and HTTPS
+- [ ] Clicking copy on an assistant message copies content to clipboard on HTTPS
+- [ ] Clicking copy on an assistant message copies content to clipboard on HTTP (execCommand fallback)
+- [ ] When copy fails entirely, an `AlertCircle` icon appears for 2 seconds with "Copy failed" tooltip
+- [ ] On success, a `Check` icon appears for 2 seconds
+
+### AC-3: Auto-scroll reliable
+- [ ] Sending a message auto-scrolls to the new response if user was within 150 px of bottom
+- [ ] Streaming content auto-scrolls without jitter or position jumps
+- [ ] Scrolling up mid-stream pauses auto-scroll; scrolling back to bottom resumes it
+
+### AC-4: No message overlap
+- [ ] No two message bubbles occupy the same vertical space
+- [ ] Layout is stable during streaming — no position jumps as content grows
+
+### AC-5: Conversation forking
+- [ ] A "Branch from here" (`GitBranch`) button appears on hover for every message (user and assistant) when not streaming
+- [ ] Clicking it creates a new session containing messages up to and including that message
+- [ ] The UI navigates to the new forked session immediately
+- [ ] The forked session appears in the sidebar with a `GitBranch` icon
+- [ ] The original session is unchanged
+- [ ] Forking from an invalid index returns a clear error (HTTP 400 backend, `toast.error` frontend)
+- [ ] Fork button is hidden during active streaming
+
+---
+
+## Test Cases
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| T-1 | Send message, observe loading state | One thinking indicator only |
+| T-2 | Send message, observe transition when first token arrives | Thinking disappears, content renders, cursor continues |
+| T-3 | Click copy on HTTP | Content copied via execCommand; check icon appears |
+| T-4 | Click copy on HTTPS | Content copied via clipboard API; check icon appears |
+| T-5 | Simulate clipboard failure | AlertCircle icon + "Copy failed" tooltip for 2 s |
+| T-6 | Send long response, stay at bottom | Auto-scroll follows without jitter |
+| T-7 | Scroll up mid-stream | Auto-scroll pauses |
+| T-8 | Scroll back to bottom mid-stream | Auto-scroll resumes |
+| T-9 | Hover over message during streaming | No fork button visible |
+| T-10 | Hover over message when idle | Fork button visible |
+| T-11 | Click fork on message 2 of 5 | New session with messages 0-2 created; navigate to it |
+| T-12 | Forked session in sidebar | GitBranch icon visible beside session title |
+| T-13 | Original session after fork | Unchanged: still has all 5 messages |
+| T-14 | Fork API with out-of-bounds index | HTTP 400 returned |
+| T-15 | Fork API failure → frontend | toast.error displayed |
+
+---
+
+## Files Changed
+
+| File | Change type |
+|------|-------------|
+| `frontend/src/components/chat/TranscriptPane.tsx` | Bug fix (1, 3, 4) + fork wiring |
+| `frontend/src/components/chat/AssistantMessage.tsx` | Bug fix (1, 2) + fork button |
+| `frontend/src/components/chat/MessageBubble.tsx` | Fork button |
+| `frontend/src/components/chat/SessionRail.tsx` | Fork indicator |
+| `frontend/src/lib/api.ts` | Fork API function + ChatSession interface |
+| `backend/app/models/database.py` | Fork columns migration |
+| `backend/app/api/routes/chat.py` | Fork endpoint + list_sessions update |


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Five user-reported chat UI issues fixed, plus a new conversation forking feature:

- **Double thinking indicator** — removed external `WaitingIndicator` positioned outside the virtualizer; gated inline "Thinking" label on `!message.content` so it disappears on first token
- **Copy button silent failure** — added `execCommand('copy')` fallback for HTTP (non-secure) contexts; shows `AlertCircle` error indicator for 2s on total failure instead of swallowing silently
- **Auto-scroll jitter** — removed redundant `virtualizer.measure()` streaming effect (v3 uses ResizeObserver automatically via `measureElement` ref); consolidated three competing scroll effects to one; increased `isAtBottom` threshold 100px → 150px
- **Message overlap** — resolved by removing the unmeasured `WaitingIndicator` that was positioned outside the virtualizer container's declared height, breaking scroll height calculations
- **Conversation forking** — full-stack: DB migration (idempotent), `POST /api/chat/sessions/{id}/fork` endpoint with bounds validation, frontend API function, hover-visible `GitBranch` button on every message, sidebar fork indicator

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/chat/TranscriptPane.tsx` | Remove WaitingIndicator + debounce state; consolidate scroll; add `handleFork` |
| `frontend/src/components/chat/AssistantMessage.tsx` | Fix Thinking condition; copy fallback + error state; fork button in ActionBar |
| `frontend/src/components/chat/MessageBubble.tsx` | Fork button with hover visibility |
| `frontend/src/components/chat/SessionRail.tsx` | GitBranch icon for forked sessions |
| `frontend/src/lib/api.ts` | `forkChatSession()` + updated `ChatSession` interface |
| `backend/app/models/database.py` | Idempotent migration adding fork columns |
| `backend/app/api/routes/chat.py` | Fork endpoint with bounds check + `list_sessions` update |
| `specs/fix-chat-ui/SPEC.md` | Spec document |

## Test plan

- [ ] Send message → exactly one "Thinking •••" appears; disappears on first token
- [ ] Simulate HTTP context → copy via execCommand succeeds; check icon appears
- [ ] Simulate clipboard failure → AlertCircle icon + "Copy failed" for 2s
- [ ] Send long response, stay at bottom → auto-scroll follows without jitter
- [ ] Scroll up mid-stream → auto-scroll pauses; scroll back → resumes
- [ ] Hover over message when idle → GitBranch fork button visible
- [ ] Hover over message during streaming → fork button hidden
- [ ] Click fork on message N → new session with messages 0..N; navigate to it
- [ ] Forked session in sidebar → GitBranch icon visible
- [ ] Original session after fork → unchanged
- [ ] Fork API with out-of-bounds index → HTTP 400

https://claude.ai/code/session_01LK3PkisRbTz4dfVH8W4QaF
EOF
)