### PR TITLE
feat: UI/UX polish — accessibility, file icons, code blocks, citation tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [1.0.2] - 2026-04-30
+
+### Added
+- File-type icon utility (`frontend/src/lib/fileIcon.tsx`) with color-coded Lucide icons for PDF (red), DOCX (blue), Markdown (teal), spreadsheets (green), and generic fallback
+- File-type icons integrated into SourcesPanel, DocumentCard, and DocumentsPage table rows
+- Citation chip source-snippet tooltips — hovering a `[Source: …]` chip now shows up to 100 chars of the matched passage
+- Code block rendering in assistant messages: language badge, copy-to-clipboard button, proper `pre`/`code` wrapping via ReactMarkdown component overrides
+- Suggested-prompt chips enriched with contextual Lucide icons (TrendingUp, AlignLeft, Database, CheckCircle2)
+
+### Changed
+- ActionBar default opacity raised from 30% to 60% for better discoverability; always 100% on touch/coarse-pointer devices (`[@media(pointer:coarse)]`)
+- Mobile bottom-nav labels bumped from 10 px to `text-xs` (12 px) to meet WCAG minimum font-size
+- User message rows: left-border accent (`border-l-2 border-primary/40`) + slightly stronger background (`bg-primary/[0.12]`) replacing flat `bg-primary/10`
+- User avatar now renders the authenticated user's initials (from `useAuthStore`) instead of a static `<User>` icon
+- Composer textarea border highlights on `focus-within` for clearer focus state
+- Send and Stop buttons bumped from `size="sm"` to `size="default"` for larger tap targets
+- SourcesPanel scroll area set to `h-full` so it fills its container rather than a fixed 400 px height
+- Removed duplicate "View all sources" text link that competed with the existing "+N more" chip button
+- NavigationRail active-indicator motion pill removed (caused layout shift); logo wrapper simplified
+
+### Fixed
+- `fileIcon.tsx` handles `null`/`undefined` filenames without crashing (null-coalescing before `.split`)
+- AssistantMessage tests updated to match the count-prefixed aria-label `"View all N sources"` and the new `opacity-60` class

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledgevault-frontend",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/chat/AssistantMessage.test.tsx
+++ b/frontend/src/components/chat/AssistantMessage.test.tsx
@@ -410,7 +410,7 @@ describe("AssistantMessage - Citations and Sources", () => {
     render(<AssistantMessage message={message} />);
 
     // View all only shows when sources.length > 3
-    expect(screen.getByLabelText("View all sources")).toBeInTheDocument();
+    expect(screen.getByLabelText("View all 4 sources")).toBeInTheDocument();
   });
 
   it("should open right pane when '+N more' is clicked", () => {
@@ -493,8 +493,8 @@ describe("AssistantMessage - Hover Actions", () => {
 
     const messageContainer = screen.getByLabelText("Assistant message");
 
-    // Initially action bar should be hidden (opacity-30 from group-hover pattern)
-    const actionBar = messageContainer.querySelector('[class*="opacity-30"]');
+    // Initially action bar should be hidden (opacity-60 from group-hover pattern)
+    const actionBar = messageContainer.querySelector('[class*="opacity-60"]');
     expect(actionBar).toBeInTheDocument();
 
     // After mouse enter, action buttons should be in the DOM
@@ -516,7 +516,7 @@ describe("AssistantMessage - Hover Actions", () => {
       <AssistantMessage message={message} onViewAllSources={onViewAllSources} />
     );
 
-    const viewAllButton = screen.getByLabelText("View all sources");
+    const viewAllButton = screen.getByLabelText("View all 4 sources");
     fireEvent.click(viewAllButton);
 
     expect(mockSetActiveRightTab).toHaveBeenCalledWith("evidence");

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { motion } from "framer-motion";
-import { Bot, Copy, Check, RotateCcw, Bug, ChevronRight, FileText, ThumbsUp, ThumbsDown, AlertCircle, GitBranch } from "lucide-react";
+import { Bot, Copy, Check, RotateCcw, Bug, FileText, ThumbsUp, ThumbsDown, AlertCircle, GitBranch } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +15,7 @@ import { getRelevanceLabel, type ScoreType } from "@/lib/relevance";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
+import { CopyButton } from "@/components/shared/CopyButton";
 
 // =============================================================================
 // TYPES & INTERFACES
@@ -194,19 +195,30 @@ function CitationChip({ source, index, onClick, variant = "strip" }: CitationChi
   }
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs",
-        "bg-primary/10 text-primary hover:bg-primary/25 active:scale-95 transition-all duration-150",
-        "border border-primary/20 hover:border-primary/40 hover:shadow-sm"
-      )}
-      aria-label={label}
-    >
-      <FileText className="h-3 w-3" />
-      <span className="truncate max-w-[120px]">{source.filename}</span>
-    </button>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onClick}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs",
+              "bg-primary/10 text-primary hover:bg-primary/25 active:scale-95 transition-all duration-150",
+              "border border-primary/20 hover:border-primary/40 hover:shadow-sm"
+            )}
+            aria-label={label}
+          >
+            <FileText className="h-3 w-3" />
+            <span className="truncate max-w-[120px]">{source.filename}</span>
+          </button>
+        </TooltipTrigger>
+        {source.snippet && (
+          <TooltipContent className="max-w-[250px] text-xs">
+            <p>{source.snippet.slice(0, 100)}{source.snippet.length > 100 ? '…' : ''}</p>
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -248,16 +260,6 @@ function EvidenceStrip({ sources, onSourceClick, onViewAll }: EvidenceStripProps
           aria-label={`View all ${sources.length} sources`}
         >
           +{remainingCount} more
-        </button>
-      )}
-      {sources.length > 3 && (
-        <button
-          onClick={onViewAll}
-          className="inline-flex items-center gap-0.5 text-xs text-primary hover:underline ml-1"
-          aria-label="View all sources"
-        >
-          View all
-          <ChevronRight className="h-3 w-3" />
         </button>
       )}
     </div>
@@ -393,7 +395,7 @@ function ActionBar({
   }, [feedback, externalFeedback, onFeedback, saveFeedbackToStorage]);
 
   return (
-    <div className="flex items-center gap-1 mt-3 opacity-30 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
+    <div className="flex items-center gap-1 mt-3 opacity-60 group-hover:opacity-100 focus-within:opacity-100 [@media(pointer:coarse)]:opacity-100 transition-opacity duration-200">
       <TooltipProvider>
         {showCopy && (
           <Tooltip>
@@ -576,6 +578,10 @@ export function AssistantMessage({
 
   // Render content with inline citation chips
   const renderContent = () => {
+    // TECH DEBT: This creates one ReactMarkdown + rehypeSanitize parse cycle per
+    // text segment (N segments = N parse cycles for N citations). Fix: replace
+    // citation markers with unique tokens before rendering, run a single markdown
+    // pass, then post-process the output to swap tokens for React elements.
     return segments.map((segment, index) => {
       if (segment.type === "citation") {
         // Resolve by source_label first, then by filename (legacy), then by index
@@ -620,6 +626,38 @@ export function AssistantMessage({
           components={{
             // Override to prevent nesting issues
             p: ({ children }) => <>{children}</>,
+            // Prevent double-wrapping: block code renders its own <pre>
+            pre: ({ children }) => <>{children}</>,
+            code: ({ className, children, ...props }) => {
+              const isBlock = Boolean(className?.startsWith("language-"));
+              if (!isBlock) {
+                return (
+                  <code
+                    className="bg-muted px-1 py-0.5 rounded text-sm font-mono"
+                    {...props}
+                  >
+                    {children}
+                  </code>
+                );
+              }
+              const language = className?.replace("language-", "") ?? "";
+              const codeText = String(children).replace(/\n$/, "");
+              return (
+                <pre className="rounded-lg bg-muted p-4 overflow-x-auto text-sm font-mono my-3 relative group/code">
+                  {language && (
+                    <span className="absolute top-2 left-3 text-[10px] text-muted-foreground select-none">
+                      {language}
+                    </span>
+                  )}
+                  <CopyButton
+                    text={codeText}
+                    label="Copy code"
+                    className="absolute top-1.5 right-1.5 opacity-0 group-hover/code:opacity-100 focus:opacity-100 transition-opacity"
+                  />
+                  <code className={className}>{children}</code>
+                </pre>
+              );
+            },
           }}
         >
           {segment.content}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,10 +1,11 @@
 import { motion } from "framer-motion";
-import { User, Bot, AlertCircle, GitBranch } from "lucide-react";
+import { Bot, AlertCircle, GitBranch } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MessageContent } from "./MessageContent";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Message } from "@/stores/useChatStore";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 interface MessageBubbleProps {
   message: Message;
@@ -14,6 +15,8 @@ interface MessageBubbleProps {
 
 export function MessageBubble({ message, isStreaming, onFork }: MessageBubbleProps) {
   const isUser = message.role === "user";
+  const user = useAuthStore((state) => state.user);
+  const userInitial = (user?.full_name || user?.username || "U")[0].toUpperCase();
 
   return (
     <motion.div
@@ -22,7 +25,9 @@ export function MessageBubble({ message, isStreaming, onFork }: MessageBubblePro
       transition={{ duration: 0.3 }}
       className={cn(
         "group flex gap-3 p-4",
-        isUser ? "bg-primary/10" : "bg-muted/30"
+        isUser
+          ? "bg-primary/[0.12] border-l-2 border-primary/40"
+          : "bg-muted/30"
       )}
     >
       <div
@@ -32,7 +37,7 @@ export function MessageBubble({ message, isStreaming, onFork }: MessageBubblePro
         )}
       >
         {isUser ? (
-          <User className="h-4 w-4" />
+          <span className="text-xs font-semibold leading-none">{userInitial}</span>
         ) : (
           <Bot className="h-4 w-4" />
         )}

--- a/frontend/src/components/chat/SourcesPanel.tsx
+++ b/frontend/src/components/chat/SourcesPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { FileText, ChevronDown, ChevronRight, BookOpen } from "lucide-react";
 import type { Source } from "@/lib/api";
 import { getRelevanceLabel } from "@/lib/relevance";
+import { FileIcon } from "@/lib/fileIcon";
 
 interface SourcesPanelProps {
   sources: Source[] | undefined;
@@ -74,10 +75,10 @@ function DesktopSourcesContent({
             : "Sources will appear here after the AI responds"}
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex-1">
+      <CardContent className="flex-1 min-h-0 p-0">
         {hasSources ? (
-          <ScrollArea className="h-[400px] pr-4">
-            <div className="space-y-3" role="list" aria-label="Document sources">
+          <ScrollArea className="h-full pr-4">
+            <div className="space-y-3 p-4" role="list" aria-label="Document sources">
               {sources!.map((source: Source, index: number) => (
                 <SourceCard
                   key={source.id}
@@ -157,7 +158,7 @@ function SourceCard({ source, isExpanded, onToggle, index }: SourceCardProps) {
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <FileText className="w-4 h-4 text-muted-foreground" />
+            <FileIcon filename={source.filename} className="w-4 h-4 flex-shrink-0" />
             <span className="text-sm font-medium truncate max-w-[180px] lg:max-w-[180px] max-w-[200px]">
               {source.filename}
             </span>
@@ -195,7 +196,7 @@ function SourceCard({ source, isExpanded, onToggle, index }: SourceCardProps) {
 // Empty Sources State
 function EmptySourcesState() {
   return (
-    <div className="flex flex-col items-center justify-center h-[200px] text-center">
+    <div className="flex flex-col items-center justify-center min-h-[120px] flex-1 text-center">
       <FileText className="w-8 h-8 text-muted-foreground/50 mb-2" />
       <p className="text-sm text-muted-foreground">No sources available</p>
       <p className="text-xs text-muted-foreground/70 mt-1">

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -16,6 +16,9 @@ import {
   GitCompare,
   Calendar,
   ListChecks,
+  TrendingUp,
+  AlignLeft,
+  CheckCircle2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -101,10 +104,10 @@ const SLASH_COMMANDS: SlashCommand[] = [
 ];
 
 const SUGGESTED_PROMPTS = [
-  "What are the key findings?",
-  "Summarize the main topics",
-  "What data sources were used?",
-  "What are the main conclusions?",
+  { text: "What are the key findings?", Icon: TrendingUp },
+  { text: "Summarize the main topics", Icon: AlignLeft },
+  { text: "What data sources were used?", Icon: Database },
+  { text: "What are the main conclusions?", Icon: CheckCircle2 },
 ];
 
 // =============================================================================
@@ -156,15 +159,15 @@ function EmptyTranscript({
             {SUGGESTED_PROMPTS.map((prompt, index) => (
               <button
                 key={index}
-                onClick={() => onPromptClick(prompt)}
+                onClick={() => onPromptClick(prompt.text)}
                 className="group flex items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-all duration-200 hover:bg-accent hover:text-accent-foreground hover:border-accent hover:shadow-sm hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                aria-label={`Use prompt: ${prompt}`}
+                aria-label={`Use prompt: ${prompt.text}`}
               >
-                <Sparkles
+                <prompt.Icon
                   className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground group-hover:text-accent-foreground"
                   aria-hidden="true"
                 />
-                <span className="text-sm">{prompt}</span>
+                <span className="text-sm">{prompt.text}</span>
               </button>
             ))}
           </div>
@@ -306,7 +309,7 @@ function Composer({ onSend, onStop, isStreaming, className, inputRef }: Composer
       )}
 
       {/* Composer container */}
-      <div className="relative rounded-xl border border-input bg-background shadow-sm">
+      <div className="relative rounded-xl border border-input bg-background shadow-sm focus-within:border-primary/60 transition-colors duration-150">
         {/* Textarea */}
         <Textarea
           ref={textareaRef as React.Ref<HTMLTextAreaElement>}
@@ -442,7 +445,7 @@ function Composer({ onSend, onStop, isStreaming, className, inputRef }: Composer
           {isStreaming ? (
             <Button
               variant="destructive"
-              size="sm"
+              size="default"
               onClick={onStop}
               className="gap-1.5"
               aria-label="Stop generating"
@@ -452,10 +455,10 @@ function Composer({ onSend, onStop, isStreaming, className, inputRef }: Composer
             </Button>
           ) : (
             <Button
-              size="sm"
+              size="default"
               onClick={handleSubmit}
               disabled={!input.trim() || input.length > MAX_INPUT_LENGTH}
-              className="gap-1.5"
+              className="gap-1.5 shadow-sm"
               aria-label="Send message"
             >
               <Send className="h-3.5 w-3.5" aria-hidden="true" />

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -62,7 +62,7 @@ export function MobileBottomNav({ activeItem, onItemSelect }: MobileBottomNavPro
               />
               <span
                 className={cn(
-                  "text-[10px] font-medium transition-colors",
+                  "text-xs font-medium transition-colors",
                   isActive ? "text-primary" : "text-muted-foreground"
                 )}
               >
@@ -92,7 +92,7 @@ export function MobileBottomNav({ activeItem, onItemSelect }: MobileBottomNavPro
               />
               <span
                 className={cn(
-                  "text-[10px] font-medium transition-colors",
+                  "text-xs font-medium transition-colors",
                   moreOpen ? "text-primary" : "text-muted-foreground"
                 )}
               >

--- a/frontend/src/components/layout/NavigationRail.tsx
+++ b/frontend/src/components/layout/NavigationRail.tsx
@@ -1,5 +1,4 @@
 import { MessageSquare, FileText, Brain, Settings, Database, Users, UserCog, Building2, UserCircle, Sun, Moon } from "lucide-react";
-import { motion } from "framer-motion";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { NavLink, useLocation } from "react-router-dom";
@@ -76,10 +75,8 @@ export function NavigationRail({ healthStatus }: NavigationRailProps) {
   return (
     <nav className="w-20 min-h-screen bg-card border-r border-border flex flex-col items-center py-6 gap-2" aria-label="Main navigation">
       {/* App Logo */}
-      <div className="mb-8 p-3 rounded-xl bg-primary/10">
-        <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
-          <span className="text-primary-foreground font-bold text-sm">KV</span>
-        </div>
+      <div className="mb-8 mx-auto w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+        <span className="text-primary-foreground font-bold text-sm">KV</span>
       </div>
 
       {/* Navigation Items */}
@@ -110,15 +107,6 @@ export function NavigationRail({ healthStatus }: NavigationRailProps) {
                 )}
               >
                 <Icon className="w-5 h-5" />
-
-                {/* Active Indicator — animated sliding pill */}
-                {isActive && (
-                  <motion.span
-                    layoutId="nav-active-indicator"
-                    className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-4 bg-primary rounded-full"
-                    transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                  />
-                )}
               </div>
 
               {/* Label */}

--- a/frontend/src/components/shared/DocumentCard.tsx
+++ b/frontend/src/components/shared/DocumentCard.tsx
@@ -3,7 +3,8 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { FileText, Trash2, MoreVertical } from "lucide-react";
+import { Trash2, MoreVertical } from "lucide-react";
+import { FileIcon } from "@/lib/fileIcon";
 import { StatusBadge } from "./StatusBadge";
 import { formatFileSize, formatDate } from "@/lib/formatters";
 import {
@@ -78,7 +79,7 @@ export function DocumentCard({
               className="flex-shrink-0 p-2 bg-muted rounded-md"
               aria-hidden="true"
             >
-              <FileText className="w-5 h-5 text-muted-foreground" />
+              <FileIcon filename={document.filename} className="w-5 h-5" />
             </div>
             <div className="min-w-0">
               <h3

--- a/frontend/src/lib/fileIcon.tsx
+++ b/frontend/src/lib/fileIcon.tsx
@@ -1,0 +1,26 @@
+import { FileText, FileType, Sheet, File } from "lucide-react";
+
+/**
+ * Returns a colored Lucide icon component for the given filename based on extension.
+ * Always use via JSX: <FileIcon filename={doc.filename} className="h-4 w-4" />
+ */
+export function FileIcon({ filename, className }: { filename: string | null | undefined; className?: string }) {
+  const ext = (filename ?? '').split('.').pop()?.toLowerCase() ?? '';
+
+  if (ext === 'pdf') {
+    return <FileType className={className} style={{ color: '#ef4444' }} aria-hidden="true" />;
+  }
+  if (ext === 'docx' || ext === 'doc') {
+    return <FileType className={className} style={{ color: '#3b82f6' }} aria-hidden="true" />;
+  }
+  if (ext === 'md' || ext === 'mdx') {
+    return <FileText className={className} style={{ color: '#14b8a6' }} aria-hidden="true" />;
+  }
+  if (ext === 'xlsx' || ext === 'xls' || ext === 'csv') {
+    return <Sheet className={className} style={{ color: '#22c55e' }} aria-hidden="true" />;
+  }
+  if (ext === 'txt') {
+    return <FileText className={className} style={{ color: undefined }} aria-hidden="true" />;
+  }
+  return <File className={className} aria-hidden="true" />;
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { FileText, Upload, Search, Trash2, ScanLine, AlertCircle, Loader2, X, RotateCcw, Trash, Info } from "lucide-react";
+import { FileIcon } from "@/lib/fileIcon";
 import { listDocuments, scanDocuments, deleteDocument, deleteDocuments, deleteAllDocumentsInVault, getDocumentStats, type Document, type DocumentStatsResponse } from "@/lib/api";
 import { formatFileSize, formatDate } from "@/lib/formatters";
 import { useDebounce } from "@/hooks/useDebounce";
@@ -765,7 +766,7 @@ export default function DocumentsPage() {
                           </td>
                           <td className="p-4 flex-none" style={{ width: filenameColWidth, flexShrink: 0 }}>
                             <div className="flex items-center gap-2">
-                              <FileText className="w-4 h-4 text-muted-foreground" />
+                              <FileIcon filename={doc.filename} className="w-4 h-4 flex-shrink-0" />
                               <span className="font-medium truncate max-w-full" title={doc.filename}>{doc.filename}</span>
                             </div>
                           </td>


### PR DESCRIPTION
## Summary

- **Accessibility**: Mobile nav labels raised from 10 px to `text-xs` (12 px) — WCAG minimum font size
- **Discoverability**: ActionBar default opacity 30%→60%; always visible on touch devices
- **File-type icons**: Color-coded icons for PDF (red), DOCX (blue), Markdown (teal), spreadsheets (green) across SourcesPanel, DocumentCard, and DocumentsPage
- **Code blocks**: Language badge + copy-to-clipboard button in assistant message code blocks
- **Citation tooltips**: Hovering a `[Source: …]` chip now shows the matched passage snippet
- **User avatar**: Shows authenticated user's initials instead of a generic User icon
- **Layout fixes**: SourcesPanel fills container height, NavigationRail layout-shift animation removed, duplicate "View all" link removed
- **Composer**: `focus-within` border highlight for clear focus state; Send/Stop buttons enlarged

## Pre-Landing Review

No critical issues found. Informational notes:
- `AssistantMessage.tsx` still renders one ReactMarkdown parse cycle per text segment (tech-debt comment added at the site)

## Eval Results

No prompt-related files changed — evals skipped.

## Test plan
- [x] All 1025 Vitest tests pass (0 failures, 1 skipped)
- [x] TypeScript build clean (`tsc --noEmit`)
- [x] Vite production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)