### PR TITLE
fix: preserve file_id across retry requeue in _handle_failure and admin retry

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -164,7 +164,7 @@ async def retry_document(
         if not background_processor.is_running:
             await background_processor.start()
 
-        await background_processor.enqueue(row["file_path"], vault_id=row["vault_id"])
+        await background_processor.enqueue(row["file_path"], vault_id=row["vault_id"], file_id=file_id)
 
         user_id = (
             str(current_user["id"])

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -423,7 +423,15 @@ async def list_documents(
 
 
 class DocumentStatusResponse(BaseModel):
-    """Lightweight status response used by the upload UI to poll indexing."""
+    """Phase-aware status response used by the upload UI to poll indexing.
+
+    `status` stays in the canonical 4-value enum
+    ('pending','processing','indexed','error'); upload/queued/parsing/
+    chunking/embedding/writing-index detail lives in `phase` and friends.
+    `wiki_status` is derived from the latest `wiki_compile_jobs` row for
+    this file, or 'pending' when `files.wiki_pending=1` and no job row
+    has appeared yet, or null when no wiki job has been requested.
+    """
 
     id: int
     filename: str
@@ -431,6 +439,20 @@ class DocumentStatusResponse(BaseModel):
     chunk_count: int
     error_message: Optional[str] = None
     processed_at: Optional[str] = None
+    # Phase-aware progress
+    phase: Optional[str] = None
+    phase_message: Optional[str] = None
+    progress_percent: Optional[float] = None
+    processed_units: Optional[int] = None
+    total_units: Optional[int] = None
+    unit_label: Optional[str] = None
+    phase_started_at: Optional[str] = None
+    processing_started_at: Optional[str] = None
+    elapsed_seconds: Optional[float] = None
+    # Wiki state (derived)
+    wiki_status: Optional[str] = None
+    wiki_phase: Optional[str] = None
+    wiki_job_id: Optional[int] = None
 
 
 @router.get("/{file_id}/status", response_model=DocumentStatusResponse)
@@ -440,18 +462,19 @@ async def get_document_status(
     user: dict = Depends(get_current_active_user),
     evaluate: Callable = Depends(get_evaluate_policy),
 ):
-    """Return the current ingest status of a single document.
+    """Return the phase-aware ingest status of a single document.
 
-    Used by the composer attachment tray to poll whether an uploaded file has
-    finished indexing. Returns 404 when the file doesn't exist and 403 when
-    the user lacks read access to the file's vault. Status values are the
-    canonical ``files.status`` enum: ``pending`` | ``processing`` | ``indexed``
-    | ``error``.
+    Used by the composer attachment tray and the Documents upload queue to
+    poll progress. Returns 404 when the file doesn't exist and 403 when
+    the user lacks read access to the file's vault.
     """
     cursor = await asyncio.to_thread(
         conn.execute,
         """
-        SELECT id, vault_id, file_name, status, chunk_count, error_message, processed_at
+        SELECT id, vault_id, file_name, status, chunk_count, error_message,
+               processed_at, phase, phase_message, progress_percent,
+               processed_units, total_units, unit_label, phase_started_at,
+               processing_started_at, wiki_pending
         FROM files WHERE id = ?
         """,
         (file_id,),
@@ -463,16 +486,87 @@ async def get_document_status(
     if not await evaluate(user, "vault", row["vault_id"], "read"):
         raise HTTPException(status_code=403, detail="No read access to this vault")
 
+    # Derive wiki state from the latest wiki_compile_jobs row for this file.
+    # We look up by trigger_id="file:<id>" because that's how DocumentProcessor
+    # tags ingest jobs (see services/document_processor.py).
+    wiki_status: Optional[str] = None
+    wiki_phase: Optional[str] = None
+    wiki_job_id: Optional[int] = None
+    try:
+        wiki_cursor = await asyncio.to_thread(
+            conn.execute,
+            """
+            SELECT id, status FROM wiki_compile_jobs
+            WHERE trigger_id = ?
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (f"file:{file_id}",),
+        )
+        wiki_row = await asyncio.to_thread(wiki_cursor.fetchone)
+        if wiki_row is not None:
+            wiki_job_id = int(wiki_row["id"])
+            wiki_status = wiki_row["status"]
+            wiki_phase = wiki_row["status"]
+        elif _safe_get(row, "wiki_pending", 0):
+            # Job hasn't appeared yet but processor has signalled intent.
+            wiki_status = "pending"
+            wiki_phase = "pending"
+    except sqlite3.Error:
+        # wiki_compile_jobs may not exist on very old test fixtures; treat as no wiki.
+        pass
+
+    # elapsed_seconds: from processing_started_at to now, when applicable.
+    # We compute on the server so the frontend doesn't need clock-skew handling.
+    elapsed_seconds: Optional[float] = None
+    started = _safe_get(row, "processing_started_at")
+    if started:
+        try:
+            from datetime import datetime, timezone
+            # SQLite stores CURRENT_TIMESTAMP as 'YYYY-MM-DD HH:MM:SS' (UTC, no tz).
+            started_dt = datetime.strptime(str(started), "%Y-%m-%d %H:%M:%S")
+            started_dt = started_dt.replace(tzinfo=timezone.utc)
+            elapsed_seconds = max(
+                0.0,
+                (datetime.now(timezone.utc) - started_dt).total_seconds(),
+            )
+        except (ValueError, TypeError):
+            elapsed_seconds = None
+
     return DocumentStatusResponse(
         id=row["id"],
         filename=row["file_name"],
         status=row["status"],
         chunk_count=row["chunk_count"] or 0,
-        error_message=row["error_message"]
-        if "error_message" in row.keys()
-        else None,
-        processed_at=row["processed_at"],
+        error_message=_safe_get(row, "error_message"),
+        processed_at=_safe_get(row, "processed_at"),
+        phase=_safe_get(row, "phase"),
+        phase_message=_safe_get(row, "phase_message"),
+        progress_percent=_safe_get(row, "progress_percent"),
+        processed_units=_safe_get(row, "processed_units"),
+        total_units=_safe_get(row, "total_units"),
+        unit_label=_safe_get(row, "unit_label"),
+        phase_started_at=_safe_get(row, "phase_started_at"),
+        processing_started_at=_safe_get(row, "processing_started_at"),
+        elapsed_seconds=elapsed_seconds,
+        wiki_status=wiki_status,
+        wiki_phase=wiki_phase,
+        wiki_job_id=wiki_job_id,
     )
+
+
+def _safe_get(row, key: str, default=None):
+    """sqlite3.Row.get-like helper: returns default when key is missing.
+
+    sqlite3.Row supports indexing by name but raises IndexError on missing
+    keys; in tests with hand-crafted dicts this avoids surprises.
+    """
+    try:
+        if hasattr(row, "keys"):
+            return row[key] if key in row.keys() else default
+        return row[key]  # tuple/dict
+    except (KeyError, IndexError, TypeError):
+        return default
 
 
 @router.get("/stats", response_model=DocumentStatsResponse)
@@ -573,14 +667,27 @@ async def upload_document_root(
     vector_store: VectorStore = Depends(get_vector_store),
     embedding_service: EmbeddingService = Depends(get_embedding_service),
     db_pool: SQLiteConnectionPool = Depends(get_db_pool),
+    background_processor: BackgroundProcessor = Depends(get_background_processor),
     user: dict = Depends(require_vault_permission("write")),
 ):
     """
     Upload endpoint at root /documents for frontend compatibility.
     Delegates to the main upload handler.
+
+    Returns promptly after the file is durably saved and a `files` row exists
+    with status='pending' / phase='queued'. Actual parsing/chunking/embedding
+    runs in the background processor; clients poll
+    ``GET /documents/{file_id}/status`` for progress.
     """
     return await _do_upload(
-        request, file, settings_dep, vector_store, embedding_service, db_pool, vault_id
+        request,
+        file,
+        settings_dep,
+        vector_store,
+        embedding_service,
+        db_pool,
+        background_processor,
+        vault_id,
     )
 
 
@@ -593,17 +700,27 @@ async def upload_document(
     vector_store: VectorStore = Depends(get_vector_store),
     embedding_service: EmbeddingService = Depends(get_embedding_service),
     db_pool: SQLiteConnectionPool = Depends(get_db_pool),
+    background_processor: BackgroundProcessor = Depends(get_background_processor),
     user: dict = Depends(require_vault_permission("write")),
 ):
     """
-    Upload a file and process it with strict security controls.
+    Upload a file with strict security controls and queue it for indexing.
 
-    Validates filename, extension, and file size before saving.
-    Saves the uploaded file to settings.uploads_dir using aiofiles,
-    then processes it via DocumentProcessor.process_file in asyncio.to_thread.
+    Validates filename, extension, and file size before saving. Saves the
+    uploaded file to settings.uploads_dir using aiofiles, registers a `files`
+    row with status='pending' / phase='queued', and enqueues the row for the
+    background processor. Returns immediately so the client can poll
+    ``GET /documents/{file_id}/status`` for phase-aware progress.
     """
     return await _do_upload(
-        request, file, settings_dep, vector_store, embedding_service, db_pool, vault_id
+        request,
+        file,
+        settings_dep,
+        vector_store,
+        embedding_service,
+        db_pool,
+        background_processor,
+        vault_id,
     )
 
 
@@ -614,6 +731,7 @@ async def _do_upload(
     vector_store: VectorStore,
     embedding_service: EmbeddingService,
     db_pool: SQLiteConnectionPool,
+    background_processor: BackgroundProcessor,
     vault_id: int,
 ) -> UploadResponse:
     # Validate file is provided
@@ -721,7 +839,17 @@ async def _do_upload(
                     )
                 await f.write(chunk)
 
-        # Process file with injected dependencies
+        # Async ingestion: register the file row synchronously (so duplicate
+        # detection still happens at the request, not in the worker), then
+        # enqueue the existing row for background processing. The route
+        # returns immediately with status='pending' / phase='queued' and the
+        # client polls GET /documents/{file_id}/status for phase progress.
+        from app.services.document_progress import (
+            PHASE_QUEUED,
+            set_phase,
+        )
+        from app.utils.file_utils import compute_file_hash
+
         processor = DocumentProcessor(
             chunk_size_chars=settings_dep.chunk_size_chars,
             chunk_overlap_chars=settings_dep.chunk_overlap_chars,
@@ -731,36 +859,106 @@ async def _do_upload(
         )
 
         try:
-            result = await processor.process_file(str(file_path), vault_id=vault_id)
+            file_hash = compute_file_hash(str(file_path))
+
+            # Phase 1: route-side duplicate check + row insert. Worker will
+            # NOT re-run these because we pass file_id on the queue task.
+            #
+            # The check uses ``_check_duplicate_in_flight`` (matches pending /
+            # processing / indexed) rather than the legacy ``_check_duplicate``
+            # (indexed only) so two concurrent uploads of the same file
+            # collapse to a single ingestion instead of both racing through
+            # to the partial unique index ``idx_files_hash_vault_indexed``,
+            # which would surface as a generic IntegrityError on the loser.
+            conn = db_pool.get_connection()
+            try:
+                duplicate = processor._check_duplicate_in_flight(
+                    file_hash, conn, vault_id
+                )
+                if duplicate:
+                    # Don't leak the existing file's storage path in the 409
+                    # detail (info disclosure). file_id + status + hash are
+                    # enough for the client to reconcile against /documents.
+                    file_path.unlink(missing_ok=True)
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"File with hash {file_hash} already exists in "
+                            f"this vault (status={duplicate['status']}, "
+                            f"file_id={duplicate['id']}). Uploaded copy was "
+                            f"cleaned up."
+                        ),
+                    )
+
+                # _insert_or_get_file_record itself can raise DuplicateFileError
+                # if the partial unique index trips (race window between the
+                # in-flight check and the INSERT/UPDATE). Translate to 409.
+                try:
+                    file_id = processor._insert_or_get_file_record(
+                        str(file_path),
+                        file_hash,
+                        conn,
+                        vault_id,
+                        "upload",
+                        None,
+                        None,
+                    )
+                except DuplicateFileError as e:
+                    file_path.unlink(missing_ok=True)
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"{e} (uploaded file was cleaned up)",
+                    )
+                conn.commit()
+            finally:
+                db_pool.release_connection(conn)
+
+            # Mark queued phase; status stays 'pending' until the worker
+            # transitions it to 'processing'. mark_processing_started=False
+            # because actual processing has not started yet — only queueing.
+            set_phase(
+                db_pool,
+                file_id,
+                phase=PHASE_QUEUED,
+                message="Queued for processing",
+            )
+
+            await background_processor.enqueue(
+                file_path=str(file_path),
+                source="upload",
+                vault_id=vault_id,
+                file_id=file_id,
+            )
 
             return UploadResponse(
-                file_id=result.file_id,
+                file_id=file_id,
                 file_name=file_name,
-                id=result.file_id,  # Frontend alias
-                filename=file_name,  # Frontend alias
-                status="indexed",
-                message=f"File '{file_name}' uploaded and processed successfully with {len(result.chunks)} chunks",
-            )
-        except DuplicateFileError as e:
-            # File is a duplicate, remove the uploaded file
-            file_path.unlink(missing_ok=True)
-            raise HTTPException(
-                status_code=409, detail=f"{e} (uploaded file was cleaned up)"
+                id=file_id,
+                filename=file_name,
+                status="pending",
+                message=(
+                    f"File '{file_name}' uploaded and queued for processing. "
+                    f"Poll GET /documents/{file_id}/status for progress."
+                ),
             )
         except HTTPException:
-            # Clean up partial file if it exists
-            if temp_file_path and temp_file_path.exists():
-                temp_file_path.unlink(missing_ok=True)
+            # Clean up partial file only if it still exists; duplicate path
+            # already removed it. Don't unconditionally unlink — the file is
+            # legitimately on disk for accepted uploads.
             raise
         except DocumentProcessingError as e:
+            file_path.unlink(missing_ok=True)
             logger.exception("Document processing error for file: %s", file_name)
             raise HTTPException(status_code=500, detail=f"Processing error: {e}")
         except Exception as e:
-            logger.exception("Unexpected error processing file: %s", file_name)
+            file_path.unlink(missing_ok=True)
+            logger.exception("Unexpected error registering file: %s", file_name)
             raise HTTPException(status_code=500, detail=f"Server error: {e}")
+    except HTTPException:
+        # Validation / size-limit errors already cleaned up partial files inline.
+        raise
     except Exception as e:
         logger.exception("Error uploading file: %s", file_name)
-        # Clean up file if it was created
         if temp_file_path and temp_file_path.exists():
             temp_file_path.unlink(missing_ok=True)
         raise HTTPException(status_code=500, detail=f"Upload failed: {e}")

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -55,6 +55,29 @@ class SettingsUpdate(BaseModel):
     maintenance_mode: Optional[bool] = None
     enable_model_validation: Optional[bool] = None
 
+    # Wiki / Knowledge Compiler config
+    wiki_enabled: Optional[bool] = None
+    wiki_compile_on_ingest: Optional[bool] = None
+    wiki_compile_on_query: Optional[bool] = None
+    wiki_compile_after_indexing: Optional[bool] = None
+    wiki_lint_enabled: Optional[bool] = None
+
+    # Optional LLM Wiki Curator config
+    wiki_llm_curator_enabled: Optional[bool] = None
+    wiki_llm_curator_url: Optional[str] = None
+    wiki_llm_curator_model: Optional[str] = None
+    wiki_llm_curator_temperature: Optional[float] = None
+    wiki_llm_curator_max_input_chars: Optional[int] = None
+    wiki_llm_curator_max_output_tokens: Optional[int] = None
+    wiki_llm_curator_timeout_sec: Optional[float] = None
+    wiki_llm_curator_concurrency: Optional[int] = None
+    wiki_llm_curator_mode: Optional[str] = None
+    wiki_llm_curator_require_quote_match: Optional[bool] = None
+    wiki_llm_curator_require_chunk_id: Optional[bool] = None
+    wiki_llm_curator_run_on_ingest: Optional[bool] = None
+    wiki_llm_curator_run_on_query: Optional[bool] = None
+    wiki_llm_curator_run_on_manual: Optional[bool] = None
+
     @field_validator("chunk_size")
     @classmethod
     def validate_chunk_size(cls, v):
@@ -201,6 +224,83 @@ class SettingsUpdate(BaseModel):
             raise ValueError("chunk_overlap must be less than chunk_size")
         return self
 
+    # ── Curator validators ────────────────────────────────────────────────
+    @field_validator("wiki_llm_curator_temperature")
+    @classmethod
+    def validate_curator_temperature(cls, v):
+        if v is not None and not (0.0 <= float(v) <= 1.0):
+            raise ValueError("wiki_llm_curator_temperature must be between 0.0 and 1.0")
+        return v
+
+    @field_validator("wiki_llm_curator_max_input_chars")
+    @classmethod
+    def validate_curator_max_input_chars(cls, v):
+        if v is not None and not (1000 <= int(v) <= 24000):
+            raise ValueError(
+                "wiki_llm_curator_max_input_chars must be between 1000 and 24000"
+            )
+        return v
+
+    @field_validator("wiki_llm_curator_max_output_tokens")
+    @classmethod
+    def validate_curator_max_output_tokens(cls, v):
+        if v is not None and not (1 <= int(v) <= 16384):
+            raise ValueError(
+                "wiki_llm_curator_max_output_tokens must be between 1 and 16384"
+            )
+        return v
+
+    @field_validator("wiki_llm_curator_timeout_sec")
+    @classmethod
+    def validate_curator_timeout_sec(cls, v):
+        if v is not None and not (10 <= float(v) <= 600):
+            raise ValueError(
+                "wiki_llm_curator_timeout_sec must be between 10 and 600"
+            )
+        return v
+
+    @field_validator("wiki_llm_curator_concurrency")
+    @classmethod
+    def validate_curator_concurrency(cls, v):
+        if v is not None and not (1 <= int(v) <= 4):
+            raise ValueError("wiki_llm_curator_concurrency must be between 1 and 4")
+        return v
+
+    @field_validator("wiki_llm_curator_mode")
+    @classmethod
+    def validate_curator_mode(cls, v):
+        if v is not None and v not in ("draft", "active_if_verified"):
+            raise ValueError(
+                "wiki_llm_curator_mode must be 'draft' or 'active_if_verified'"
+            )
+        return v
+
+    @field_validator("wiki_llm_curator_url", mode="before")
+    @classmethod
+    def validate_curator_url(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, str) or len(v) > 2048:
+            raise ValueError("wiki_llm_curator_url must be a string up to 2048 chars")
+        v = v.strip()
+        if v and not v.startswith(("http://", "https://")):
+            raise ValueError("wiki_llm_curator_url must start with http:// or https://")
+        if "@" in v:
+            raise ValueError("wiki_llm_curator_url must not contain credentials (@)")
+        return v
+
+    @field_validator("wiki_llm_curator_model", mode="before")
+    @classmethod
+    def validate_curator_model(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, str) or len(v) > 256:
+            raise ValueError("wiki_llm_curator_model must be a string up to 256 chars")
+        v = v.strip()
+        if any(ord(c) < 32 or ord(c) == 127 for c in v):
+            raise ValueError("wiki_llm_curator_model must not contain control characters")
+        return v
+
 
 ALLOWED_FIELDS = [
     "chunk_size",
@@ -230,7 +330,34 @@ ALLOWED_FIELDS = [
     "ollama_chat_url",
     "embedding_model",
     "chat_model",
+    # Wiki / Knowledge Compiler
+    "wiki_enabled",
+    "wiki_compile_on_ingest",
+    "wiki_compile_on_query",
+    "wiki_compile_after_indexing",
+    "wiki_lint_enabled",
+    # Optional LLM Wiki Curator
+    "wiki_llm_curator_enabled",
+    "wiki_llm_curator_url",
+    "wiki_llm_curator_model",
+    "wiki_llm_curator_temperature",
+    "wiki_llm_curator_max_input_chars",
+    "wiki_llm_curator_max_output_tokens",
+    "wiki_llm_curator_timeout_sec",
+    "wiki_llm_curator_concurrency",
+    "wiki_llm_curator_mode",
+    "wiki_llm_curator_require_quote_match",
+    "wiki_llm_curator_require_chunk_id",
+    "wiki_llm_curator_run_on_ingest",
+    "wiki_llm_curator_run_on_query",
+    "wiki_llm_curator_run_on_manual",
 ]
+
+
+# Curator fields that must be non-empty when wiki_llm_curator_enabled is true.
+# Enforced at PUT-time so the backend never silently accepts a half-configured
+# curator (which would then surface as a runtime error during compile).
+_CURATOR_REQUIRED_WHEN_ENABLED = ("wiki_llm_curator_url", "wiki_llm_curator_model")
 
 
 def _persist_settings(conn: sqlite3.Connection, update: SettingsUpdate) -> None:
@@ -243,6 +370,42 @@ def _persist_settings(conn: sqlite3.Connection, update: SettingsUpdate) -> None:
                 (field, json.dumps(value)),
             )
     conn.commit()
+
+
+def _enforce_curator_required_when_enabled(update: SettingsUpdate) -> None:
+    """Reject PUT bodies that enable the curator without URL+model.
+
+    Reads the *effective post-update state*: if the body sets
+    ``wiki_llm_curator_enabled=True`` but does not also supply (or already
+    has) a non-empty url + model, raise 422. This prevents silent half-
+    configured curators that fail at runtime instead of at save time.
+    """
+    # Effective enabled = body value if provided, else current setting.
+    if update.wiki_llm_curator_enabled is not None:
+        will_be_enabled = bool(update.wiki_llm_curator_enabled)
+    else:
+        will_be_enabled = bool(getattr(settings, "wiki_llm_curator_enabled", False))
+    if not will_be_enabled:
+        return
+
+    missing: list[str] = []
+    for field in _CURATOR_REQUIRED_WHEN_ENABLED:
+        # Effective post-update value: body wins, else current setting.
+        body_val = getattr(update, field)
+        if body_val is not None:
+            effective = body_val
+        else:
+            effective = getattr(settings, field, "")
+        if not effective or (isinstance(effective, str) and not effective.strip()):
+            missing.append(field)
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Curator is enabled but required fields are missing: "
+                f"{', '.join(missing)}. Provide URL and model, or disable the curator."
+            ),
+        )
 
 
 class SettingsResponse(BaseModel):
@@ -299,6 +462,29 @@ class SettingsResponse(BaseModel):
     hybrid_search_enabled: bool = True
     hybrid_alpha: float = 0.5
 
+    # Wiki / Knowledge Compiler config
+    wiki_enabled: bool = True
+    wiki_compile_on_ingest: bool = True
+    wiki_compile_on_query: bool = True
+    wiki_compile_after_indexing: bool = True
+    wiki_lint_enabled: bool = True
+
+    # Optional LLM Wiki Curator config
+    wiki_llm_curator_enabled: bool = False
+    wiki_llm_curator_url: str = ""
+    wiki_llm_curator_model: str = ""
+    wiki_llm_curator_temperature: float = 0.0
+    wiki_llm_curator_max_input_chars: int = 6000
+    wiki_llm_curator_max_output_tokens: int = 2048
+    wiki_llm_curator_timeout_sec: float = 120.0
+    wiki_llm_curator_concurrency: int = 1
+    wiki_llm_curator_mode: str = "draft"
+    wiki_llm_curator_require_quote_match: bool = True
+    wiki_llm_curator_require_chunk_id: bool = True
+    wiki_llm_curator_run_on_ingest: bool = True
+    wiki_llm_curator_run_on_query: bool = False
+    wiki_llm_curator_run_on_manual: bool = True
+
     # Limits (safe to expose)
     max_file_size_mb: int
     allowed_extensions: list[str]
@@ -306,10 +492,129 @@ class SettingsResponse(BaseModel):
     # CORS (safe to expose)
     backend_cors_origins: list[str]
 
+    # Source map: per field, where the effective runtime value came from.
+    # Values: "kv" (settings_kv override), "env" (matches an env variable),
+    # "default" (Pydantic default). The Models tab uses this to label each
+    # field instead of disabling inputs based on env presence (kv > env at
+    # runtime in the actual lifespan order, so disabling on env presence
+    # would lie). May be omitted on legacy clients that do not expect it.
+    effective_sources: dict[str, str] = {}
+
     @field_validator("data_dir", mode="before")
     @classmethod
     def convert_path_to_str(cls, v):
         return str(v)
+
+
+def _build_settings_dict() -> dict:
+    """Build the public settings dict from the live ``settings`` singleton.
+
+    Used by both GET /settings and the post-update response so the wire
+    shape is identical regardless of code path.
+    """
+    base = {
+        "port": settings.port,
+        "data_dir": str(settings.data_dir),
+        "ollama_embedding_url": settings.ollama_embedding_url,
+        "ollama_chat_url": settings.ollama_chat_url,
+        "embedding_model": settings.embedding_model,
+        "chat_model": settings.chat_model,
+        "chunk_size": settings.chunk_size,
+        "chunk_overlap": settings.chunk_overlap,
+        "max_context_chunks": settings.max_context_chunks,
+        "rag_relevance_threshold": settings.rag_relevance_threshold,
+        "vector_top_k": settings.vector_top_k,
+        "chunk_size_chars": settings.chunk_size_chars,
+        "chunk_overlap_chars": settings.chunk_overlap_chars,
+        "retrieval_top_k": settings.retrieval_top_k,
+        "vector_metric": settings.vector_metric,
+        "max_distance_threshold": settings.max_distance_threshold,
+        "embedding_doc_prefix": settings.embedding_doc_prefix,
+        "embedding_query_prefix": settings.embedding_query_prefix,
+        "retrieval_window": settings.retrieval_window,
+        "embedding_batch_size": settings.embedding_batch_size,
+        "maintenance_mode": settings.maintenance_mode,
+        "auto_scan_enabled": settings.auto_scan_enabled,
+        "auto_scan_interval_minutes": settings.auto_scan_interval_minutes,
+        "enable_model_validation": settings.enable_model_validation,
+        "max_file_size_mb": settings.max_file_size_mb,
+        "allowed_extensions": settings.allowed_extensions,
+        "backend_cors_origins": settings.backend_cors_origins,
+        "reranker_url": settings.reranker_url,
+        "reranker_model": settings.reranker_model,
+        "reranking_enabled": settings.reranking_enabled,
+        "reranker_top_n": settings.reranker_top_n,
+        "initial_retrieval_top_k": settings.initial_retrieval_top_k,
+        "hybrid_search_enabled": settings.hybrid_search_enabled,
+        "hybrid_alpha": settings.hybrid_alpha,
+        # Wiki / Knowledge Compiler
+        "wiki_enabled": settings.wiki_enabled,
+        "wiki_compile_on_ingest": settings.wiki_compile_on_ingest,
+        "wiki_compile_on_query": settings.wiki_compile_on_query,
+        "wiki_compile_after_indexing": settings.wiki_compile_after_indexing,
+        "wiki_lint_enabled": settings.wiki_lint_enabled,
+        # Optional LLM Wiki Curator
+        "wiki_llm_curator_enabled": settings.wiki_llm_curator_enabled,
+        "wiki_llm_curator_url": settings.wiki_llm_curator_url,
+        "wiki_llm_curator_model": settings.wiki_llm_curator_model,
+        "wiki_llm_curator_temperature": settings.wiki_llm_curator_temperature,
+        "wiki_llm_curator_max_input_chars": settings.wiki_llm_curator_max_input_chars,
+        "wiki_llm_curator_max_output_tokens": settings.wiki_llm_curator_max_output_tokens,
+        "wiki_llm_curator_timeout_sec": settings.wiki_llm_curator_timeout_sec,
+        "wiki_llm_curator_concurrency": settings.wiki_llm_curator_concurrency,
+        "wiki_llm_curator_mode": settings.wiki_llm_curator_mode,
+        "wiki_llm_curator_require_quote_match": settings.wiki_llm_curator_require_quote_match,
+        "wiki_llm_curator_require_chunk_id": settings.wiki_llm_curator_require_chunk_id,
+        "wiki_llm_curator_run_on_ingest": settings.wiki_llm_curator_run_on_ingest,
+        "wiki_llm_curator_run_on_query": settings.wiki_llm_curator_run_on_query,
+        "wiki_llm_curator_run_on_manual": settings.wiki_llm_curator_run_on_manual,
+    }
+    # NOTE: callers MUST set base["effective_sources"] explicitly with a
+    # real DB connection. _compute_effective_sources(None) would silently
+    # return an all-"env"/"default" map (no kv visibility), which would
+    # mislead the Models tab badges. Forcing the assignment at the call
+    # site keeps the contract honest.
+    return base
+
+
+def _compute_effective_sources(conn: Optional[sqlite3.Connection]) -> dict[str, str]:
+    """Map each ALLOWED_FIELD to the source of its current effective value.
+
+    Precedence reflects actual runtime behaviour from
+    ``backend/app/lifespan.py``: settings_kv is loaded at startup and
+    ``setattr(settings, key, value)`` overwrites env-derived values, so
+    persistence wins after the first save. Values:
+      - "kv":      a row exists in ``settings_kv`` for this field.
+      - "env":     no kv row, and an env variable with the same name
+                   (uppercased) is set.
+      - "default": neither.
+
+    The Models tab uses this to label inputs honestly without disabling
+    them on env presence.
+    """
+    kv_keys: set[str] = set()
+    if conn is not None:
+        try:
+            cursor = conn.execute("SELECT key FROM settings_kv")
+            kv_keys = {row[0] for row in cursor.fetchall()}
+        except sqlite3.Error:
+            kv_keys = set()
+    out: dict[str, str] = {}
+    import os as _os
+
+    for field in ALLOWED_FIELDS:
+        if field in kv_keys:
+            out[field] = "kv"
+        else:
+            # Treat ``X=""`` as "not set". Pydantic typically falls back
+            # to its default for empty strings, so labelling the source
+            # as "env" would mislead the Models tab badges.
+            env_val = _os.environ.get(field.upper(), "")
+            if env_val != "":
+                out[field] = "env"
+            else:
+                out[field] = "default"
+    return out
 
 
 def _apply_settings_update(update: SettingsUpdate) -> SettingsResponse:
@@ -324,87 +629,17 @@ def _apply_settings_update(update: SettingsUpdate) -> SettingsResponse:
         raise HTTPException(
             status_code=400, detail="No valid fields provided for update"
         )
-    # Convert settings object to dict for validation
-    settings_dict = {
-        "port": settings.port,
-        "data_dir": str(settings.data_dir),
-        "ollama_embedding_url": settings.ollama_embedding_url,
-        "ollama_chat_url": settings.ollama_chat_url,
-        "embedding_model": settings.embedding_model,
-        "chat_model": settings.chat_model,
-        "chunk_size": settings.chunk_size,
-        "chunk_overlap": settings.chunk_overlap,
-        "max_context_chunks": settings.max_context_chunks,
-        "rag_relevance_threshold": settings.rag_relevance_threshold,
-        "vector_top_k": settings.vector_top_k,
-        "chunk_size_chars": settings.chunk_size_chars,
-        "chunk_overlap_chars": settings.chunk_overlap_chars,
-        "retrieval_top_k": settings.retrieval_top_k,
-        "vector_metric": settings.vector_metric,
-        "max_distance_threshold": settings.max_distance_threshold,
-        "embedding_doc_prefix": settings.embedding_doc_prefix,
-        "embedding_query_prefix": settings.embedding_query_prefix,
-        "retrieval_window": settings.retrieval_window,
-        "embedding_batch_size": settings.embedding_batch_size,
-        "maintenance_mode": settings.maintenance_mode,
-        "auto_scan_enabled": settings.auto_scan_enabled,
-        "auto_scan_interval_minutes": settings.auto_scan_interval_minutes,
-        "enable_model_validation": settings.enable_model_validation,
-        "max_file_size_mb": settings.max_file_size_mb,
-        "allowed_extensions": settings.allowed_extensions,
-        "backend_cors_origins": settings.backend_cors_origins,
-        "reranker_url": settings.reranker_url,
-        "reranker_model": settings.reranker_model,
-        "reranking_enabled": settings.reranking_enabled,
-        "reranker_top_n": settings.reranker_top_n,
-        "initial_retrieval_top_k": settings.initial_retrieval_top_k,
-        "hybrid_search_enabled": settings.hybrid_search_enabled,
-        "hybrid_alpha": settings.hybrid_alpha,
-    }
-    return SettingsResponse.model_validate(settings_dict)
+    return SettingsResponse.model_validate(_build_settings_dict())
 
 
 @router.get("/settings", response_model=SettingsResponse)
 def get_settings(
     user: dict = Depends(get_current_active_user),
+    conn: sqlite3.Connection = Depends(get_db),
 ):
     """Return current public settings dict (including embedding_batch_size)."""
-    settings_dict = {
-        "port": settings.port,
-        "data_dir": str(settings.data_dir),
-        "ollama_embedding_url": settings.ollama_embedding_url,
-        "ollama_chat_url": settings.ollama_chat_url,
-        "embedding_model": settings.embedding_model,
-        "chat_model": settings.chat_model,
-        "chunk_size": settings.chunk_size,
-        "chunk_overlap": settings.chunk_overlap,
-        "max_context_chunks": settings.max_context_chunks,
-        "rag_relevance_threshold": settings.rag_relevance_threshold,
-        "vector_top_k": settings.vector_top_k,
-        "chunk_size_chars": settings.chunk_size_chars,
-        "chunk_overlap_chars": settings.chunk_overlap_chars,
-        "retrieval_top_k": settings.retrieval_top_k,
-        "vector_metric": settings.vector_metric,
-        "max_distance_threshold": settings.max_distance_threshold,
-        "embedding_doc_prefix": settings.embedding_doc_prefix,
-        "embedding_query_prefix": settings.embedding_query_prefix,
-        "retrieval_window": settings.retrieval_window,
-        "embedding_batch_size": settings.embedding_batch_size,
-        "maintenance_mode": settings.maintenance_mode,
-        "auto_scan_enabled": settings.auto_scan_enabled,
-        "auto_scan_interval_minutes": settings.auto_scan_interval_minutes,
-        "enable_model_validation": settings.enable_model_validation,
-        "max_file_size_mb": settings.max_file_size_mb,
-        "allowed_extensions": settings.allowed_extensions,
-        "backend_cors_origins": settings.backend_cors_origins,
-        "reranker_url": settings.reranker_url,
-        "reranker_model": settings.reranker_model,
-        "reranking_enabled": settings.reranking_enabled,
-        "reranker_top_n": settings.reranker_top_n,
-        "initial_retrieval_top_k": settings.initial_retrieval_top_k,
-        "hybrid_search_enabled": settings.hybrid_search_enabled,
-        "hybrid_alpha": settings.hybrid_alpha,
-    }
+    settings_dict = _build_settings_dict()
+    settings_dict["effective_sources"] = _compute_effective_sources(conn)
     return SettingsResponse.model_validate(settings_dict)
 
 
@@ -415,8 +650,13 @@ def post_settings(
     _role: dict = Depends(require_role("admin")),
 ):
     """Apply settings update and persist to database."""
+    _enforce_curator_required_when_enabled(update)
     result = _apply_settings_update(update)
     _persist_settings(conn, update)
+    # Re-derive effective_sources now that we've persisted.
+    result = SettingsResponse.model_validate(
+        {**_build_settings_dict(), "effective_sources": _compute_effective_sources(conn)}
+    )
     return result
 
 
@@ -427,8 +667,12 @@ def put_settings(
     _role: dict = Depends(require_role("admin")),
 ):
     """Update settings (upserts into settings_kv)."""
+    _enforce_curator_required_when_enabled(update)
     result = _apply_settings_update(update)
     _persist_settings(conn, update)
+    result = SettingsResponse.model_validate(
+        {**_build_settings_dict(), "effective_sources": _compute_effective_sources(conn)}
+    )
     return result
 
 
@@ -478,3 +722,122 @@ async def test_connection(user: dict = Depends(get_current_active_user)):
                 "model": settings.reranker_model,
             }
     return results
+
+
+class _CuratorTestBody(BaseModel):
+    """Optional inline override for the curator test endpoint.
+
+    When the body is empty, the test uses the persisted curator settings
+    (typical case after Save). The frontend sends an inline override so
+    the operator can validate a URL/model BEFORE saving. Validation rules
+    mirror SettingsUpdate.validate_curator_url / validate_curator_model.
+    """
+
+    url: Optional[str] = None
+    model: Optional[str] = None
+
+
+@router.post("/settings/curator/test")
+async def test_curator_connection(
+    body: Optional[_CuratorTestBody] = None,
+    _role: dict = Depends(require_role("admin")),
+):
+    """Validate the curator endpoint by issuing a tiny JSON-only ping.
+
+    SSRF-guarded: rejects RFC1918 / loopback / link-local destinations
+    unless ``ALLOW_LOCAL_CURATOR=1`` is set. The ping uses
+    ``max_tokens=16`` and ``temperature=0`` so it is cheap even when
+    pointed at a real model. We never follow redirects.
+
+    Returns ``{ok, model, latency_ms, error?}`` shape — never throws to
+    the client; errors are surfaced in the body so the UI can render
+    them inline.
+    """
+    from app.services.curator_ssrf import CuratorURLBlocked, assert_curator_url_safe
+
+    url = (body.url if body and body.url is not None else settings.wiki_llm_curator_url) or ""
+    model = (
+        body.model if body and body.model is not None else settings.wiki_llm_curator_model
+    ) or ""
+
+    if not url.strip() or not model.strip():
+        return {
+            "ok": False,
+            "model": model,
+            "latency_ms": None,
+            "error": "Curator URL and model are required.",
+        }
+
+    # SSRF guard.
+    try:
+        assert_curator_url_safe(url)
+    except CuratorURLBlocked as e:
+        return {
+            "ok": False,
+            "model": model,
+            "latency_ms": None,
+            "error": str(e),
+        }
+
+    import time as _time
+
+    base = url.rstrip("/")
+    endpoint = base if base.endswith("/v1/chat/completions") else (
+        base + "/v1/chat/completions"
+    )
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a JSON-only echo. Reply with the literal JSON "
+                    'object {"ok": true} and nothing else.'
+                ),
+            },
+            {"role": "user", "content": '{"ping": true}'},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 16,
+        "stream": False,
+    }
+    timeout = float(settings.wiki_llm_curator_timeout_sec or 10.0)
+    timeout = min(max(timeout, 1.0), 30.0)  # cap test calls at 30s
+
+    started = _time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+            resp = await client.post(endpoint, json=payload)
+        latency_ms = int((_time.monotonic() - started) * 1000)
+        if resp.status_code >= 300:
+            return {
+                "ok": False,
+                "model": model,
+                "latency_ms": latency_ms,
+                "error": f"Curator returned HTTP {resp.status_code}: {resp.text[:200]}",
+            }
+        # Parsing the response is best-effort — if the model returns plain
+        # text instead of JSON, the test still passes (the curator client
+        # in PR C does robust JSON extraction during real runs).
+        return {
+            "ok": True,
+            "model": model,
+            "latency_ms": latency_ms,
+            "error": None,
+        }
+    except httpx.TimeoutException:
+        latency_ms = int((_time.monotonic() - started) * 1000)
+        return {
+            "ok": False,
+            "model": model,
+            "latency_ms": latency_ms,
+            "error": f"Curator endpoint timed out after {timeout}s.",
+        }
+    except Exception as e:  # broad: surface any transport error to the UI
+        latency_ms = int((_time.monotonic() - started) * 1000)
+        return {
+            "ok": False,
+            "model": model,
+            "latency_ms": latency_ms,
+            "error": str(e)[:300],
+        }

--- a/backend/app/api/routes/wiki.py
+++ b/backend/app/api/routes/wiki.py
@@ -281,6 +281,89 @@ async def update_wiki_claim(
         raise HTTPException(status_code=404, detail="Claim not found")
     await _require_vault_write(user, claim.vault_id)
     updates = request.model_dump(exclude_none=True)
+
+    # PR C: server-side source-quote re-verification on transitions to
+    # 'active'. Curator-authored claims default to 'needs_review' or
+    # 'active' depending on the curator mode setting; the operator can
+    # later promote a needs_review claim via this PUT, but ONLY if the
+    # source_quote stored on the claim's source row still matches the
+    # underlying chunk text. Otherwise the source has changed (or was
+    # never verifiable in the first place) and we must reject the
+    # promotion rather than silently activate an unverifiable claim.
+    new_status = updates.get("status")
+    if (
+        new_status == "active"
+        and claim.status != "active"
+        and claim.created_by_kind == "llm_curator"
+    ):
+        from app.services.wiki_curator import verify_quote
+
+        # Fetch every source row for this claim and require at least
+        # one verifiable quote against the file's parsed_text.
+        source_rows = db.execute(
+            "SELECT * FROM wiki_claim_sources WHERE claim_id = ?",
+            (claim_id,),
+        ).fetchall()
+        verified = False
+        any_file_source = False
+        any_quote = False
+        for src_row in source_rows:
+            try:
+                src = dict(src_row) if hasattr(src_row, "keys") else {}
+            except Exception:
+                src = {}
+            quote = src.get("quote")
+            file_id = src.get("file_id")
+            if quote:
+                any_quote = True
+            if not quote or file_id is None:
+                continue
+            any_file_source = True
+            file_row = db.execute(
+                "SELECT parsed_text FROM files WHERE id = ?",
+                (int(file_id),),
+            ).fetchone()
+            if not file_row:
+                continue
+            try:
+                parsed_text = file_row["parsed_text"]
+            except (KeyError, IndexError, TypeError):
+                parsed_text = file_row[0] if len(file_row) else None
+            if not parsed_text:
+                continue
+            if verify_quote(quote, parsed_text):
+                verified = True
+                break
+        if not verified:
+            # Distinguish "verifiable but mismatched" from "no file
+            # source attached" so the operator gets an actionable
+            # message rather than a generic 400. Curator claims
+            # authored on the query/manual trigger have file_id=None
+            # on every source row and can NEVER be auto-promoted to
+            # active — they must be edited manually or replaced.
+            if not any_file_source:
+                detail = (
+                    "Cannot auto-activate curator-authored claim: no source "
+                    "row references a document file (this claim was likely "
+                    "produced from a chat-query or manual-promote curator "
+                    "trigger). Edit the claim and attach a file source, or "
+                    "leave it in 'needs_review' status for manual handling."
+                )
+            elif not any_quote:
+                detail = (
+                    "Cannot auto-activate curator-authored claim: no source "
+                    "row carries a stored quote. Re-run the wiki compile "
+                    "or attach a verifiable source."
+                )
+            else:
+                detail = (
+                    "Cannot auto-activate curator-authored claim: source_quote "
+                    "no longer verifiable in any associated source. The "
+                    "underlying document may have changed; re-run the wiki "
+                    "compile or attach a new verifiable source."
+                )
+            raise HTTPException(status_code=400, detail=detail)
+
     updated = store.update_claim(claim_id, claim.vault_id, **updates)
     return _as_dict(updated)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -273,6 +273,50 @@ class Settings(BaseSettings):
     chunk_enrichment_fields: str = "summary,questions,entities"
     """Comma-separated list of enrichment fields to generate: summary, questions, entities, aliases."""
 
+    # ── Wiki / Knowledge Compiler configuration ──────────────────────────
+    wiki_enabled: bool = True
+    """Master switch for the Knowledge Compiler / wiki subsystem."""
+    wiki_compile_on_ingest: bool = True
+    """Run wiki compile when a document finishes indexing."""
+    wiki_compile_on_query: bool = True
+    """Run wiki compile when a chat query touches the vault."""
+    wiki_compile_after_indexing: bool = True
+    """Backwards-compatible alias for wiki_compile_on_ingest."""
+    wiki_lint_enabled: bool = True
+    """Run wiki lint sweeps when triggered from the UI."""
+
+    # ── Optional LLM Wiki Curator (PR C wires this through) ───────────────
+    wiki_llm_curator_enabled: bool = False
+    """Master switch for the LLM-assisted wiki curator. Default OFF."""
+    wiki_llm_curator_url: str = ""
+    """OpenAI-compatible /v1/chat/completions base URL for the curator model.
+    Empty when the curator is disabled. SSRF-guarded at the route boundary."""
+    wiki_llm_curator_model: str = ""
+    """Model name passed to the curator endpoint. Empty when disabled."""
+    wiki_llm_curator_temperature: float = 0.0
+    """Temperature for curator calls. Default 0.0 for determinism."""
+    wiki_llm_curator_max_input_chars: int = 6000
+    """Maximum source text passed to the curator per call (1000-24000)."""
+    wiki_llm_curator_max_output_tokens: int = 2048
+    """max_tokens passed to the curator per call."""
+    wiki_llm_curator_timeout_sec: float = 120.0
+    """Per-call timeout in seconds (10-600)."""
+    wiki_llm_curator_concurrency: int = 1
+    """Maximum concurrent curator calls inside one compile job (1-4)."""
+    wiki_llm_curator_mode: str = "draft"
+    """draft (always status='needs_review') or active_if_verified
+    (status='active' iff source_quote + chunk_id verify)."""
+    wiki_llm_curator_require_quote_match: bool = True
+    """Reject candidates whose source_quote does not match the source text."""
+    wiki_llm_curator_require_chunk_id: bool = True
+    """Reject candidates whose chunk_id is not in the provided chunk set."""
+    wiki_llm_curator_run_on_ingest: bool = True
+    """Run the curator in ingest compile jobs when curator is enabled."""
+    wiki_llm_curator_run_on_query: bool = False
+    """Run the curator in query compile jobs. Default OFF to protect chat latency."""
+    wiki_llm_curator_run_on_manual: bool = True
+    """Run the curator in manual / recompile jobs when curator is enabled."""
+
     # ── Retrieval profile configuration ──────────────────────────────────
     retrieval_profile: str = "advanced"
     """Retrieval profile: 'baseline' (dense + hybrid + rerank), 'advanced' (adds enrichment)."""

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -48,6 +48,17 @@ CREATE TABLE IF NOT EXISTS files (
     document_date TEXT,
     supersedes_file_id INTEGER,
     ingestion_version INTEGER DEFAULT 1,
+    -- Phase-aware progress (status stays in the canonical 4-value enum;
+    -- async/queued/parsing/chunking/embedding live in `phase`).
+    phase TEXT,
+    phase_message TEXT,
+    progress_percent REAL,
+    processed_units INTEGER,
+    total_units INTEGER,
+    unit_label TEXT,
+    phase_started_at TIMESTAMP,
+    processing_started_at TIMESTAMP,
+    wiki_pending INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (vault_id) REFERENCES vaults(id)
 );
 
@@ -113,6 +124,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 -- Index for faster lookups
 CREATE INDEX IF NOT EXISTS idx_chat_messages_session_id ON chat_messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_files_status ON files(status);
+CREATE INDEX IF NOT EXISTS idx_files_hash_vault_status ON files(file_hash, vault_id, status);
 
 -- Document actions for auditing admin operations
 CREATE TABLE IF NOT EXISTS document_actions (
@@ -576,6 +588,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_refs_and_job_input(sqlite_path)
     migrate_add_wiki_jobs_retry_count(sqlite_path)
     migrate_add_files_parsed_text(sqlite_path)
+    migrate_add_files_processing_progress(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
     # Wrapped in IntegrityError handler: existing databases may have duplicate
@@ -1289,6 +1302,49 @@ def migrate_add_files_parsed_text(sqlite_path: str) -> None:
         ]
         if "parsed_text" not in existing_cols:
             conn.execute("ALTER TABLE files ADD COLUMN parsed_text TEXT")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_files_processing_progress(sqlite_path: str) -> None:
+    """Migration: add phase-aware processing-progress columns to files table.
+
+    files.status stays in the canonical 4-value enum
+    ('pending','processing','indexed','error'). All async/queued/parsing/
+    chunking/embedding/writing-index detail lives in `phase` and friends.
+
+    Also creates ``idx_files_hash_vault_status`` to back the in-flight
+    duplicate check used by the async upload route. Without this index,
+    the ``IN ('pending','processing','indexed')`` filter falls back to
+    scanning every indexed row and the request-blocking dedup check
+    becomes O(indexed_rows).
+
+    Idempotent — safe to run multiple times.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        existing_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(files)").fetchall()
+        }
+        new_columns = (
+            ("phase", "TEXT"),
+            ("phase_message", "TEXT"),
+            ("progress_percent", "REAL"),
+            ("processed_units", "INTEGER"),
+            ("total_units", "INTEGER"),
+            ("unit_label", "TEXT"),
+            ("phase_started_at", "TIMESTAMP"),
+            ("processing_started_at", "TIMESTAMP"),
+            ("wiki_pending", "INTEGER NOT NULL DEFAULT 0"),
+        )
+        for name, ddl in new_columns:
+            if name not in existing_cols:
+                conn.execute(f"ALTER TABLE files ADD COLUMN {name} {ddl}")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_files_hash_vault_status "
+            "ON files(file_hash, vault_id, status)"
+        )
         conn.commit()
     finally:
         conn.close()

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -351,9 +351,13 @@ CREATE TABLE IF NOT EXISTS wiki_claims (
     source_type TEXT NOT NULL CHECK (source_type IN (
         'document','memory','chat_synthesis','manual','mixed')),
     status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
-        'active','contradicted','superseded','unverified','archived')),
+        'active','contradicted','superseded','unverified','archived','needs_review')),
     confidence REAL DEFAULT 0.0,
     created_by INTEGER,
+    -- 'deterministic' | 'llm_curator' | NULL (legacy / unknown).
+    -- Distinct from `created_by` (user id) so a curator-authored claim
+    -- can still record the operator who promoted/reviewed it.
+    created_by_kind TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -589,6 +593,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_jobs_retry_count(sqlite_path)
     migrate_add_files_parsed_text(sqlite_path)
     migrate_add_files_processing_progress(sqlite_path)
+    migrate_add_curator_claim_support(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
     # Wrapped in IntegrityError handler: existing databases may have duplicate
@@ -1122,9 +1127,10 @@ def migrate_add_wiki_tables(sqlite_path: str) -> None:
                 source_type TEXT NOT NULL CHECK (source_type IN (
                     'document','memory','chat_synthesis','manual','mixed')),
                 status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
-                    'active','contradicted','superseded','unverified','archived')),
+                    'active','contradicted','superseded','unverified','archived','needs_review')),
                 confidence REAL DEFAULT 0.0,
                 created_by INTEGER,
+                created_by_kind TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
@@ -1303,6 +1309,227 @@ def migrate_add_files_parsed_text(sqlite_path: str) -> None:
         if "parsed_text" not in existing_cols:
             conn.execute("ALTER TABLE files ADD COLUMN parsed_text TEXT")
         conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_curator_claim_support(sqlite_path: str) -> None:
+    """Migration (PR C): widen wiki_claims.status to include 'needs_review'
+    and add a TEXT ``created_by_kind`` column that records whether a claim
+    came from deterministic extraction or the optional LLM curator.
+
+    SQLite cannot ALTER a CHECK constraint, so we follow the rename-
+    recreate-copy pattern. Three subtleties matter:
+
+    1. CRITICAL — SQLite >= 3.26 with the default
+       ``legacy_alter_table=OFF`` rewrites the textual FK references in
+       *child* tables to follow ``ALTER TABLE … RENAME TO``. After we
+       drop ``wiki_claims_old``, those FKs would dangle silently:
+       ``wiki_claim_sources.claim_id`` and ``wiki_relations.claim_id``
+       would still point at ``wiki_claims_old`` and CASCADE would never
+       fire. We set ``legacy_alter_table=ON`` for the duration of the
+       swap so child FK references stay textually pointing at
+       ``wiki_claims``. Verified post-swap with
+       ``PRAGMA foreign_key_check`` and ``foreign_key_list``.
+
+    2. FTS triggers on wiki_claims are dropped before the rename and
+       recreated after the swap; the ``wiki_claims_fts`` virtual table
+       is repopulated via the standard ``('rebuild')`` command so search
+       keeps working.
+
+    3. Recovery — if a previous run died after the rename but before the
+       drop, ``wiki_claims_old`` will still exist on disk. The function
+       detects that at the top and restores by renaming back, then
+       re-runs cleanly. Without this an interrupted migration would
+       leave the DB unable to ever finish.
+
+    Idempotent — safe to run multiple times.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    # Force autocommit so PRAGMA statements take effect outside of an
+    # implicit transaction. This matches the behaviour we verified in
+    # the SQLite reproduction case at PR-C reviewer time.
+    conn.isolation_level = None
+    try:
+        # Recovery: if a previous run crashed mid-migration, the old
+        # table may still be present alongside (or instead of) the new
+        # one. Restore the canonical name before doing anything else.
+        old_present = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='wiki_claims_old'"
+        ).fetchone()
+        new_present = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='wiki_claims'"
+        ).fetchone()
+        if old_present and not new_present:
+            # Crashed after rename but before CREATE TABLE wiki_claims.
+            # Restore the original name and let the migration run again.
+            logger.warning(
+                "migrate_add_curator_claim_support: detected "
+                "wiki_claims_old without wiki_claims; restoring."
+            )
+            conn.execute("PRAGMA legacy_alter_table = ON")
+            conn.execute("ALTER TABLE wiki_claims_old RENAME TO wiki_claims")
+            conn.execute("PRAGMA legacy_alter_table = OFF")
+            new_present = True
+
+        # Skip if wiki_claims doesn't exist yet (fresh install path will
+        # create it via migrate_add_wiki_tables, which already includes
+        # the new schema after this function lands).
+        if not new_present:
+            return
+
+        existing_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()
+        }
+        if "created_by_kind" in existing_cols:
+            # Migration already applied; nothing to do — but if a stray
+            # wiki_claims_old somehow lingers (shouldn't, given the
+            # recovery branch above), drop it now.
+            if old_present:
+                conn.execute("DROP TABLE IF EXISTS wiki_claims_old")
+            return
+
+        # Third recovery branch (per PR-C critic Fix #1): both tables
+        # exist and wiki_claims is the OLD shape (no created_by_kind).
+        # This means a previous run completed the rename, started the
+        # new CREATE TABLE, but somehow ended up with both tables.
+        # The safe move is to drop the stale wiki_claims_old before the
+        # main path runs — otherwise the next ALTER ... RENAME TO
+        # wiki_claims_old below will fail with "table already exists".
+        if old_present:
+            logger.warning(
+                "migrate_add_curator_claim_support: detected stale "
+                "wiki_claims_old alongside pre-PR-C wiki_claims; "
+                "dropping the stale table before re-running migration."
+            )
+            conn.execute("DROP TABLE IF EXISTS wiki_claims_old")
+
+        # Snapshot row count for parity check.
+        before_count = conn.execute("SELECT COUNT(*) FROM wiki_claims").fetchone()[0]
+
+        # Detach FK validation for the duration of the swap and force
+        # legacy ALTER behaviour so child-table FK references stay
+        # textually pointing at the canonical table name.
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute("PRAGMA legacy_alter_table = ON")
+        try:
+            # Drop FTS triggers — they reference wiki_claims by name.
+            for trig in (
+                "wiki_claims_fts_insert",
+                "wiki_claims_fts_delete",
+                "wiki_claims_fts_update",
+            ):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+
+            # Move the old table out of the way.
+            conn.execute("ALTER TABLE wiki_claims RENAME TO wiki_claims_old")
+
+            # Create the new table with widened status CHECK + new column.
+            conn.execute(
+                """
+                CREATE TABLE wiki_claims (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL,
+                    page_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
+                    claim_text TEXT NOT NULL,
+                    claim_type TEXT NOT NULL DEFAULT 'fact',
+                    subject TEXT,
+                    predicate TEXT,
+                    object TEXT,
+                    source_type TEXT NOT NULL CHECK (source_type IN (
+                        'document','memory','chat_synthesis','manual','mixed')),
+                    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active','contradicted','superseded','unverified','archived','needs_review')),
+                    confidence REAL DEFAULT 0.0,
+                    created_by INTEGER,
+                    created_by_kind TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+            # Copy every column. created_by_kind defaults to NULL on
+            # backfill — interpreted by readers as "deterministic /
+            # unknown" (the curator path explicitly sets 'llm_curator').
+            conn.execute(
+                """
+                INSERT INTO wiki_claims (
+                    id, vault_id, page_id, claim_text, claim_type,
+                    subject, predicate, object, source_type, status,
+                    confidence, created_by, created_at, updated_at
+                )
+                SELECT id, vault_id, page_id, claim_text, claim_type,
+                       subject, predicate, object, source_type, status,
+                       confidence, created_by, created_at, updated_at
+                FROM wiki_claims_old
+                """
+            )
+
+            # Verify row count parity before dropping the old table.
+            after_count = conn.execute("SELECT COUNT(*) FROM wiki_claims").fetchone()[0]
+            if after_count != before_count:
+                # Bail out without dropping the old table so an operator
+                # can recover.
+                raise RuntimeError(
+                    f"migrate_add_curator_claim_support: row-count parity "
+                    f"failed ({before_count} -> {after_count}). "
+                    f"wiki_claims_old has been preserved."
+                )
+
+            conn.execute("DROP TABLE wiki_claims_old")
+
+            # Recreate the FTS triggers exactly as in the original schema.
+            conn.executescript(
+                """
+                CREATE TRIGGER IF NOT EXISTS wiki_claims_fts_insert
+                AFTER INSERT ON wiki_claims BEGIN
+                    INSERT INTO wiki_claims_fts(rowid, claim_text, subject, predicate, object)
+                    VALUES (new.id, new.claim_text, new.subject, new.predicate, new.object);
+                END;
+                CREATE TRIGGER IF NOT EXISTS wiki_claims_fts_delete
+                AFTER DELETE ON wiki_claims BEGIN
+                    INSERT INTO wiki_claims_fts(wiki_claims_fts, rowid, claim_text, subject, predicate, object)
+                    VALUES ('delete', old.id, old.claim_text, old.subject, old.predicate, old.object);
+                END;
+                CREATE TRIGGER IF NOT EXISTS wiki_claims_fts_update
+                AFTER UPDATE ON wiki_claims BEGIN
+                    INSERT INTO wiki_claims_fts(wiki_claims_fts, rowid, claim_text, subject, predicate, object)
+                    VALUES ('delete', old.id, old.claim_text, old.subject, old.predicate, old.object);
+                    INSERT INTO wiki_claims_fts(rowid, claim_text, subject, predicate, object)
+                    VALUES (new.id, new.claim_text, new.subject, new.predicate, new.object);
+                END;
+                """
+            )
+
+            # Repopulate the FTS virtual table from the new wiki_claims.
+            conn.execute(
+                "INSERT INTO wiki_claims_fts(wiki_claims_fts) VALUES('rebuild')"
+            )
+
+            # Re-create vault/page/status index (was on the original
+            # table; index is dropped by the rename pattern in some
+            # SQLite versions).
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_wiki_claims_vault_page_status "
+                "ON wiki_claims(vault_id, page_id, status)"
+            )
+        finally:
+            # Restore both PRAGMAs unconditionally; new connections
+            # otherwise inherit the legacy_alter_table=ON behaviour
+            # which is undesirable for normal traffic.
+            conn.execute("PRAGMA legacy_alter_table = OFF")
+            conn.execute("PRAGMA foreign_keys = ON")
+
+        # Validate FK integrity post-swap. Any violation here means we
+        # produced a broken DB; fail loudly so an operator notices.
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise RuntimeError(
+                f"migrate_add_curator_claim_support: foreign_key_check "
+                f"reported {len(violations)} violation(s) post-swap: "
+                f"{violations[:5]}"
+            )
     finally:
         conn.close()
 

--- a/backend/app/services/background_tasks.py
+++ b/backend/app/services/background_tasks.py
@@ -445,6 +445,7 @@ class BackgroundProcessor:
                 email_subject=task.email_subject,
                 email_sender=task.email_sender,
                 vault_id=task.vault_id,
+                file_id=task.file_id,
             )
             await self.queue.put(new_task)
         else:

--- a/backend/app/services/background_tasks.py
+++ b/backend/app/services/background_tasks.py
@@ -99,6 +99,12 @@ class TaskItem:
     email_subject: Optional[str] = None
     email_sender: Optional[str] = None
     vault_id: int = 1
+    # When set, the worker calls DocumentProcessor.process_existing_file
+    # against this row id instead of process_file. The async upload route
+    # populates this so the worker does NOT re-run duplicate detection or
+    # create a duplicate `files` row. Scan/email paths leave this None so
+    # legacy behavior (process_file) is preserved.
+    file_id: Optional[int] = None
 
 
 class BackgroundProcessor:
@@ -167,6 +173,13 @@ class BackgroundProcessor:
 
         Creates and starts the worker task that processes items from the queue.
         Safe to call multiple times - will not create duplicate workers.
+
+        Also runs a startup recovery sweep: under the async upload route the
+        request inserts a `files` row with status='pending' / phase='queued'
+        and only then enqueues. If the process crashes between the insert and
+        the worker pickup, the row would be stranded forever and the
+        in-flight duplicate check would 409 every retry of the same hash.
+        The sweep re-enqueues stranded rows so they are processed normally.
         """
         if self._running:
             logger.warning("Background processor is already running")
@@ -174,8 +187,78 @@ class BackgroundProcessor:
 
         self._running = True
         self.shutdown_event.clear()
+        await self._recover_stranded_pending_rows()
         self._worker_task = asyncio.create_task(self._worker_loop())
         logger.info("Background processor started")
+
+    async def _recover_stranded_pending_rows(self) -> None:
+        """Re-enqueue any `files` rows left at status='pending' from a prior process.
+
+        Detection: status='pending' AND phase='queued'. The async upload
+        route is the only writer of this exact combination; legacy scan/
+        email paths leave phase NULL. We deliberately do NOT touch rows
+        in any other phase (parsing/embedding/...) — those imply a worker
+        was actively in the middle of processing them and the operator
+        should investigate manually.
+
+        Best-effort: pool absence (e.g. tests) is silently skipped.
+        """
+        if self.processor is None or self.processor.pool is None:
+            return
+        try:
+            with self.processor.pool.connection() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT id, file_path, vault_id, source
+                    FROM files
+                    WHERE status = 'pending' AND phase = 'queued'
+                    """,
+                )
+                stranded = cursor.fetchall()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Stranded-row recovery sweep failed at SELECT: %s", e)
+            return
+
+        if not stranded:
+            return
+
+        logger.info(
+            "Recovering %d stranded async-upload row(s) left at status=pending/phase=queued",
+            len(stranded),
+        )
+        for row in stranded:
+            try:
+                row_id = row["id"] if hasattr(row, "keys") else row[0]
+                file_path = row["file_path"] if hasattr(row, "keys") else row[1]
+                vault_id = row["vault_id"] if hasattr(row, "keys") else row[2]
+                source = (
+                    (row["source"] if hasattr(row, "keys") else row[3]) or "upload"
+                )
+                # If the saved file no longer exists on disk, mark error
+                # rather than re-enqueueing — the worker would just fail.
+                from pathlib import Path as _Path
+
+                if not _Path(file_path).exists():
+                    try:
+                        with self.processor.pool.connection() as conn:
+                            conn.execute(
+                                "UPDATE files SET status='error', "
+                                "error_message='Upload file missing after process restart', "
+                                "phase='error' WHERE id = ?",
+                                (row_id,),
+                            )
+                            conn.commit()
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    continue
+                await self.enqueue(
+                    file_path=file_path,
+                    source=source,
+                    vault_id=int(vault_id),
+                    file_id=int(row_id),
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Failed to re-enqueue stranded row id=%s: %s", row, e)
 
     async def stop(self, timeout: float = 60.0) -> None:
         """
@@ -215,6 +298,7 @@ class BackgroundProcessor:
         email_subject: Optional[str] = None,
         email_sender: Optional[str] = None,
         vault_id: int = 1,
+        file_id: Optional[int] = None,
     ) -> None:
         """
         Add a file to the processing queue.
@@ -224,6 +308,11 @@ class BackgroundProcessor:
             source: Source of the file ('upload', 'scan', 'email')
             email_subject: Subject line for email-sourced files
             email_sender: Sender address for email-sourced files
+            vault_id: Vault to associate the file with
+            file_id: When provided, the worker calls
+                ``DocumentProcessor.process_existing_file`` against this row
+                instead of ``process_file``. Used by the async upload route
+                so duplicate detection and row insertion do not run twice.
 
         Note:
             If the processor is not running, the item will still be queued
@@ -240,9 +329,10 @@ class BackgroundProcessor:
             email_subject=email_subject,
             email_sender=email_sender,
             vault_id=vault_id,
+            file_id=file_id,
         )
         await self.queue.put(task)
-        logger.debug(f"Enqueued file: {file_path}")
+        logger.debug(f"Enqueued file: {file_path} (file_id={file_id})")
 
     async def _worker_loop(self) -> None:
         """
@@ -293,16 +383,28 @@ class BackgroundProcessor:
         On failure, requeues the task with incremented attempt count
         and exponential backoff delay if retries remain.
         """
-        logger.info(f"Processing file: {task.file_path} (attempt {task.attempt})")
+        logger.info(
+            f"Processing file: {task.file_path} (attempt {task.attempt}, file_id={task.file_id})"
+        )
 
         try:
-            await self.processor.process_file(
-                task.file_path,
-                source=task.source,
-                email_subject=task.email_subject,
-                email_sender=task.email_sender,
-                vault_id=task.vault_id,
-            )
+            if task.file_id is not None:
+                # Async upload path: the row already exists with status='pending'
+                # / phase='queued' and the duplicate check has already passed.
+                await self.processor.process_existing_file(
+                    file_id=task.file_id,
+                    file_path=task.file_path,
+                    vault_id=task.vault_id,
+                )
+            else:
+                # Legacy path (scan/email): processor handles dup check + insert.
+                await self.processor.process_file(
+                    task.file_path,
+                    source=task.source,
+                    email_subject=task.email_subject,
+                    email_sender=task.email_sender,
+                    vault_id=task.vault_id,
+                )
             logger.info(f"Successfully processed: {task.file_path}")
 
         except DocumentProcessingError as e:

--- a/backend/app/services/curator_ssrf.py
+++ b/backend/app/services/curator_ssrf.py
@@ -1,0 +1,112 @@
+"""SSRF guard for the optional LLM Wiki Curator endpoint.
+
+The curator URL is user-supplied and reaches outbound HTTP. We default-deny
+private/loopback targets so a misconfigured (or malicious) admin can't turn
+the backend into a port scanner of the internal network. Local-model setups
+are the intended use case, so an explicit ``ALLOW_LOCAL_CURATOR=1``
+environment opt-in re-enables RFC1918 / loopback / link-local destinations.
+
+Used by the curator-test route (PR B) and the curator client (PR C).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+
+class CuratorURLBlocked(Exception):
+    """Raised when a curator URL fails the SSRF guard.
+
+    The message is safe to surface in API responses — it never echoes
+    the resolved IP back to the client (only the offending hostname),
+    so we don't expose internal DNS data.
+    """
+
+
+_LOCAL_OPT_IN_ENV = "ALLOW_LOCAL_CURATOR"
+_LOCAL_OPT_IN_HINT = (
+    "Local curator endpoints require ALLOW_LOCAL_CURATOR=1."
+)
+
+
+def _local_opt_in_enabled() -> bool:
+    """Read ALLOW_LOCAL_CURATOR=1 at call time so tests can flip it."""
+    return os.environ.get(_LOCAL_OPT_IN_ENV, "").strip() in ("1", "true", "True")
+
+
+def _is_blocked_address(ip: str) -> bool:
+    """Return True for private / loopback / link-local / multicast IPs."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        # Unresolvable bytes — treat as blocked rather than fail-open.
+        return True
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    )
+
+
+def assert_curator_url_safe(url: str) -> None:
+    """Validate a curator URL and raise ``CuratorURLBlocked`` on rejection.
+
+    Rules:
+      - URL must be http:// or https://. Other schemes (file://, gopher://,
+        data://, javascript:) are denied unconditionally.
+      - URL may not include credentials (``user:pass@``).
+      - The hostname must resolve. If any resolved address is private /
+        loopback / link-local / multicast / reserved / unspecified, the
+        URL is denied unless ``ALLOW_LOCAL_CURATOR=1`` is set.
+      - Empty URL is treated as "curator disabled" — the caller is
+        responsible for not invoking this with an empty URL when curator
+        is enabled.
+
+    The caller is expected to also pass ``follow_redirects=False`` to its
+    HTTP client so a 30x to a private host can't bypass the guard.
+    """
+    if not url or not url.strip():
+        raise CuratorURLBlocked("Curator URL is empty.")
+
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in ("http", "https"):
+        raise CuratorURLBlocked(
+            f"Curator URL scheme must be http or https (got {parsed.scheme!r})."
+        )
+    if parsed.username or parsed.password:
+        raise CuratorURLBlocked(
+            "Curator URL must not embed credentials (user:pass@host)."
+        )
+    host = parsed.hostname
+    if not host:
+        raise CuratorURLBlocked("Curator URL has no hostname.")
+
+    # Hostname literal IPs short-circuit DNS.
+    try:
+        ipaddress.ip_address(host)
+        candidates = [host]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, parsed.port or 80, type=socket.SOCK_STREAM)
+        except OSError as e:
+            raise CuratorURLBlocked(
+                f"Curator URL host {host!r} did not resolve: {e}"
+            ) from e
+        candidates = sorted({info[4][0] for info in infos})
+        if not candidates:
+            raise CuratorURLBlocked(f"Curator URL host {host!r} resolved to nothing.")
+
+    blocked = [ip for ip in candidates if _is_blocked_address(ip)]
+    if blocked and not _local_opt_in_enabled():
+        # Don't echo the resolved IPs back — saying "private/loopback"
+        # is enough for the operator and avoids leaking internal DNS.
+        raise CuratorURLBlocked(
+            f"Curator URL host {host!r} resolves to a private / loopback / "
+            f"link-local address. {_LOCAL_OPT_IN_HINT}"
+        )

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -23,6 +23,16 @@ from ..utils.retry import with_retry
 from .chunk_enrichment import ChunkEnrichmentService
 from .chunking import ProcessedChunk, SemanticChunker, compute_parent_windows
 from .contextual_chunking import ContextualChunker
+from .document_progress import (
+    PHASE_CHUNKING,
+    PHASE_EMBEDDING,
+    PHASE_EXTRACTING_TEXT,
+    PHASE_PARSING,
+    PHASE_WRITING_INDEX,
+    clear_progress,
+    set_phase,
+    set_wiki_pending,
+)
 from .embeddings import EmbeddingService
 from .llm_client import LLMClient
 from .schema_parser import SchemaParser
@@ -611,6 +621,44 @@ class DocumentProcessor:
     @with_retry(
         max_attempts=3, retry_exceptions=(sqlite3.Error,), raise_last_exception=True
     )
+    def _check_duplicate_in_flight(
+        self, file_hash: str, conn: sqlite3.Connection, vault_id: int
+    ) -> Optional[sqlite3.Row]:
+        """
+        Check for any existing file with this hash in any non-terminal state.
+
+        Used by the async upload route to collapse two concurrent uploads of the
+        same content to a single ingestion. ``_check_duplicate`` only matches
+        ``status='indexed'`` (its legacy semantic for synchronous callers); the
+        async route inserts rows with ``status='pending'`` first, so it needs to
+        reject duplicates at every stage of the pipeline, not just indexed.
+
+        Args:
+            file_hash: The hash of the file to check.
+            conn: Database connection.
+            vault_id: Vault to scope the check to.
+
+        Returns:
+            The existing row when one of {pending, processing, indexed} matches,
+            else None. Rows in 'error' state are intentionally NOT matched —
+            re-uploading a previously-failed file should be allowed.
+        """
+        cursor = conn.execute(
+            """
+            SELECT * FROM files
+            WHERE file_hash = ?
+              AND vault_id = ?
+              AND status IN ('pending', 'processing', 'indexed')
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (file_hash, vault_id),
+        )
+        return cursor.fetchone()
+
+    @with_retry(
+        max_attempts=3, retry_exceptions=(sqlite3.Error,), raise_last_exception=True
+    )
     def _insert_or_get_file_record(
         self,
         file_path: str,
@@ -1007,6 +1055,15 @@ class DocumentProcessor:
             # Release connection before long-running operations
             self.pool.release_connection(conn)
 
+        # Mark processing started + initial phase. Best-effort; ignored on failure.
+        set_phase(
+            self.pool,
+            file_id,
+            phase=PHASE_PARSING,
+            message="Parsing document",
+            mark_processing_started=True,
+        )
+
         # Phase 2: Long operations (NO connection held!)
         try:
             # Process the file based on type
@@ -1014,12 +1071,25 @@ class DocumentProcessor:
                 chunks = await self._process_schema_file(file_path)
                 document_text = ""
             elif self._is_spreadsheet_file(file_path):
+                set_phase(
+                    self.pool,
+                    file_id,
+                    phase=PHASE_PARSING,
+                    message="Parsing spreadsheet (large spreadsheets can take several minutes)",
+                )
                 chunks = await self._process_spreadsheet_file(file_path)
                 document_text = " ".join(c.text for c in chunks)
             else:
                 chunks, document_text = await self._process_document_file(
                     file_path, file_id
                 )
+
+            set_phase(
+                self.pool,
+                file_id,
+                phase=PHASE_EXTRACTING_TEXT,
+                message="Text extracted",
+            )
 
             # Define source_filename here so it is available to both contextual
             # chunking and chunk enrichment below, regardless of which branches run.
@@ -1082,6 +1152,17 @@ class DocumentProcessor:
                     "The file may be empty, encrypted, or in an unsupported format."
                 )
 
+            set_phase(
+                self.pool,
+                file_id,
+                phase=PHASE_CHUNKING,
+                message=f"Prepared {len(chunks)} chunks",
+                total=len(chunks),
+                processed=len(chunks),
+                unit="chunks",
+                percent=100.0,
+            )
+
             # Chunk enrichment: generate auxiliary metadata (summary, questions, entities)
             enrichment_service = self._get_chunk_enrichment_service()
             if enrichment_service is not None:
@@ -1129,9 +1210,33 @@ class DocumentProcessor:
                     # Validate chunk sizes before embedding
                     self._validate_chunk_sizes(texts, source_filename)
 
+                    # Phase: embedding. embed_batch is opaque per-batch internally,
+                    # so we report total/processed at start and again on completion
+                    # rather than streaming sub-batch progress (avoids reaching into
+                    # the embedding service's batching boundary).
+                    set_phase(
+                        self.pool,
+                        file_id,
+                        phase=PHASE_EMBEDDING,
+                        message=f"Embedding {len(chunks)} chunks",
+                        total=len(chunks),
+                        processed=0,
+                        unit="chunks",
+                        percent=0.0,
+                    )
                     # Generate dense embeddings (Harrier dense-only)
                     embeddings = await self.embedding_service.embed_batch(texts)
                     sparse_embeddings = [None] * len(chunks)
+                    set_phase(
+                        self.pool,
+                        file_id,
+                        phase=PHASE_EMBEDDING,
+                        message="Embeddings ready",
+                        total=len(chunks),
+                        processed=len(chunks),
+                        unit="chunks",
+                        percent=100.0,
+                    )
 
                     # Validate embeddings count matches chunks count
                     if len(embeddings) != len(chunks):
@@ -1224,6 +1329,18 @@ class DocumentProcessor:
                                 record["sparse_embedding"] = None
                         records.append(record)
 
+                    # Phase: writing vector index
+                    set_phase(
+                        self.pool,
+                        file_id,
+                        phase=PHASE_WRITING_INDEX,
+                        message="Writing vector index",
+                        total=len(records),
+                        processed=0,
+                        unit="chunks",
+                        percent=0.0,
+                    )
+
                     # Initialize vector table with embedding dimension and add chunks
                     embedding_dim = len(embeddings[0])
                     await self.vector_store.init_table(embedding_dim)
@@ -1256,6 +1373,15 @@ class DocumentProcessor:
                 conn.commit()
             finally:
                 self.pool.release_connection(conn)
+            # Surface error in the phase fields so the frontend can render it
+            # without waiting for a status-route round-trip.
+            set_phase(
+                self.pool,
+                file_id,
+                phase="error",
+                message=str(e)[:500],
+                percent=None,
+            )
             raise
 
         # Phase 3: Final DB operations - update status to indexed
@@ -1281,15 +1407,406 @@ class DocumentProcessor:
                         (_full_text, file_id),
                     )
                     conn.commit()
+                # Mark wiki_pending=1 synchronously BEFORE the wiki job is created
+                # so the status route can report wiki_status="pending" during the
+                # brief window before the wiki_compile_jobs row exists.
+                set_wiki_pending(self.pool, file_id, True)
                 _WikiStore(conn).create_job(
                     vault_id=vault_id,
                     trigger_type="ingest",
                     trigger_id=f"file:{file_id}",
                     input_json={"file_id": file_id, "vault_id": vault_id},
                 )
+                # Job row now exists; the status route will derive wiki_status
+                # from it directly. Clear the flag so the row doesn't carry a
+                # permanently-stale wiki_pending=1 marker.
+                set_wiki_pending(self.pool, file_id, False)
             finally:
                 self.pool.release_connection(conn)
         except Exception as _wiki_exc:
             logger.warning("Failed to enqueue wiki ingest job for file_id=%d: %s", file_id, _wiki_exc)
+            # If wiki enqueue failed, don't leave wiki_pending=1 hanging.
+            set_wiki_pending(self.pool, file_id, False)
+
+        # Clear transient progress fields and pin phase=indexed so polls show
+        # a clean "ready" snapshot rather than stale embedding counters.
+        clear_progress(self.pool, file_id)
+
+        return ProcessedDocument(file_id=file_id, chunks=chunks)
+
+    async def process_existing_file(
+        self,
+        file_id: int,
+        file_path: str,
+        vault_id: int,
+    ) -> ProcessedDocument:
+        """Process a file whose `files` row already exists.
+
+        Used by the async upload path: the route inserts the `files` row
+        with status='pending' / phase='queued' and a duplicate-hash check
+        already passed. The worker then calls this method instead of
+        ``process_file`` to avoid re-running the duplicate check or
+        creating a second row.
+
+        Failure semantics match ``process_file``: status -> 'error',
+        phase -> 'error', error_message populated. Wiki ingest job is
+        enqueued at the end on success (same as ``process_file``).
+        """
+        path = Path(file_path)
+        if not path.exists():
+            # Surface as error on the existing row so the frontend can render it.
+            conn = self.pool.get_connection()
+            try:
+                self._update_status(
+                    file_id,
+                    "error",
+                    conn,
+                    error_message=f"File not found: {file_path}",
+                )
+                conn.commit()
+            finally:
+                self.pool.release_connection(conn)
+            set_phase(
+                self.pool,
+                file_id,
+                phase="error",
+                message=f"File not found: {file_path}",
+            )
+            raise FileNotFoundError(f"File not found: {file_path}")
+        if not path.is_file():
+            conn = self.pool.get_connection()
+            try:
+                self._update_status(
+                    file_id,
+                    "error",
+                    conn,
+                    error_message=f"Path is not a file: {file_path}",
+                )
+                conn.commit()
+            finally:
+                self.pool.release_connection(conn)
+            set_phase(
+                self.pool,
+                file_id,
+                phase="error",
+                message=f"Path is not a file: {file_path}",
+            )
+            raise FileNotFoundError(f"Path is not a file: {file_path}")
+
+        # Transition status: pending -> processing. Duplicate check intentionally
+        # skipped — the route already ran it before inserting the row.
+        conn = self.pool.get_connection()
+        try:
+            self._update_status(file_id, "processing", conn)
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        set_phase(
+            self.pool,
+            file_id,
+            phase=PHASE_PARSING,
+            message="Parsing document",
+            mark_processing_started=True,
+        )
+
+        # The remainder mirrors process_file Phase 2/3 exactly so behavior is
+        # identical to the synchronous path. We re-derive file_hash here for
+        # the safe-reupload chunk-id prefix logic; this is cheap I/O.
+        file_hash = compute_file_hash(file_path)
+
+        try:
+            if self._is_schema_file(file_path):
+                chunks = await self._process_schema_file(file_path)
+                document_text = ""
+            elif self._is_spreadsheet_file(file_path):
+                set_phase(
+                    self.pool,
+                    file_id,
+                    phase=PHASE_PARSING,
+                    message="Parsing spreadsheet (large spreadsheets can take several minutes)",
+                )
+                chunks = await self._process_spreadsheet_file(file_path)
+                document_text = " ".join(c.text for c in chunks)
+            else:
+                chunks, document_text = await self._process_document_file(
+                    file_path, file_id
+                )
+
+            set_phase(
+                self.pool,
+                file_id,
+                phase=PHASE_EXTRACTING_TEXT,
+                message="Text extracted",
+            )
+
+            source_filename = Path(file_path).name
+
+            if settings.contextual_chunking_enabled and chunks and document_text:
+                chunker = self._get_contextual_chunker()
+                if chunker is not None:
+                    try:
+                        await chunker.contextualize_chunks(
+                            document_text=document_text,
+                            chunks=chunks,
+                            source_filename=source_filename,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Contextual chunking failed for %s: %s",
+                            source_filename,
+                            str(e),
+                        )
+
+            if document_text and chunks:
+                try:
+                    compute_parent_windows(
+                        chunks,
+                        document_text,
+                        window_chars=settings.parent_window_chars,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "compute_parent_windows failed for %s: %s",
+                        Path(file_path).name,
+                        e,
+                    )
+
+            if not chunks:
+                raise DocumentProcessingError(
+                    "No extractable content found in document. "
+                    "The file may be empty, encrypted, or in an unsupported format."
+                )
+
+            set_phase(
+                self.pool,
+                file_id,
+                phase=PHASE_CHUNKING,
+                message=f"Prepared {len(chunks)} chunks",
+                total=len(chunks),
+                processed=len(chunks),
+                unit="chunks",
+                percent=100.0,
+            )
+
+            enrichment_service = self._get_chunk_enrichment_service()
+            if enrichment_service is not None:
+                try:
+                    chunk_dicts = [
+                        {
+                            "chunk_uid": self._build_chunk_uid(file_id, c),
+                            "text": c.text,
+                            "metadata": c.metadata,
+                        }
+                        for c in chunks
+                    ]
+                    enrichments = await enrichment_service.enrich_chunks(
+                        chunk_dicts, document_title=source_filename
+                    )
+                    for chunk, enrichment in zip(chunks, enrichments):
+                        chunk.metadata["enrichment"] = enrichment.to_dict()
+                except Exception as e:
+                    logger.warning(
+                        "Chunk enrichment failed for %s: %s",
+                        source_filename,
+                        str(e),
+                    )
+
+            if self.embedding_service is not None and self.vector_store is not None:
+                if chunks:
+                    chunks = [c for c in chunks if c.text and c.text.strip()]
+                    if not chunks:
+                        raise DocumentProcessingError(
+                            "All chunks were empty after filtering. "
+                            "The document may contain only whitespace or unsupported content."
+                        )
+
+                    texts = [c.text for c in chunks]
+                    self._validate_chunk_sizes(texts, source_filename)
+
+                    set_phase(
+                        self.pool,
+                        file_id,
+                        phase=PHASE_EMBEDDING,
+                        message=f"Embedding {len(chunks)} chunks",
+                        total=len(chunks),
+                        processed=0,
+                        unit="chunks",
+                        percent=0.0,
+                    )
+                    embeddings = await self.embedding_service.embed_batch(texts)
+                    sparse_embeddings = [None] * len(chunks)
+                    set_phase(
+                        self.pool,
+                        file_id,
+                        phase=PHASE_EMBEDDING,
+                        message="Embeddings ready",
+                        total=len(chunks),
+                        processed=len(chunks),
+                        unit="chunks",
+                        percent=100.0,
+                    )
+
+                    if len(embeddings) != len(chunks):
+                        raise DocumentProcessingError(
+                            f"Embedding count mismatch: expected {len(chunks)}, got {len(embeddings)}"
+                        )
+                    expected_dim = len(embeddings[0]) if embeddings[0] else 0
+                    for i, emb in enumerate(embeddings):
+                        if not emb or not isinstance(emb, list):
+                            raise DocumentProcessingError(
+                                f"Embedding {i} is empty or not a list"
+                            )
+                        if len(emb) != expected_dim:
+                            raise DocumentProcessingError(
+                                f"Embedding {i} has dimension {len(emb)}, expected {expected_dim}"
+                            )
+
+                    records = []
+                    for chunk, embedding, sparse_emb in zip(
+                        chunks, embeddings, sparse_embeddings
+                    ):
+                        chunk_scale = chunk.metadata.get("chunk_scale", "default")
+                        chunk_uid = self._build_chunk_uid(file_id, chunk)
+                        chunk_metadata = chunk.metadata.copy()
+                        chunk_metadata["chunk_uid"] = chunk_uid
+                        chunk_metadata["file_id"] = str(file_id)
+                        chunk_metadata["chunk_count"] = chunk.metadata.get(
+                            "total_chunks", len(chunks)
+                        )
+                        chunk_metadata["chunk_scale"] = chunk_scale
+                        if hasattr(chunk, "raw_text") and chunk.raw_text:
+                            chunk_metadata["raw_text"] = chunk.raw_text
+
+                        if chunk.parent_window_start is not None:
+                            chunk_metadata["parent_window_start"] = chunk.parent_window_start
+                        if chunk.parent_window_end is not None:
+                            chunk_metadata["parent_window_end"] = chunk.parent_window_end
+                        if chunk.chunk_position is not None:
+                            chunk_metadata["chunk_position"] = chunk.chunk_position
+                        if (
+                            chunk.parent_window_start is not None
+                            and chunk.parent_window_end is not None
+                            and document_text
+                        ):
+                            chunk_metadata["parent_window_text"] = document_text[
+                                chunk.parent_window_start : chunk.parent_window_end
+                            ]
+
+                        if settings.reupload_safe_order:
+                            record_id = f"{file_id}_{file_hash[:8]}_{chunk_scale}_{chunk.chunk_index}"
+                        else:
+                            record_id = chunk_uid
+
+                        record = {
+                            "id": record_id,
+                            "text": chunk.text,
+                            "file_id": str(file_id),
+                            "chunk_index": chunk.chunk_index,
+                            "vault_id": str(vault_id),
+                            "chunk_scale": chunk_scale,
+                            "parent_doc_id": str(file_id),
+                            "parent_window_start": chunk.parent_window_start,
+                            "parent_window_end": chunk.parent_window_end,
+                            "chunk_position": chunk.chunk_position,
+                            "metadata": json.dumps(chunk_metadata),
+                            "embedding": embedding,
+                        }
+                        if sparse_emb is not None:
+                            try:
+                                record["sparse_embedding"] = json.dumps(sparse_emb)
+                            except (TypeError, ValueError) as e:
+                                logger.warning(
+                                    f"Failed to serialize sparse embedding: {e}"
+                                )
+                                record["sparse_embedding"] = None
+                        records.append(record)
+
+                    set_phase(
+                        self.pool,
+                        file_id,
+                        phase=PHASE_WRITING_INDEX,
+                        message="Writing vector index",
+                        total=len(records),
+                        processed=0,
+                        unit="chunks",
+                        percent=0.0,
+                    )
+
+                    embedding_dim = len(embeddings[0])
+                    await self.vector_store.init_table(embedding_dim)
+
+                    if settings.reupload_safe_order:
+                        await self.vector_store.add_chunks(records)
+                        deleted = await self.vector_store.delete_old_generation_by_file(
+                            str(file_id), file_hash[:8]
+                        )
+                        if deleted > 0:
+                            logger.info(
+                                "Safe re-upload: deleted %d old-generation chunks for file_id=%s",
+                                deleted,
+                                file_id,
+                            )
+                    else:
+                        await self.vector_store.delete_by_file(str(file_id))
+                        await self.vector_store.add_chunks(records)
+        except Exception as e:
+            conn = self.pool.get_connection()
+            try:
+                self._update_status(file_id, "error", conn, error_message=str(e))
+                conn.commit()
+            finally:
+                self.pool.release_connection(conn)
+            set_phase(
+                self.pool,
+                file_id,
+                phase="error",
+                message=str(e)[:500],
+                percent=None,
+            )
+            raise
+
+        # Mark indexed
+        conn = self.pool.get_connection()
+        try:
+            self._update_status(file_id, "indexed", conn, chunk_count=len(chunks))
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        # Save parsed text + enqueue wiki ingest job (best-effort, non-blocking).
+        try:
+            from app.services.wiki_store import WikiStore as _WikiStore
+
+            _full_text = document_text or ""
+            conn = self.pool.get_connection()
+            try:
+                if _full_text:
+                    conn.execute(
+                        "UPDATE files SET parsed_text = ? WHERE id = ?",
+                        (_full_text, file_id),
+                    )
+                    conn.commit()
+                set_wiki_pending(self.pool, file_id, True)
+                _WikiStore(conn).create_job(
+                    vault_id=vault_id,
+                    trigger_type="ingest",
+                    trigger_id=f"file:{file_id}",
+                    input_json={"file_id": file_id, "vault_id": vault_id},
+                )
+                # Clear flag now that the job row exists — status route
+                # derives wiki_status from the job row directly.
+                set_wiki_pending(self.pool, file_id, False)
+            finally:
+                self.pool.release_connection(conn)
+        except Exception as _wiki_exc:
+            logger.warning(
+                "Failed to enqueue wiki ingest job for file_id=%d: %s",
+                file_id,
+                _wiki_exc,
+            )
+            set_wiki_pending(self.pool, file_id, False)
+
+        clear_progress(self.pool, file_id)
 
         return ProcessedDocument(file_id=file_id, chunks=chunks)

--- a/backend/app/services/document_progress.py
+++ b/backend/app/services/document_progress.py
@@ -1,0 +1,179 @@
+"""Phase-aware processing-progress helpers for the `files` table.
+
+Status (`files.status`) stays in the canonical 4-value enum
+('pending','processing','indexed','error'). All async lifecycle detail
+(queued / parsing / chunking / embedding / writing-index / wiki) lives in
+the new `phase` column and friends. Frontend polls
+`GET /documents/{file_id}/status` and uses these fields to render
+phase-aware progress without ever conflating upload completion with
+indexing completion.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Any, Optional
+
+from app.models.database import SQLiteConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+# Canonical phase strings emitted by DocumentProcessor. The frontend maps
+# these to user-facing labels; preserving the wire values means backend
+# changes don't silently desync UX.
+PHASE_QUEUED = "queued"
+PHASE_PARSING = "parsing"
+PHASE_EXTRACTING_TEXT = "extracting_text"
+PHASE_CHUNKING = "chunking"
+PHASE_EMBEDDING = "embedding"
+PHASE_WRITING_INDEX = "writing_index"
+PHASE_INDEXED = "indexed"
+PHASE_ERROR = "error"
+
+ALL_PHASES = frozenset(
+    {
+        PHASE_QUEUED,
+        PHASE_PARSING,
+        PHASE_EXTRACTING_TEXT,
+        PHASE_CHUNKING,
+        PHASE_EMBEDDING,
+        PHASE_WRITING_INDEX,
+        PHASE_INDEXED,
+        PHASE_ERROR,
+    }
+)
+
+
+def set_phase(
+    pool: SQLiteConnectionPool,
+    file_id: int,
+    *,
+    phase: Optional[str] = None,
+    message: Optional[str] = None,
+    percent: Optional[float] = None,
+    processed: Optional[int] = None,
+    total: Optional[int] = None,
+    unit: Optional[str] = None,
+    mark_processing_started: bool = False,
+) -> None:
+    """Atomically update phase-aware progress fields on a `files` row.
+
+    Acquires and releases a pool connection per call so long-running phases
+    (embedding loops) don't pin pool capacity. Writes are best-effort: a
+    progress-update failure must never abort indexing.
+
+    Only fields explicitly provided are written; unset fields preserve
+    their prior value. Passing ``phase`` updates ``phase_started_at`` only
+    when the phase actually transitions (read-modify-write inside a single
+    connection so two callers can't race the timestamp).
+    """
+    if phase is not None and phase not in ALL_PHASES:
+        logger.warning("set_phase: unknown phase %r — writing anyway", phase)
+
+    sets: list[str] = []
+    params: list[Any] = []
+
+    try:
+        with pool.connection() as conn:
+            current_phase: Optional[str] = None
+            if phase is not None:
+                row = conn.execute(
+                    "SELECT phase FROM files WHERE id = ?", (file_id,)
+                ).fetchone()
+                if row is not None:
+                    # sqlite3.Row supports indexing by name; tolerate tuple too
+                    try:
+                        current_phase = row["phase"]
+                    except (TypeError, IndexError):
+                        current_phase = row[0] if len(row) else None
+                sets.append("phase = ?")
+                params.append(phase)
+                if phase != current_phase:
+                    sets.append("phase_started_at = CURRENT_TIMESTAMP")
+            if message is not None:
+                sets.append("phase_message = ?")
+                params.append(message)
+            if percent is not None:
+                # Clamp; an out-of-range percent shouldn't poison the row
+                clamped = max(0.0, min(100.0, float(percent)))
+                sets.append("progress_percent = ?")
+                params.append(clamped)
+            if processed is not None:
+                sets.append("processed_units = ?")
+                params.append(int(processed))
+            if total is not None:
+                sets.append("total_units = ?")
+                params.append(int(total))
+            if unit is not None:
+                sets.append("unit_label = ?")
+                params.append(unit)
+            if mark_processing_started:
+                # Set processing_started_at only on first transition to processing.
+                sets.append(
+                    "processing_started_at = COALESCE(processing_started_at, CURRENT_TIMESTAMP)"
+                )
+
+            if not sets:
+                return
+
+            params.append(file_id)
+            conn.execute(
+                f"UPDATE files SET {', '.join(sets)} WHERE id = ?",
+                params,
+            )
+            conn.commit()
+    except sqlite3.Error as e:  # pragma: no cover - defensive
+        logger.warning("set_phase failed for file_id=%s: %s", file_id, e)
+
+
+def clear_progress(pool: SQLiteConnectionPool, file_id: int) -> None:
+    """Reset transient progress fields on terminal success.
+
+    Called after a successful indexing run so the next poll snapshot shows
+    a clean ``indexed`` state without stale processed/total counters.
+    `phase` is left at ``indexed`` so the frontend can distinguish "ready"
+    from "still mid-pipeline".
+    """
+    try:
+        with pool.connection() as conn:
+            conn.execute(
+                """
+                UPDATE files
+                SET phase = ?,
+                    phase_message = NULL,
+                    progress_percent = NULL,
+                    processed_units = NULL,
+                    total_units = NULL,
+                    unit_label = NULL,
+                    phase_started_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (PHASE_INDEXED, file_id),
+            )
+            conn.commit()
+    except sqlite3.Error as e:  # pragma: no cover - defensive
+        logger.warning("clear_progress failed for file_id=%s: %s", file_id, e)
+
+
+def set_wiki_pending(
+    pool: SQLiteConnectionPool, file_id: int, pending: bool
+) -> None:
+    """Set or clear the wiki_pending flag synchronously.
+
+    Set TRUE when DocumentProcessor is about to enqueue the wiki ingest job
+    so the status route can report ``wiki_status="pending"`` for the brief
+    window before any wiki_compile_jobs row exists. Cleared once the job
+    row appears (route-side derivation also handles the cleared state by
+    falling back to the latest jobs row).
+    """
+    try:
+        with pool.connection() as conn:
+            conn.execute(
+                "UPDATE files SET wiki_pending = ? WHERE id = ?",
+                (1 if pending else 0, file_id),
+            )
+            conn.commit()
+    except sqlite3.Error as e:  # pragma: no cover - defensive
+        logger.warning("set_wiki_pending failed for file_id=%s: %s", file_id, e)

--- a/backend/app/services/wiki_compiler.py
+++ b/backend/app/services/wiki_compiler.py
@@ -1,10 +1,14 @@
 """
 WikiCompiler: Deterministic entity/acronym/relation extraction and memory promotion.
 
-All extraction is regex-based. No LLM required.
-Pronoun resolution: maintains current_org_context from most recently seen acronym/org entity.
+All deterministic extraction is regex-based. No LLM required for the
+trust boundary. The optional LLM Wiki Curator (PR C) runs *after* the
+deterministic pass and can only widen the candidate set — it can never
+overrule a deterministic claim, and its output only becomes an active
+wiki claim when its source_quote verifies against the chunk it cites.
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -13,6 +17,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from app.config import settings as _app_settings
+from app.services.wiki_curator import (
+    CuratorChunk,
+    WikiCurator,
+    deterministic_dedupe_key,
+)
+from app.services.wiki_curator_client import CuratorClient
 from app.services.wiki_store import WikiStore, normalize_slug
 
 # Approximate bytes per text chunk for deterministic chunk-uid generation.
@@ -431,12 +442,27 @@ class WikiCompiler:
         # Reload page with all relations
         page = self._store.get_page(page_id)
 
-        return {
+        # PR C: optional curator on the manual / promote_memory path.
+        # Gated by wiki_llm_curator_run_on_manual.
+        curator_summary = self._maybe_run_curator(
+            vault_id=vault_id,
+            file_id=None,
+            text=content,
+            trigger="manual",
+            deterministic_extraction=extraction,
+            page_id=page_id,
+            existing_entities=entities_created,
+        )
+
+        result_dict: dict = {
             "page": page,
             "claims": claims_created,
             "entities": entities_created,
             "relations": relations_created,
         }
+        if curator_summary is not None:
+            result_dict["curator"] = curator_summary
+        return result_dict
 
     def compile_query_job(self, vault_id: int, input_json: dict) -> dict:
         """
@@ -692,12 +718,30 @@ class WikiCompiler:
             )
             relations_created.append(relation)
 
-        return {
+        # PR C: optional curator on query path. Default-disabled
+        # (wiki_llm_curator_run_on_query=False) to protect chat latency,
+        # but operators who flip it on get the same provenance gating
+        # as the ingest path. file_id is None here — curator chunks
+        # therefore use a 'text_N' chunk_id prefix.
+        curator_summary = self._maybe_run_curator(
+            vault_id=vault_id,
+            file_id=None,
+            text=_clean_answer,
+            trigger="query",
+            deterministic_extraction=extraction,
+            page_id=None,
+            existing_entities=entities_created,
+        )
+
+        result_dict: dict = {
             "page": None,
             "claims": [{"id": c.id, "status": c.status} for c in claims_created],
             "entities": [{"id": e.id, "name": e.canonical_name} for e in entities_created],
             "relations_count": len(relations_created),
         }
+        if curator_summary is not None:
+            result_dict["curator"] = curator_summary
+        return result_dict
 
     def compile_ingest_job(self, vault_id: int, input_json: dict) -> dict:
         """
@@ -881,10 +925,257 @@ class WikiCompiler:
             )
             relations_count += 1
 
+        # ----------- Optional LLM Wiki Curator (PR C) -----------
+        # Gated by settings.wiki_llm_curator_enabled AND the per-trigger
+        # flag. Curator output never replaces deterministic output; it
+        # can only add candidates that pass quote+chunk verification.
+        # Errors are recorded into the result, never raised.
+        curator_summary = self._maybe_run_curator(
+            vault_id=vault_id,
+            file_id=file_id,
+            text=text,
+            trigger="ingest",
+            deterministic_extraction=extraction,
+            page_id=page_id,
+            existing_entities=entities_created,
+        )
+
         page = self._store.get_page(page_id)
-        return {
+        result_dict: dict = {
             "page": {"id": page_id, "slug": slug} if page else None,
             "claims": claims_created,
             "entities": [{"id": e.id, "name": e.canonical_name} for e in entities_created],
             "relations_count": relations_count,
         }
+        if curator_summary is not None:
+            result_dict["curator"] = curator_summary
+        return result_dict
+
+    # ------------------------------------------------------------------
+    # Optional LLM Wiki Curator integration (PR C)
+    # ------------------------------------------------------------------
+
+    def _maybe_run_curator(
+        self,
+        *,
+        vault_id: int,
+        file_id: Optional[int],
+        text: str,
+        trigger: str,  # 'ingest' | 'query' | 'manual'
+        deterministic_extraction,
+        page_id: Optional[int],
+        existing_entities: list,
+    ) -> Optional[dict]:
+        """Run the curator if enabled for this trigger; return summary
+        dict for ``result_json.curator`` or None when curator is off.
+
+        All exceptions are caught and recorded in the returned summary;
+        a curator failure must NEVER fail the underlying compile job.
+        """
+        if not getattr(_app_settings, "wiki_llm_curator_enabled", False):
+            return None
+        flag_for_trigger = {
+            "ingest": "wiki_llm_curator_run_on_ingest",
+            "query": "wiki_llm_curator_run_on_query",
+            "manual": "wiki_llm_curator_run_on_manual",
+        }.get(trigger)
+        if not flag_for_trigger or not getattr(
+            _app_settings, flag_for_trigger, False
+        ):
+            return None
+        url = getattr(_app_settings, "wiki_llm_curator_url", "") or ""
+        model = getattr(_app_settings, "wiki_llm_curator_model", "") or ""
+        if not url.strip() or not model.strip():
+            return {
+                "errors": ["disabled: missing url or model"],
+                "accepted": 0,
+                "rejected": 0,
+                "lint": 0,
+                "calls": 0,
+                "input_chars": 0,
+            }
+        if not text:
+            return None
+
+        # Build chunks the same way the deterministic pass infers them.
+        chunks = self._build_curator_chunks(text=text, file_id=file_id)
+        if not chunks:
+            return None
+
+        # Seed dedupe with deterministic role_claims so the curator
+        # can't re-emit the same fact as a duplicate "needs_review" row.
+        dedupe_seed: set[str] = set()
+        for rc in deterministic_extraction.role_claims:
+            dedupe_seed.add(
+                deterministic_dedupe_key(
+                    rc.get("subject", ""),
+                    rc.get("predicate", ""),
+                    rc.get("object_person", ""),
+                    rc.get("sentence", ""),
+                )
+            )
+
+        deterministic_summary = {
+            "acronyms": [
+                {"acronym": a.get("acronym"), "full_name": a.get("full_name")}
+                for a in deterministic_extraction.acronyms
+            ],
+            "role_claims": [
+                {
+                    "subject": rc.get("subject"),
+                    "predicate": rc.get("predicate"),
+                    "object": rc.get("object_person"),
+                }
+                for rc in deterministic_extraction.role_claims
+            ],
+        }
+        existing_brief = [e.canonical_name for e in existing_entities[:50]]
+
+        client = CuratorClient(
+            base_url=url,
+            model=model,
+            timeout=float(getattr(_app_settings, "wiki_llm_curator_timeout_sec", 120.0)),
+            max_tokens=int(getattr(_app_settings, "wiki_llm_curator_max_output_tokens", 2048)),
+            temperature=float(getattr(_app_settings, "wiki_llm_curator_temperature", 0.0)),
+        )
+        curator = WikiCurator(client=client, store=self._store)
+
+        try:
+            # The compiler is sync, but CuratorClient.propose is async.
+            # Use a fresh event loop only when there isn't one already
+            # running (background processor calls us from inside one).
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop is None:
+                cur_result = asyncio.run(
+                    curator.curate(
+                        vault_id=vault_id,
+                        file_id=file_id,
+                        chunks=chunks,
+                        deterministic_summary=deterministic_summary,
+                        existing_entities_brief=existing_brief,
+                        deterministic_dedupe_keys=dedupe_seed,
+                    )
+                )
+            else:
+                # Schedule on the running loop and block until done.
+                # We can't do `loop.run_until_complete` from inside the
+                # loop, so spin a separate thread.
+                import concurrent.futures
+
+                def _runner():
+                    return asyncio.run(
+                        curator.curate(
+                            vault_id=vault_id,
+                            file_id=file_id,
+                            chunks=chunks,
+                            deterministic_summary=deterministic_summary,
+                            existing_entities_brief=existing_brief,
+                            deterministic_dedupe_keys=dedupe_seed,
+                        )
+                    )
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                    cur_result = ex.submit(_runner).result()
+        except Exception as e:  # broad — curator must never fail the job
+            logger.warning(
+                "wiki curator: orchestration failed for vault=%s file=%s: %s",
+                vault_id, file_id, e,
+            )
+            return {
+                "errors": [f"orchestration_error: {type(e).__name__}: {e}"],
+                "accepted": 0,
+                "rejected": 0,
+                "lint": 0,
+                "calls": 0,
+                "input_chars": 0,
+            }
+
+        # Persist accepted candidates as wiki_claims with provenance.
+        for accepted in cur_result.accepted:
+            try:
+                claim = self._store.create_claim(
+                    vault_id=vault_id,
+                    claim_text=accepted.claim_text,
+                    source_type="document",
+                    page_id=page_id,
+                    claim_type=accepted.claim_type,
+                    subject=accepted.subject,
+                    predicate=accepted.predicate,
+                    object=accepted.object,
+                    status=accepted.status,
+                    confidence=accepted.confidence,
+                    created_by_kind="llm_curator",
+                )
+                self._store.attach_source(
+                    claim_id=claim.id,
+                    source_kind="document",
+                    file_id=accepted.file_id,
+                    chunk_id=accepted.chunk_id,
+                    source_label=accepted.source_label or (
+                        f"file:{accepted.file_id}" if accepted.file_id else "curator"
+                    ),
+                    quote=accepted.source_quote,
+                    confidence=accepted.confidence,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                cur_result.errors.append(
+                    f"persist_error: {type(e).__name__}: {e}"
+                )
+                logger.warning(
+                    "wiki curator: failed to persist accepted claim: %s", e
+                )
+
+        # Persist lint findings.
+        for finding in cur_result.lint_findings:
+            try:
+                self._store.create_lint_finding(
+                    vault_id=vault_id,
+                    finding_type=finding["finding_type"],
+                    severity=finding.get("severity", "medium"),
+                    title=finding.get("title", "Curator lint"),
+                    details=finding.get("details", ""),
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                cur_result.errors.append(
+                    f"lint_persist_error: {type(e).__name__}: {e}"
+                )
+
+        return cur_result.to_summary()
+
+    @staticmethod
+    def _build_curator_chunks(
+        *, text: str, file_id: Optional[int]
+    ) -> list[CuratorChunk]:
+        """Slice the source text into 2 000-char windows so the curator's
+        chunk_id values match the deterministic ``f"{file_id}_{idx}"``
+        format used elsewhere in the compiler."""
+        if not text:
+            return []
+        out: list[CuratorChunk] = []
+        max_input = int(getattr(_app_settings, "wiki_llm_curator_max_input_chars", 6000))
+        budget = max(_COMPILE_CHUNK_SIZE, max_input)
+        # Take from the start of the text up to budget; bounded by the
+        # curator's own per-call max_input_chars, so we don't need to
+        # paginate here.
+        bound_text = text[:budget]
+        for i in range(0, len(bound_text), _COMPILE_CHUNK_SIZE):
+            window = bound_text[i : i + _COMPILE_CHUNK_SIZE]
+            chunk_id = (
+                f"{file_id}_{i // _COMPILE_CHUNK_SIZE}"
+                if file_id is not None
+                else f"text_{i // _COMPILE_CHUNK_SIZE}"
+            )
+            out.append(
+                CuratorChunk(
+                    chunk_id=chunk_id,
+                    source_text=window,
+                    file_id=file_id,
+                    source_label=(
+                        f"file:{file_id}" if file_id is not None else None
+                    ),
+                )
+            )
+        return out

--- a/backend/app/services/wiki_curator.py
+++ b/backend/app/services/wiki_curator.py
@@ -1,0 +1,505 @@
+"""Optional LLM Wiki Curator (PR C).
+
+Runs after deterministic extraction inside a wiki compile job. Goals:
+
+  * High-recall candidate generation: a small instruct model proposes
+    structured claims/entities/relations that the deterministic
+    extractor missed.
+  * Trust boundary on provenance: a candidate is only allowed to land
+    as an active wiki claim when its source_quote is verifiable in the
+    chunk it cites (substring or rapidfuzz partial_ratio above
+    threshold) AND the chunk_id is one we actually fed to the curator.
+  * Failure isolation: any curator error (timeout, breaker open,
+    unparseable JSON, schema violation) is recorded into the job's
+    ``result_json.curator.errors`` list. The deterministic pipeline's
+    output is the final word; curator output never replaces it.
+
+Concurrency: per-chunk calls run in parallel up to
+``settings.wiki_llm_curator_concurrency`` (1-4). With concurrency=1
+the calls are serialised. Each call sees a single chunk plus the
+deterministic candidate summary; results are merged + de-duped at the
+end. This honours the operator-facing knob exposed in PR B settings.
+
+The compiler integration in wiki_compiler.py is responsible for
+deciding *whether* to run the curator (settings flags
+``wiki_llm_curator_enabled`` + ``wiki_llm_curator_run_on_*``). This
+module just runs the curator when asked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from app.config import settings
+from app.services.curator_ssrf import CuratorURLBlocked
+from app.services.wiki_curator_client import CuratorClient, extract_json
+from app.services.wiki_store import WikiStore
+
+logger = logging.getLogger(__name__)
+
+
+# A single chunk handed to the curator. The compiler prepares these
+# from already-loaded source rows.
+@dataclass
+class CuratorChunk:
+    chunk_id: str
+    source_text: str
+    file_id: Optional[int] = None
+    source_label: Optional[str] = None
+
+
+@dataclass
+class CuratorAcceptedClaim:
+    claim_text: str
+    claim_type: str
+    subject: Optional[str]
+    predicate: Optional[str]
+    object: Optional[str]
+    source_quote: str
+    chunk_id: str
+    file_id: Optional[int]
+    source_label: Optional[str]
+    confidence: float
+    page_title: Optional[str] = None
+    page_type: Optional[str] = None
+    # Status the compiler should use when calling create_claim.
+    status: str = "needs_review"
+
+
+@dataclass
+class CuratorRejection:
+    claim_text: str
+    reason: str  # one of: "missing_quote" | "missing_chunk_id" | "quote_mismatch" | "schema"
+
+
+@dataclass
+class CuratorResult:
+    accepted: list[CuratorAcceptedClaim] = field(default_factory=list)
+    rejected: list[CuratorRejection] = field(default_factory=list)
+    lint_findings: list[dict[str, Any]] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    calls: int = 0
+    input_chars: int = 0
+
+    def to_summary(self) -> dict[str, Any]:
+        return {
+            "accepted": len(self.accepted),
+            "rejected": len(self.rejected),
+            "lint": len(self.lint_findings),
+            "errors": list(self.errors),
+            "calls": self.calls,
+            "input_chars": self.input_chars,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Verification helpers
+# ---------------------------------------------------------------------------
+
+_NORM_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """Collapse whitespace + lowercase. Punctuation is kept because it
+    carries meaning in code-like quotes (e.g. acronyms with periods)."""
+    if not text:
+        return ""
+    return _NORM_RE.sub(" ", text).strip().lower()
+
+
+def _quote_matches(quote: str, source_text: str, *, fuzzy_threshold: int = 92) -> bool:
+    """Return True iff ``quote`` is verifiable in ``source_text``.
+
+    Strict path: normalized substring. Falls back to rapidfuzz partial
+    ratio above ``fuzzy_threshold`` (0-100). rapidfuzz is now a hard
+    backend dependency (added to requirements.txt for PR C); if for
+    some reason the import fails at runtime we fall back to strict
+    substring only — safer to reject a borderline match than to
+    silently accept it.
+    """
+    if not quote or not source_text:
+        return False
+    nq = _normalize(quote)
+    ns = _normalize(source_text)
+    if nq in ns:
+        return True
+    try:
+        from rapidfuzz import fuzz
+    except ImportError:  # pragma: no cover - defensive
+        return False
+    score = fuzz.partial_ratio(nq, ns)
+    return score >= fuzzy_threshold
+
+
+def _dedupe_key(subject: str, predicate: str, obj: str, normalized_quote: str) -> str:
+    """Stable hash used to drop curator candidates that duplicate a
+    deterministic claim of the same job."""
+    raw = f"{subject or ''}|{predicate or ''}|{obj or ''}|{normalized_quote}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+_CURATOR_SYSTEM_PROMPT = """You are a knowledge-extraction assistant.
+Your job is to read a small chunk of source text and propose factual
+claims, entities, and relations that an analyst could verify against
+the source. You do NOT write opinions, summaries, or prose.
+
+Output rules — STRICT:
+  - Reply with a single JSON object and NOTHING ELSE. No prose. No
+    Markdown fences. No commentary.
+  - Every claim MUST include a "source_quote" copied verbatim from the
+    source text (exact substring; whitespace may differ but words must
+    match) AND a "chunk_id" exactly equal to one of the chunk IDs you
+    were given.
+  - If you cannot find a verbatim source_quote, do not emit the claim.
+  - If you are unsure about a relationship, prefer to emit it as an
+    "open_question" rather than an unverifiable "claim".
+
+The JSON object MUST conform to this schema:
+{
+  "claims": [
+    {
+      "claim_text": str,
+      "claim_type": "definition"|"role"|"procedure_step"|"configuration"|
+                    "troubleshooting"|"warning"|"fact"|"open_question",
+      "subject": str | null,
+      "predicate": str | null,
+      "object": str | null,
+      "source_quote": str,        // verbatim from source_text
+      "chunk_id": str,            // MUST be one of the provided chunk_ids
+      "confidence": number,       // 0.0–1.0
+      "page_title": str | null,
+      "page_type": "entity"|"procedure"|"system"|"acronym"|"qa"|
+                   "open_question"|"manual" | null
+    }
+  ],
+  "entities": [
+    {"canonical_name": str, "entity_type": str, "aliases": [str]}
+  ],
+  "relations": [
+    {"subject": str, "predicate": str, "object": str, "source_quote": str}
+  ],
+  "open_questions": [
+    {"question": str, "reason": str, "source_quote": str}
+  ],
+  "contradictions": [
+    {"claim_a": str, "claim_b": str, "reason": str, "source_quote": str}
+  ]
+}
+
+If a section has no items, return an empty list for that key.
+"""
+
+
+def build_user_prompt(
+    chunks: list[CuratorChunk],
+    *,
+    deterministic_summary: Optional[dict] = None,
+    existing_entities_brief: Optional[list[str]] = None,
+) -> str:
+    """Render the user message for a curator call.
+
+    Bounds the input by ``settings.wiki_llm_curator_max_input_chars`` —
+    chunks are concatenated in order until the budget runs out. The
+    same budget is applied per call (not per document); when curator
+    is invoked in per-chunk mode the budget cap protects each call
+    individually.
+    """
+    budget = int(settings.wiki_llm_curator_max_input_chars or 6000)
+    parts: list[str] = []
+    used = 0
+    chunk_block_lines: list[str] = []
+    for c in chunks:
+        if used >= budget:
+            break
+        remaining = budget - used
+        snippet = c.source_text[:remaining]
+        chunk_block_lines.append(
+            f'### chunk_id="{c.chunk_id}"\n{snippet}'
+        )
+        used += len(snippet)
+    parts.append("Source chunks:\n" + "\n\n".join(chunk_block_lines))
+
+    if deterministic_summary:
+        parts.append(
+            "Deterministic extraction has already produced these "
+            "candidates (do NOT duplicate; you may add new ones):\n"
+            + json.dumps(deterministic_summary, ensure_ascii=False, indent=2)
+        )
+    if existing_entities_brief:
+        # Bound the context to a few dozen names.
+        names = existing_entities_brief[:50]
+        parts.append(
+            "Known wiki entities (for disambiguation only):\n"
+            + ", ".join(names)
+        )
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# WikiCurator orchestrator
+# ---------------------------------------------------------------------------
+
+
+class WikiCurator:
+    """Run the curator over bounded chunks and verify each candidate."""
+
+    def __init__(self, client: CuratorClient, store: Optional[WikiStore] = None):
+        self.client = client
+        self.store = store
+        self.require_quote_match = bool(
+            settings.wiki_llm_curator_require_quote_match
+        )
+        self.require_chunk_id = bool(
+            settings.wiki_llm_curator_require_chunk_id
+        )
+        # Mode is whether verified candidates land as 'active' or as
+        # 'needs_review'. Failed candidates always become rejections /
+        # lint findings, never claims.
+        mode = settings.wiki_llm_curator_mode or "draft"
+        self.mode = mode if mode in ("draft", "active_if_verified") else "draft"
+
+    async def curate(
+        self,
+        *,
+        vault_id: int,
+        file_id: Optional[int],
+        chunks: list[CuratorChunk],
+        deterministic_summary: Optional[dict] = None,
+        existing_entities_brief: Optional[list[str]] = None,
+        deterministic_dedupe_keys: Optional[set[str]] = None,
+    ) -> CuratorResult:
+        result = CuratorResult()
+        if not chunks:
+            return result
+        result.input_chars = sum(len(c.source_text) for c in chunks)
+
+        # Per-chunk parallelism, bounded by the operator-facing
+        # concurrency knob. Each call sees ONE chunk; the deterministic
+        # summary + existing-entity brief are repeated per call so the
+        # curator has the same context regardless of order.
+        concurrency = max(1, min(4, int(
+            getattr(settings, "wiki_llm_curator_concurrency", 1) or 1
+        )))
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def _one_chunk(chunk: CuratorChunk) -> tuple[Optional[dict], Optional[str]]:
+            prompt = build_user_prompt(
+                [chunk],
+                deterministic_summary=deterministic_summary,
+                existing_entities_brief=existing_entities_brief,
+            )
+            async with semaphore:
+                try:
+                    text = await self.client.propose(
+                        [
+                            {"role": "system", "content": _CURATOR_SYSTEM_PROMPT},
+                            {"role": "user", "content": prompt},
+                        ]
+                    )
+                except CuratorURLBlocked as e:
+                    return None, f"ssrf_blocked: {e}"
+                except Exception as e:  # broad — never propagate
+                    return None, f"transport_error: {type(e).__name__}: {e}"
+            parsed = extract_json(text)
+            if parsed is None or not isinstance(parsed, dict):
+                return None, "json_parse_failed"
+            return parsed, None
+
+        gather_results = await asyncio.gather(
+            *(_one_chunk(c) for c in chunks), return_exceptions=False
+        )
+
+        # Index chunks by id for chunk_id verification + source_quote lookup.
+        chunk_index: dict[str, CuratorChunk] = {c.chunk_id: c for c in chunks}
+        dedupe_keys: set[str] = set(deterministic_dedupe_keys or set())
+        merged_claims: list[dict] = []
+        merged_contradictions: list[dict] = []
+
+        for parsed, err in gather_results:
+            result.calls += 1
+            if err is not None:
+                result.errors.append(err)
+                continue
+            if parsed is None:
+                continue
+            raw_claims = parsed.get("claims") or []
+            if isinstance(raw_claims, list):
+                merged_claims.extend(c for c in raw_claims if isinstance(c, dict))
+            raw_contradictions = parsed.get("contradictions") or []
+            if isinstance(raw_contradictions, list):
+                merged_contradictions.extend(
+                    c for c in raw_contradictions if isinstance(c, dict)
+                )
+
+        for raw in merged_claims:
+            try:
+                claim_text = str(raw.get("claim_text") or "").strip()
+                source_quote = str(raw.get("source_quote") or "").strip()
+                chunk_id = str(raw.get("chunk_id") or "").strip()
+            except (AttributeError, TypeError):
+                result.rejected.append(
+                    CuratorRejection(claim_text="", reason="schema")
+                )
+                continue
+            if not claim_text:
+                result.rejected.append(
+                    CuratorRejection(claim_text="", reason="schema")
+                )
+                continue
+
+            if not source_quote:
+                result.rejected.append(
+                    CuratorRejection(claim_text=claim_text, reason="missing_quote")
+                )
+                if self.store is not None:
+                    result.lint_findings.append({
+                        "finding_type": "unsupported_claim",
+                        "severity": "medium",
+                        "title": "Curator claim missing source_quote",
+                        "details": json.dumps({
+                            "subtype": "curator",
+                            "claim_text": claim_text,
+                        }),
+                    })
+                continue
+
+            if self.require_chunk_id and chunk_id not in chunk_index:
+                result.rejected.append(
+                    CuratorRejection(claim_text=claim_text, reason="missing_chunk_id")
+                )
+                if self.store is not None:
+                    result.lint_findings.append({
+                        "finding_type": "unsupported_claim",
+                        "severity": "medium",
+                        "title": "Curator claim references unknown chunk",
+                        "details": json.dumps({
+                            "subtype": "curator",
+                            "claim_text": claim_text,
+                            "chunk_id": chunk_id,
+                        }),
+                    })
+                continue
+
+            chunk_for_verify = chunk_index.get(chunk_id) or (
+                chunks[0] if not self.require_chunk_id else None
+            )
+            if chunk_for_verify is None:
+                result.rejected.append(
+                    CuratorRejection(claim_text=claim_text, reason="missing_chunk_id")
+                )
+                continue
+
+            if self.require_quote_match and not _quote_matches(
+                source_quote, chunk_for_verify.source_text
+            ):
+                result.rejected.append(
+                    CuratorRejection(claim_text=claim_text, reason="quote_mismatch")
+                )
+                if self.store is not None:
+                    result.lint_findings.append({
+                        "finding_type": "unsupported_claim",
+                        "severity": "high",
+                        "title": "Curator source_quote not verifiable",
+                        "details": json.dumps({
+                            "subtype": "curator",
+                            "claim_text": claim_text,
+                            "chunk_id": chunk_id,
+                            "attempted_quote": source_quote[:500],
+                        }),
+                    })
+                continue
+
+            subject = (raw.get("subject") or "") if isinstance(raw.get("subject"), str) else ""
+            predicate = (raw.get("predicate") or "") if isinstance(raw.get("predicate"), str) else ""
+            obj = (raw.get("object") or "") if isinstance(raw.get("object"), str) else ""
+            key = _dedupe_key(subject, predicate, obj, _normalize(source_quote))
+            if key in dedupe_keys:
+                # Silent duplicate — already covered by deterministic
+                # output. Don't store as rejection or lint; not a bug.
+                continue
+            dedupe_keys.add(key)
+
+            confidence = raw.get("confidence")
+            try:
+                confidence = float(confidence) if confidence is not None else 0.5
+            except (TypeError, ValueError):
+                confidence = 0.5
+            confidence = max(0.0, min(1.0, confidence))
+
+            claim_type = raw.get("claim_type") or "fact"
+            if not isinstance(claim_type, str):
+                claim_type = "fact"
+
+            # Status by mode: draft => always needs_review.
+            # active_if_verified => active (we already passed the quote
+            # check, so the verification gate is satisfied).
+            status = "needs_review" if self.mode == "draft" else "active"
+
+            page_title = raw.get("page_title") if isinstance(raw.get("page_title"), str) else None
+            page_type = raw.get("page_type") if isinstance(raw.get("page_type"), str) else None
+
+            result.accepted.append(
+                CuratorAcceptedClaim(
+                    claim_text=claim_text,
+                    claim_type=claim_type,
+                    subject=subject or None,
+                    predicate=predicate or None,
+                    object=obj or None,
+                    source_quote=source_quote,
+                    chunk_id=chunk_for_verify.chunk_id,
+                    file_id=chunk_for_verify.file_id,
+                    source_label=chunk_for_verify.source_label,
+                    confidence=confidence,
+                    page_title=page_title,
+                    page_type=page_type,
+                    status=status,
+                )
+            )
+
+        # Contradictions become lint findings only, never claims.
+        for c in merged_contradictions:
+            if not isinstance(c, dict):
+                continue
+            result.lint_findings.append({
+                "finding_type": "contradiction",
+                "severity": "high",
+                "title": "Curator-detected contradiction",
+                "details": json.dumps({
+                    "subtype": "curator",
+                    "claim_a": c.get("claim_a"),
+                    "claim_b": c.get("claim_b"),
+                    "reason": c.get("reason"),
+                    "source_quote": c.get("source_quote"),
+                }),
+            })
+
+        return result
+
+
+# Public utility: stable hash used by the compiler to seed
+# ``deterministic_dedupe_keys`` when calling ``WikiCurator.curate``.
+def deterministic_dedupe_key(
+    subject: str, predicate: str, obj: str, source_quote: str
+) -> str:
+    return _dedupe_key(subject or "", predicate or "", obj or "", _normalize(source_quote or ""))
+
+
+def verify_quote(quote: str, source_text: str, *, fuzzy_threshold: int = 92) -> bool:
+    """Public alias for the source-quote verification helper.
+
+    The wiki claim PUT route imports this when re-verifying a curator
+    claim's source on transitions to status='active'. Exposing a public
+    name keeps the route from depending on a private symbol.
+    """
+    return _quote_matches(quote, source_text, fuzzy_threshold=fuzzy_threshold)

--- a/backend/app/services/wiki_curator_client.py
+++ b/backend/app/services/wiki_curator_client.py
@@ -1,0 +1,281 @@
+"""HTTP client for the optional LLM Wiki Curator (PR C).
+
+Independent of LLMClient on purpose: the curator runs against a
+separate model / endpoint and must not trip the chat circuit breaker
+when it fails. We mirror LLMClient's OpenAI-compatible request shape
+and reuse the same thinking-content sanitizer so the curator's output
+is treated exactly like chat output downstream.
+
+SSRF guard: every outbound call assert_curator_url_safe()'s the URL
+first, even though the settings PUT validator did the same. Defense in
+depth: a curator URL persisted before the guard was tightened, or a
+local-model env var that flipped, must still be rejected at request
+time.
+
+JSON extraction: small local instruct models routinely emit JSON
+wrapped in prose ("Sure! Here's the JSON: { ... }"). The
+``extract_json`` helper is robust to that — it tries strict parse,
+balanced-brace scan, and trailing-prose strip in order.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import httpx
+
+from app.services.circuit_breaker import (
+    AsyncCircuitBreaker,
+    CircuitBreakerError,
+)
+from app.services.curator_ssrf import (
+    CuratorURLBlocked,
+    assert_curator_url_safe,
+)
+from app.utils.assistant_sanitizer import sanitize_assistant_content
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CuratorPingResult:
+    ok: bool
+    model: str
+    latency_ms: Optional[int]
+    error: Optional[str] = None
+
+
+class CuratorClient:
+    """Async OpenAI-compatible client for the curator endpoint.
+
+    All instance configuration (URL / model / timeout / max_tokens /
+    temperature) is captured at construction so a single curator job
+    can use a stable config even if the operator edits settings mid-run.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        *,
+        timeout: float = 120.0,
+        max_tokens: int = 2048,
+        temperature: float = 0.0,
+        breaker_name: str = "curator",
+    ):
+        self.base_url = (base_url or "").rstrip("/")
+        self.model = model or ""
+        self.timeout = float(timeout)
+        self.max_tokens = int(max_tokens)
+        self.temperature = float(temperature)
+        # Independent breaker so curator outages don't trip chat.
+        self._breaker = AsyncCircuitBreaker(
+            fail_max=5,
+            reset_timeout=60.0,
+            success_threshold=1,
+            name=breaker_name,
+        )
+
+    @property
+    def endpoint(self) -> str:
+        if self.base_url.endswith("/v1/chat/completions"):
+            return self.base_url
+        return self.base_url + "/v1/chat/completions"
+
+    async def propose(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Issue an OpenAI-compatible chat completion and return the text.
+
+        Raises:
+            CuratorURLBlocked: SSRF guard fired.
+            CircuitBreakerError: breaker is open.
+            httpx.HTTPError: network/timeout error.
+            ValueError: response didn't include a content field.
+        """
+        if not self.base_url or not self.model:
+            raise ValueError("CuratorClient requires base_url and model")
+        assert_curator_url_safe(self.base_url)
+
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": (
+                self.temperature if temperature is None else float(temperature)
+            ),
+            "max_tokens": (
+                self.max_tokens if max_tokens is None else int(max_tokens)
+            ),
+            "stream": False,
+        }
+
+        async def _do_post() -> dict:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=False
+            ) as client:
+                resp = await client.post(self.endpoint, json=payload)
+            if resp.status_code >= 300:
+                raise httpx.HTTPStatusError(
+                    f"Curator returned HTTP {resp.status_code}: {resp.text[:200]}",
+                    request=resp.request,
+                    response=resp,
+                )
+            return resp.json()
+
+        # AsyncCircuitBreaker.call records success/failure for us and
+        # raises CircuitBreakerError when the breaker is open.
+        data = await self._breaker.call(_do_post)
+
+        try:
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise ValueError(f"Curator response missing content: {e}") from e
+
+        # Reuse the chat sanitizer so <think>…</think> blocks etc. are
+        # stripped exactly as they would be from a chat response.
+        return sanitize_assistant_content(content or "")
+
+    async def test_connection(self) -> CuratorPingResult:
+        """Issue a tiny JSON-only ping. Used by POST /settings/curator/test
+        and also exposable to operators who want to verify a config
+        without touching the full curator pipeline.
+
+        Best-effort: every error path returns a result with ok=False
+        rather than raising, so callers can render the message inline.
+        """
+        if not self.base_url or not self.model:
+            return CuratorPingResult(
+                ok=False,
+                model=self.model,
+                latency_ms=None,
+                error="Curator URL and model are required.",
+            )
+        try:
+            assert_curator_url_safe(self.base_url)
+        except CuratorURLBlocked as e:
+            return CuratorPingResult(
+                ok=False, model=self.model, latency_ms=None, error=str(e)
+            )
+
+        started = time.monotonic()
+        try:
+            text = await self.propose(
+                [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a JSON-only echo. Reply with the literal "
+                            'JSON object {"ok": true} and nothing else.'
+                        ),
+                    },
+                    {"role": "user", "content": '{"ping": true}'},
+                ],
+                max_tokens=16,
+                temperature=0.0,
+            )
+            latency_ms = int((time.monotonic() - started) * 1000)
+            # We accept ANY non-empty response — the chat path does the
+            # real schema validation on real prompts. The ping just
+            # verifies reachability + auth + non-empty completion.
+            return CuratorPingResult(
+                ok=bool(text),
+                model=self.model,
+                latency_ms=latency_ms,
+                error=None if text else "Curator returned empty content.",
+            )
+        except CircuitBreakerError as e:
+            return CuratorPingResult(
+                ok=False, model=self.model, latency_ms=None, error=str(e)
+            )
+        except httpx.TimeoutException:
+            latency_ms = int((time.monotonic() - started) * 1000)
+            return CuratorPingResult(
+                ok=False,
+                model=self.model,
+                latency_ms=latency_ms,
+                error=f"Curator endpoint timed out after {self.timeout}s.",
+            )
+        except Exception as e:  # broad — surface to UI
+            latency_ms = int((time.monotonic() - started) * 1000)
+            return CuratorPingResult(
+                ok=False,
+                model=self.model,
+                latency_ms=latency_ms,
+                error=str(e)[:300],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Robust JSON extraction. Exposed at module level so other code can reuse it
+# (and so it's easy to unit test without standing up a CuratorClient).
+# ---------------------------------------------------------------------------
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```", re.DOTALL)
+
+
+def extract_json(text: str) -> Optional[Any]:
+    """Try hard to recover a JSON object/array from a curator response.
+
+    Strategy in order:
+      1. Strict json.loads (covers well-behaved models).
+      2. Strip a ```json ... ``` fenced block and parse its contents.
+      3. Find the first balanced `{...}` or `[...]` at the top level
+         and parse it.
+      4. None — caller should treat as parse failure.
+    """
+    if not text or not text.strip():
+        return None
+    raw = text.strip()
+    # 1. Strict.
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    # 2. ```json fenced block.
+    m = _JSON_FENCE_RE.search(raw)
+    if m:
+        try:
+            return json.loads(m.group(1))
+        except json.JSONDecodeError:
+            pass
+    # 3. Balanced-brace scan.
+    for opener, closer in (("{", "}"), ("[", "]")):
+        start = raw.find(opener)
+        if start < 0:
+            continue
+        depth = 0
+        in_str = False
+        escape = False
+        for i in range(start, len(raw)):
+            ch = raw[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\" and in_str:
+                escape = True
+                continue
+            if ch == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch == opener:
+                depth += 1
+            elif ch == closer:
+                depth -= 1
+                if depth == 0:
+                    candidate = raw[start : i + 1]
+                    try:
+                        return json.loads(candidate)
+                    except json.JSONDecodeError:
+                        break  # fall through to next opener
+    return None

--- a/backend/app/services/wiki_store.py
+++ b/backend/app/services/wiki_store.py
@@ -68,6 +68,10 @@ class WikiClaim:
     status: str
     confidence: float
     created_by: Optional[int]
+    # 'deterministic' | 'llm_curator' | None.
+    # None for legacy rows pre-PR-C; readers should treat None as
+    # "deterministic / unknown".
+    created_by_kind: Optional[str]
     created_at: str
     updated_at: str
     sources: list = field(default_factory=list)
@@ -208,6 +212,7 @@ def _to_wiki_claim(row: sqlite3.Row) -> WikiClaim:
         status=d["status"],
         confidence=d.get("confidence") or 0.0,
         created_by=d.get("created_by"),
+        created_by_kind=d.get("created_by_kind"),
         created_at=d["created_at"],
         updated_at=d["updated_at"],
     )
@@ -502,16 +507,18 @@ class WikiStore:
         status: str = "active",
         confidence: float = 0.0,
         created_by: Optional[int] = None,
+        created_by_kind: Optional[str] = None,
         sources: Optional[list] = None,
     ) -> WikiClaim:
         now = datetime.utcnow().isoformat()
         cur = self._db.execute(
             """INSERT INTO wiki_claims
                (vault_id, page_id, claim_text, claim_type, subject, predicate, object,
-                source_type, status, confidence, created_by, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                source_type, status, confidence, created_by, created_by_kind,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (vault_id, page_id, claim_text, claim_type, subject, predicate, object,
-             source_type, status, confidence, created_by, now, now),
+             source_type, status, confidence, created_by, created_by_kind, now, now),
         )
         claim_id = cur.lastrowid
         if sources:

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -21,3 +21,4 @@ xlrd>=2.0.1
 PyJWT>=2.8.0
 passlib[bcrypt]>=1.7.4
 bcrypt<5.0.0
+rapidfuzz>=3.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ xlrd>=2.0.1
 PyJWT>=2.8.0
 passlib[bcrypt]>=1.7.4
 bcrypt<5.0.0
+rapidfuzz>=3.0.0

--- a/backend/tests/test_document_progress_async.py
+++ b/backend/tests/test_document_progress_async.py
@@ -1,0 +1,741 @@
+"""Tests for PR A: phase-aware progress + async upload route + status route.
+
+Covers:
+  - Migration adds the new columns idempotently
+  - set_phase / clear_progress / set_wiki_pending touch the right columns
+  - DocumentProcessor.process_existing_file skips duplicate-check + insert
+  - BackgroundProcessor.enqueue(file_id=...) routes the worker to
+    process_existing_file rather than process_file
+  - GET /documents/{file_id}/status returns the new phase/wiki fields
+  - GET /documents/{file_id}/status returns 403 cross-vault
+  - POST /documents returns promptly with status="pending" and file_id
+  - status enum stays in {pending, processing, indexed, error}
+"""
+
+import asyncio
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from queue import Empty, Queue
+from unittest.mock import AsyncMock, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional deps (mirrors test_documents_auth.py)
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    import types
+
+    _u = types.ModuleType("unstructured")
+    _u.__path__ = []
+    _u.partition = types.ModuleType("unstructured.partition")
+    _u.partition.__path__ = []
+    _u.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _u.partition.auto.partition = lambda *a, **k: []
+    _u.chunking = types.ModuleType("unstructured.chunking")
+    _u.chunking.__path__ = []
+    _u.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _u.chunking.title.chunk_by_title = lambda *a, **k: []
+    _u.documents = types.ModuleType("unstructured.documents")
+    _u.documents.__path__ = []
+    _u.documents.elements = types.ModuleType("unstructured.documents.elements")
+    _u.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _u
+    sys.modules["unstructured.partition"] = _u.partition
+    sys.modules["unstructured.partition.auto"] = _u.partition.auto
+    sys.modules["unstructured.chunking"] = _u.chunking
+    sys.modules["unstructured.chunking.title"] = _u.chunking.title
+    sys.modules["unstructured.documents"] = _u.documents
+    sys.modules["unstructured.documents.elements"] = _u.documents.elements
+
+from app.config import settings
+from app.models.database import (
+    SQLiteConnectionPool,
+    init_db,
+    migrate_add_files_processing_progress,
+    run_migrations,
+)
+from app.services.background_tasks import BackgroundProcessor
+from app.services.document_processor import DocumentProcessor
+from app.services.document_progress import (
+    PHASE_CHUNKING,
+    PHASE_INDEXED,
+    PHASE_QUEUED,
+    clear_progress,
+    set_phase,
+    set_wiki_pending,
+)
+
+
+def _columns(db_path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    finally:
+        conn.close()
+
+
+class TestProgressMigration(unittest.TestCase):
+    """The migration must be idempotent and never widen files.status."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "app.db")
+        init_db(self.db)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        os.rmdir(self.tmp)
+
+    def test_migration_adds_phase_columns_idempotently(self):
+        # init_db already includes the columns via SCHEMA, but the
+        # migration function must also be safe on existing databases.
+        cols_before = _columns(self.db, "files")
+        for expected in (
+            "phase",
+            "phase_message",
+            "progress_percent",
+            "processed_units",
+            "total_units",
+            "unit_label",
+            "phase_started_at",
+            "processing_started_at",
+            "wiki_pending",
+        ):
+            self.assertIn(expected, cols_before, f"missing column {expected}")
+
+        # Running again must not raise.
+        migrate_add_files_processing_progress(self.db)
+        cols_after = _columns(self.db, "files")
+        self.assertEqual(cols_before, cols_after)
+
+    def test_files_status_check_unchanged(self):
+        # Inserting a value outside the canonical 4-value enum must fail.
+        run_migrations(self.db)
+        conn = sqlite3.connect(self.db)
+        try:
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO files (vault_id, file_path, file_name, file_size, status) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (1, "/tmp/x", "x", 1, "queued"),
+                )
+            conn.rollback()
+            # And the legitimate enum values must still work.
+            for v in ("pending", "processing", "indexed", "error"):
+                conn.execute(
+                    "INSERT INTO files (vault_id, file_path, file_name, file_size, status) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (1, f"/tmp/x_{v}", f"x_{v}", 1, v),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+class TestSetPhase(unittest.TestCase):
+    """The phase helpers must touch only the columns explicitly named."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "app.db")
+        init_db(self.db)
+        self.pool = SQLiteConnectionPool(self.db, max_size=2)
+        # Seed a row.
+        conn = sqlite3.connect(self.db)
+        try:
+            cur = conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_size, status) "
+                "VALUES (?, ?, ?, ?, 'pending')",
+                (1, "/tmp/file", "file", 1),
+            )
+            self.file_id = cur.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+    def tearDown(self):
+        self.pool.close_all()
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        os.rmdir(self.tmp)
+
+    def _row(self):
+        conn = sqlite3.connect(self.db)
+        conn.row_factory = sqlite3.Row
+        try:
+            return conn.execute(
+                "SELECT * FROM files WHERE id = ?", (self.file_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+    def test_set_phase_writes_message_and_units(self):
+        set_phase(
+            self.pool,
+            self.file_id,
+            phase=PHASE_CHUNKING,
+            message="Prepared 10 chunks",
+            total=10,
+            processed=10,
+            unit="chunks",
+            percent=100.0,
+        )
+        row = self._row()
+        self.assertEqual(row["phase"], "chunking")
+        self.assertEqual(row["phase_message"], "Prepared 10 chunks")
+        self.assertEqual(row["total_units"], 10)
+        self.assertEqual(row["processed_units"], 10)
+        self.assertEqual(row["unit_label"], "chunks")
+        self.assertEqual(row["progress_percent"], 100.0)
+
+    def test_set_phase_does_not_touch_status(self):
+        set_phase(
+            self.pool,
+            self.file_id,
+            phase=PHASE_QUEUED,
+            message="Queued",
+        )
+        row = self._row()
+        self.assertEqual(row["status"], "pending")  # unchanged
+
+    def test_clear_progress_resets_transient_fields(self):
+        set_phase(
+            self.pool,
+            self.file_id,
+            phase=PHASE_CHUNKING,
+            message="x",
+            total=5,
+            processed=5,
+            unit="chunks",
+            percent=100.0,
+        )
+        clear_progress(self.pool, self.file_id)
+        row = self._row()
+        self.assertEqual(row["phase"], PHASE_INDEXED)
+        self.assertIsNone(row["phase_message"])
+        self.assertIsNone(row["progress_percent"])
+        self.assertIsNone(row["processed_units"])
+        self.assertIsNone(row["total_units"])
+        self.assertIsNone(row["unit_label"])
+
+    def test_set_wiki_pending(self):
+        set_wiki_pending(self.pool, self.file_id, True)
+        self.assertEqual(self._row()["wiki_pending"], 1)
+        set_wiki_pending(self.pool, self.file_id, False)
+        self.assertEqual(self._row()["wiki_pending"], 0)
+
+
+class TestProcessExistingFileSkipsDuplicateCheck(unittest.TestCase):
+    """process_existing_file must NOT run dedup or insert a second row."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "app.db")
+        init_db(self.db)
+        self._original_data_dir = settings.data_dir
+        settings.data_dir = Path(self.tmp)
+        self.pool = SQLiteConnectionPool(self.db, max_size=2)
+        self.processor = DocumentProcessor(
+            chunk_size_chars=2000, chunk_overlap_chars=200, pool=self.pool
+        )
+        # SQL file processing is the simplest path through process_file
+        # that doesn't require external services.
+        self.sql_path = os.path.join(self.tmp, "schema.sql")
+        with open(self.sql_path, "w", encoding="utf-8") as f:
+            f.write(
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);\n"
+                "CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER);\n"
+            )
+
+    def tearDown(self):
+        settings.data_dir = self._original_data_dir
+        self.pool.close_all()
+        for p in (self.sql_path, self.db):
+            if os.path.exists(p):
+                os.remove(p)
+        os.rmdir(self.tmp)
+
+    def test_process_existing_file_uses_provided_row(self):
+        from app.utils.file_utils import compute_file_hash
+
+        # Simulate the route side: insert the row first.
+        conn = self.pool.get_connection()
+        try:
+            file_id = self.processor._insert_or_get_file_record(
+                self.sql_path,
+                compute_file_hash(self.sql_path),
+                conn,
+                vault_id=1,
+                source="upload",
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        # Sanity: only one row exists for this path before processing.
+        c = sqlite3.connect(self.db)
+        try:
+            count_before = c.execute(
+                "SELECT COUNT(*) FROM files WHERE file_path = ?", (self.sql_path,)
+            ).fetchone()[0]
+        finally:
+            c.close()
+        self.assertEqual(count_before, 1)
+
+        # Run worker-side processing.
+        result = asyncio.run(
+            self.processor.process_existing_file(
+                file_id=file_id, file_path=self.sql_path, vault_id=1
+            )
+        )
+        self.assertEqual(result.file_id, file_id)
+
+        # Still exactly one row.
+        c = sqlite3.connect(self.db)
+        c.row_factory = sqlite3.Row
+        try:
+            rows = c.execute(
+                "SELECT id, status, phase, wiki_pending FROM files WHERE file_path = ?",
+                (self.sql_path,),
+            ).fetchall()
+        finally:
+            c.close()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], file_id)
+        self.assertEqual(rows[0]["status"], "indexed")
+        # Phase pinned to indexed by clear_progress at the end.
+        self.assertEqual(rows[0]["phase"], "indexed")
+        # Reviewer Fix #4: wiki_pending must be cleared on the happy path
+        # once the wiki_compile_jobs row exists, so the row carries no
+        # stale flag. (The wiki job is created by the processor; the test
+        # database has wiki tables via run_migrations through init_db
+        # path — if the wiki table is missing, the processor logs a
+        # warning and clears the flag in the except branch. Either way
+        # the flag must end at 0 on success.)
+        self.assertEqual(rows[0]["wiki_pending"], 0)
+
+
+class TestBackgroundProcessorRoutesByFileId(unittest.TestCase):
+    """When file_id is on the task, the worker calls process_existing_file."""
+
+    def test_enqueue_with_file_id_calls_process_existing_file(self):
+        bp = BackgroundProcessor()
+        bp.processor = MagicMock()
+        bp.processor.process_file = AsyncMock()
+        bp.processor.process_existing_file = AsyncMock()
+
+        async def runner():
+            await bp.enqueue(
+                file_path="/tmp/x.txt",
+                source="upload",
+                vault_id=1,
+                file_id=42,
+            )
+            # Drain one task.
+            task = await bp.queue.get()
+            await bp._process_task(task)
+            bp.queue.task_done()
+
+        asyncio.run(runner())
+        bp.processor.process_existing_file.assert_awaited_once_with(
+            file_id=42, file_path="/tmp/x.txt", vault_id=1
+        )
+        bp.processor.process_file.assert_not_awaited()
+
+    def test_enqueue_without_file_id_calls_process_file(self):
+        bp = BackgroundProcessor()
+        bp.processor = MagicMock()
+        bp.processor.process_file = AsyncMock()
+        bp.processor.process_existing_file = AsyncMock()
+
+        async def runner():
+            await bp.enqueue(
+                file_path="/tmp/x.txt",
+                source="scan",
+                vault_id=1,
+            )
+            task = await bp.queue.get()
+            await bp._process_task(task)
+            bp.queue.task_done()
+
+        asyncio.run(runner())
+        bp.processor.process_file.assert_awaited_once()
+        bp.processor.process_existing_file.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level tests for the route flip and the extended status endpoint.
+# ---------------------------------------------------------------------------
+
+
+class _SimplePool:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self._pool = Queue(maxsize=5)
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def get_connection(self):
+        if self._closed:
+            raise RuntimeError("Pool closed")
+        try:
+            return self._pool.get_nowait()
+        except Empty:
+            return self._create_connection()
+
+    def _create_connection(self):
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def release_connection(self, conn):
+        if not self._closed:
+            try:
+                self._pool.put_nowait(conn)
+            except Exception:
+                conn.close()
+
+    # Context-manager helper for set_phase
+    from contextlib import contextmanager
+
+    @contextmanager
+    def connection(self):
+        conn = self.get_connection()
+        try:
+            yield conn
+        finally:
+            self.release_connection(conn)
+
+    def close_all(self):
+        self._closed = True
+        while True:
+            try:
+                conn = self._pool.get_nowait()
+                conn.close()
+            except Empty:
+                break
+
+
+class TestStatusRouteAndAsyncUpload(unittest.TestCase):
+    """Route-level tests for PR A async upload + extended status endpoint."""
+
+    def setUp(self):
+        from fastapi.testclient import TestClient
+
+        from app.api.deps import (
+            get_background_processor,
+            get_db,
+            get_db_pool,
+            get_embedding_service,
+            get_vector_store,
+        )
+        from app.main import app
+        from app.services.auth_service import create_access_token, hash_password
+
+        self.app = app
+        self.create_token = create_access_token
+        self.hash_password = hash_password
+        self.client = TestClient(app)
+
+        self.tmp = tempfile.mkdtemp()
+        self._original_data_dir = settings.data_dir
+        self._original_users_enabled = settings.users_enabled
+        self._original_jwt = settings.jwt_secret_key
+        settings.data_dir = Path(self.tmp)
+        settings.users_enabled = True
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+
+        self.db = str(Path(self.tmp) / "app.db")
+
+        # Reset pool cache.
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        with _pool_cache_lock:
+            for _, p in list(_pool_cache.items()):
+                p.close_all()
+            _pool_cache.clear()
+
+        run_migrations(self.db)
+        self.pool = _SimplePool(self.db)
+
+        self._mock_vec = MagicMock()
+        self._mock_emb = MagicMock()
+        self._mock_bp = MagicMock()
+        self._mock_bp.is_running = True
+        self._mock_bp.enqueue = AsyncMock()
+
+        def override_db():
+            conn = self.pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.pool.release_connection(conn)
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_db_pool] = lambda: self.pool
+        app.dependency_overrides[get_vector_store] = lambda: self._mock_vec
+        app.dependency_overrides[get_embedding_service] = lambda: self._mock_emb
+        app.dependency_overrides[get_background_processor] = lambda: self._mock_bp
+
+        # Seed two vaults + two users.
+        conn = self.pool.get_connection()
+        try:
+            conn.execute("DELETE FROM files")
+            conn.execute("DELETE FROM vault_members")
+            conn.execute("DELETE FROM users WHERE id != 0")
+            pw = self.hash_password("pw")
+            conn.execute(
+                "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (1, 'sa', ?, 'SA', 'superadmin', 1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (2, 'm1', ?, 'M1', 'member', 1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (3, 'm2', ?, 'M2', 'member', 1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (2, 'V2', '')"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (3, 'V3', '')"
+            )
+            conn.execute(
+                "INSERT INTO vault_members (vault_id, user_id, permission, granted_by) "
+                "VALUES (2, 2, 'write', 1)"
+            )
+            conn.execute(
+                "INSERT INTO vault_members (vault_id, user_id, permission, granted_by) "
+                "VALUES (3, 3, 'read', 1)"
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+    def tearDown(self):
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        self.app.dependency_overrides.clear()
+        with _pool_cache_lock:
+            for _, p in list(_pool_cache.items()):
+                p.close_all()
+            _pool_cache.clear()
+        self.pool.close_all()
+        settings.data_dir = self._original_data_dir
+        settings.users_enabled = self._original_users_enabled
+        settings.jwt_secret_key = self._original_jwt
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _token(self, uid, name, role):
+        return self.create_token(uid, name, role)
+
+    def test_status_route_returns_new_phase_fields(self):
+        # Insert a row in vault 2 with phase fields populated.
+        conn = self.pool.get_connection()
+        try:
+            cur = conn.execute(
+                """INSERT INTO files
+                   (vault_id, file_path, file_name, file_size, status,
+                    phase, phase_message, progress_percent,
+                    processed_units, total_units, unit_label,
+                    processing_started_at, wiki_pending)
+                   VALUES (2, '/uploads/x.txt', 'x.txt', 100,
+                           'processing', 'embedding', 'Embedding chunks',
+                           50.0, 5, 10, 'chunks', CURRENT_TIMESTAMP, 1)""",
+            )
+            file_id = cur.lastrowid
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        token = self._token(2, "m1", "member")
+        resp = self.client.get(
+            f"/api/documents/{file_id}/status",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(body["status"], "processing")
+        self.assertEqual(body["phase"], "embedding")
+        self.assertEqual(body["phase_message"], "Embedding chunks")
+        self.assertEqual(body["progress_percent"], 50.0)
+        self.assertEqual(body["processed_units"], 5)
+        self.assertEqual(body["total_units"], 10)
+        self.assertEqual(body["unit_label"], "chunks")
+        # No wiki_compile_jobs row → wiki_pending=1 surfaces as wiki_status=pending.
+        self.assertEqual(body["wiki_status"], "pending")
+        # processing_started_at was set, so elapsed should be a non-negative float.
+        self.assertIsNotNone(body["elapsed_seconds"])
+        self.assertGreaterEqual(body["elapsed_seconds"], 0.0)
+
+    def test_in_flight_duplicate_check_matches_pending_and_processing(self):
+        """Reviewer Fix #1: route-side check rejects in-flight duplicates so two
+        concurrent uploads of the same hash collapse to a single ingestion."""
+        from app.utils.file_utils import compute_file_hash
+
+        # Seed an existing pending row with a known hash.
+        path = os.path.join(self.tmp, "dup.txt")
+        with open(path, "w") as f:
+            f.write("dup-content")
+        h = compute_file_hash(path)
+
+        conn = self.pool.get_connection()
+        try:
+            for st in ("pending", "processing", "indexed"):
+                conn.execute(
+                    "INSERT INTO files (vault_id, file_path, file_name, file_hash, "
+                    "file_size, status) VALUES (2, ?, ?, ?, ?, ?)",
+                    (f"/uploads/{st}", st, h, 1, st),
+                )
+            # An 'error' row must NOT match — re-uploading a failed file is allowed.
+            conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_hash, "
+                "file_size, status) VALUES (2, '/uploads/err', 'err', ?, 1, 'error')",
+                (h,),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        proc = DocumentProcessor(pool=self.pool)
+        conn = self.pool.get_connection()
+        try:
+            row = proc._check_duplicate_in_flight(h, conn, vault_id=2)
+            self.assertIsNotNone(row)
+            self.assertIn(row["status"], ("pending", "processing", "indexed"))
+        finally:
+            self.pool.release_connection(conn)
+
+        # Cross-vault must NOT match.
+        conn = self.pool.get_connection()
+        try:
+            self.assertIsNone(
+                proc._check_duplicate_in_flight(h, conn, vault_id=3)
+            )
+        finally:
+            self.pool.release_connection(conn)
+
+        # Hash present only in 'error' state must NOT match.
+        h2 = "deadbeef" * 8
+        conn = self.pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_hash, "
+                "file_size, status) VALUES (2, '/uploads/only_err', 'only_err', ?, 1, 'error')",
+                (h2,),
+            )
+            conn.commit()
+            self.assertIsNone(
+                proc._check_duplicate_in_flight(h2, conn, vault_id=2)
+            )
+        finally:
+            self.pool.release_connection(conn)
+
+    def test_async_upload_409_on_in_flight_hash_collision_does_not_leak_path(self):
+        """Critic Fix #3: route returns 409 (not 500) when a different filename
+        has the same hash as an in-flight upload, AND the response detail
+        does not include the existing row's file_path (info disclosure)."""
+        from app.utils.file_utils import compute_file_hash
+
+        # Seed a pending row for vault 2 with a known hash + storage path.
+        contents = b"shared-content-bytes"
+        existing_path = os.path.join(self.tmp, "uploads_existing_secret.txt")
+        with open(existing_path, "wb") as f:
+            f.write(contents)
+        h = compute_file_hash(existing_path)
+        conn = self.pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_hash, "
+                "file_size, status, phase) VALUES (2, ?, 'existing.txt', ?, ?, "
+                "'pending', 'queued')",
+                (existing_path, h, len(contents)),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        # The route streams the new file to vault_uploads_dir; the test
+        # client's vault_uploads_dir resolves under settings.data_dir,
+        # which we already point at self.tmp. We do NOT need to set up
+        # the on-disk file ourselves — the route does.
+        token = self._token(2, "m1", "member")
+        files_payload = {"file": ("new.txt", contents, "text/plain")}
+        resp = self.client.post(
+            "/api/documents",
+            params={"vault_id": 2},
+            headers={"Authorization": f"Bearer {token}"},
+            files=files_payload,
+        )
+        # CONTRACT: 409, not 500.
+        self.assertEqual(resp.status_code, 409, resp.text)
+        body = resp.json()
+        detail = body.get("detail", "")
+        # CONTRACT: detail must NOT include the existing file's storage path.
+        self.assertNotIn(
+            existing_path,
+            detail,
+            f"409 detail leaked existing file_path: {detail!r}",
+        )
+        self.assertNotIn(
+            "uploads_existing_secret",
+            detail,
+            f"409 detail leaked existing file basename: {detail!r}",
+        )
+        # Sanity: hash + status are present so the client can reconcile.
+        self.assertIn(h, detail)
+        self.assertIn("status=", detail)
+
+    def test_status_route_cross_vault_returns_403(self):
+        # File in vault 2; member3 only has access to vault 3.
+        conn = self.pool.get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_size, status) "
+                "VALUES (2, '/uploads/y.txt', 'y.txt', 100, 'indexed')",
+            )
+            file_id = cur.lastrowid
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        token = self._token(3, "m2", "member")
+        resp = self.client.get(
+            f"/api/documents/{file_id}/status",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(resp.status_code, 403, resp.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_document_progress_async.py
+++ b/backend/tests/test_document_progress_async.py
@@ -737,5 +737,103 @@ class TestStatusRouteAndAsyncUpload(unittest.TestCase):
         self.assertEqual(resp.status_code, 403, resp.text)
 
 
+class TestHandleFailurePreservesFileId(unittest.TestCase):
+    """_handle_failure must carry file_id into the requeued TaskItem.
+
+    Regression guard: the original implementation created a new TaskItem
+    without file_id, causing the retry to fall through to process_file
+    (legacy path) and re-run duplicate detection against an already-existing
+    files row.
+    """
+
+    def test_file_id_preserved_in_retry_task(self):
+        from app.services.background_tasks import TaskItem
+
+        bp = BackgroundProcessor(retry_delay=0)
+
+        async def runner():
+            task = TaskItem(
+                file_path="/tmp/x.txt",
+                attempt=1,
+                source="upload",
+                vault_id=1,
+                file_id=99,
+            )
+            await bp._handle_failure(task, "simulated error")
+            return await bp.queue.get()
+
+        retry_task = asyncio.run(runner())
+        self.assertEqual(retry_task.file_id, 99)
+        self.assertEqual(retry_task.attempt, 2)
+        self.assertEqual(retry_task.file_path, "/tmp/x.txt")
+        self.assertEqual(retry_task.vault_id, 1)
+
+    def test_retry_task_calls_process_existing_file(self):
+        """After failure, the requeued task (file_id set) must route to
+        process_existing_file — not to process_file which re-runs dedup."""
+        from app.services.background_tasks import TaskItem
+
+        bp = BackgroundProcessor(retry_delay=0)
+        bp.processor = MagicMock()
+        bp.processor.process_file = AsyncMock()
+        bp.processor.process_existing_file = AsyncMock()
+
+        async def runner():
+            task = TaskItem(
+                file_path="/tmp/x.txt",
+                attempt=1,
+                source="upload",
+                vault_id=1,
+                file_id=99,
+            )
+            await bp._handle_failure(task, "simulated error")
+            retry_task = await bp.queue.get()
+            await bp._process_task(retry_task)
+            bp.queue.task_done()
+
+        asyncio.run(runner())
+        bp.processor.process_existing_file.assert_awaited_once_with(
+            file_id=99, file_path="/tmp/x.txt", vault_id=1
+        )
+        bp.processor.process_file.assert_not_awaited()
+
+    def test_none_file_id_stays_none_in_retry(self):
+        """Legacy scan/email tasks (file_id=None) must also stay None after retry."""
+        from app.services.background_tasks import TaskItem
+
+        bp = BackgroundProcessor(retry_delay=0)
+
+        async def runner():
+            task = TaskItem(
+                file_path="/tmp/scan.txt",
+                attempt=1,
+                source="scan",
+                vault_id=1,
+                file_id=None,
+            )
+            await bp._handle_failure(task, "simulated error")
+            return await bp.queue.get()
+
+        retry_task = asyncio.run(runner())
+        self.assertIsNone(retry_task.file_id)
+
+
+class TestAdminRetryPassesFileId(unittest.TestCase):
+    """Admin retry route must pass file_id to enqueue so the worker does not
+    re-run duplicate detection on the already-existing files row."""
+
+    def test_retry_document_enqueue_includes_file_id(self):
+        import inspect
+
+        from app.api.routes.documents import retry_document
+
+        source = inspect.getsource(retry_document)
+        self.assertIn(
+            "file_id=file_id",
+            source,
+            "retry_document must pass file_id=file_id to background_processor.enqueue",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_settings_curator.py
+++ b/backend/tests/test_settings_curator.py
@@ -1,0 +1,450 @@
+"""PR B: tests for the expanded settings backend.
+
+Covers:
+  - GET /settings exposes the new wiki + curator fields and an
+    ``effective_sources`` map keyed by ALLOWED_FIELDS.
+  - PUT /settings persists the new fields and they survive reload.
+  - PUT /settings rejects (422) when curator is enabled but URL or model
+    is missing.
+  - Pydantic validators enforce numeric/enum bounds on curator fields.
+  - SSRF guard: curator URLs that resolve to RFC1918 / loopback / link-
+    local are rejected unless ALLOW_LOCAL_CURATOR=1.
+  - POST /settings/curator/test returns the contract shape
+    {ok, model, latency_ms, error?} including the explicit local-model
+    UX hint when SSRF blocks.
+  - effective_sources reports kv > env > default.
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from queue import Empty, Queue
+from unittest.mock import MagicMock
+
+# Ensure backend importable.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Shared optional-dep stubs (mirrors test_documents_auth.py).
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    import types
+
+    _u = types.ModuleType("unstructured")
+    _u.__path__ = []
+    _u.partition = types.ModuleType("unstructured.partition")
+    _u.partition.__path__ = []
+    _u.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _u.partition.auto.partition = lambda *a, **k: []
+    _u.chunking = types.ModuleType("unstructured.chunking")
+    _u.chunking.__path__ = []
+    _u.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _u.chunking.title.chunk_by_title = lambda *a, **k: []
+    _u.documents = types.ModuleType("unstructured.documents")
+    _u.documents.__path__ = []
+    _u.documents.elements = types.ModuleType("unstructured.documents.elements")
+    _u.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _u
+    sys.modules["unstructured.partition"] = _u.partition
+    sys.modules["unstructured.partition.auto"] = _u.partition.auto
+    sys.modules["unstructured.chunking"] = _u.chunking
+    sys.modules["unstructured.chunking.title"] = _u.chunking.title
+    sys.modules["unstructured.documents"] = _u.documents
+    sys.modules["unstructured.documents.elements"] = _u.documents.elements
+
+from app.config import settings
+from app.models.database import init_db, run_migrations
+from app.services.curator_ssrf import CuratorURLBlocked, assert_curator_url_safe
+
+
+class _SimplePool:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self._pool = Queue(maxsize=5)
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def get_connection(self):
+        if self._closed:
+            raise RuntimeError("Pool closed")
+        try:
+            return self._pool.get_nowait()
+        except Empty:
+            return self._create_connection()
+
+    def _create_connection(self):
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def release_connection(self, conn):
+        if not self._closed:
+            try:
+                self._pool.put_nowait(conn)
+            except Exception:
+                conn.close()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def connection(self):
+        conn = self.get_connection()
+        try:
+            yield conn
+        finally:
+            self.release_connection(conn)
+
+    def close_all(self):
+        self._closed = True
+        while True:
+            try:
+                conn = self._pool.get_nowait()
+                conn.close()
+            except Empty:
+                break
+
+
+# ---------------------------------------------------------------------------
+# Pure-unit tests for SSRF guard. No HTTP.
+# ---------------------------------------------------------------------------
+
+
+class TestCuratorSSRFGuard(unittest.TestCase):
+    def setUp(self):
+        # Default-deny.
+        os.environ.pop("ALLOW_LOCAL_CURATOR", None)
+
+    def tearDown(self):
+        os.environ.pop("ALLOW_LOCAL_CURATOR", None)
+
+    def test_empty_url_rejected(self):
+        with self.assertRaises(CuratorURLBlocked):
+            assert_curator_url_safe("")
+        with self.assertRaises(CuratorURLBlocked):
+            assert_curator_url_safe("   ")
+
+    def test_non_http_scheme_rejected(self):
+        for u in (
+            "file:///etc/passwd",
+            "ftp://example.com/",
+            "javascript:alert(1)",
+            "gopher://localhost/",
+        ):
+            with self.assertRaises(CuratorURLBlocked, msg=u):
+                assert_curator_url_safe(u)
+
+    def test_credentials_in_url_rejected(self):
+        with self.assertRaises(CuratorURLBlocked):
+            assert_curator_url_safe("http://user:pw@public.example.com/")
+
+    def test_loopback_blocked_by_default(self):
+        for u in (
+            "http://127.0.0.1:8080/",
+            "http://localhost/",
+            "http://[::1]/",
+        ):
+            with self.assertRaises(CuratorURLBlocked, msg=u) as ctx:
+                assert_curator_url_safe(u)
+            # Public-facing UX hint must mention the env var so operators
+            # know how to opt in.
+            self.assertIn("ALLOW_LOCAL_CURATOR=1", str(ctx.exception))
+
+    def test_rfc1918_blocked_by_default(self):
+        for ip in ("10.1.2.3", "192.168.1.1", "172.16.0.5"):
+            with self.assertRaises(CuratorURLBlocked, msg=ip):
+                assert_curator_url_safe(f"http://{ip}/")
+
+    def test_loopback_allowed_with_opt_in(self):
+        os.environ["ALLOW_LOCAL_CURATOR"] = "1"
+        # Should not raise.
+        assert_curator_url_safe("http://127.0.0.1:11434/v1/chat/completions")
+        assert_curator_url_safe("http://localhost:8080/")
+        assert_curator_url_safe("http://[::1]:80/")
+
+    def test_public_ip_allowed(self):
+        # 1.1.1.1 is public.
+        assert_curator_url_safe("https://1.1.1.1/v1/chat/completions")
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level tests for the new settings shape and curator-test endpoint.
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsExpansion(unittest.TestCase):
+    def setUp(self):
+        from fastapi.testclient import TestClient
+
+        from app.api.deps import get_db, get_db_pool
+        from app.main import app
+        from app.services.auth_service import create_access_token, hash_password
+
+        self.app = app
+        self.create_token = create_access_token
+        self.hash_password = hash_password
+
+        self.tmp = tempfile.mkdtemp()
+        self._original_data_dir = settings.data_dir
+        self._original_jwt = settings.jwt_secret_key
+        self._original_users = settings.users_enabled
+        settings.data_dir = Path(self.tmp)
+        settings.users_enabled = True
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        # Snapshot curator-related settings so each test is isolated.
+        self._curator_snapshot = {
+            f: getattr(settings, f)
+            for f in (
+                "wiki_llm_curator_enabled",
+                "wiki_llm_curator_url",
+                "wiki_llm_curator_model",
+                "wiki_llm_curator_temperature",
+                "wiki_llm_curator_max_input_chars",
+                "wiki_llm_curator_max_output_tokens",
+                "wiki_llm_curator_timeout_sec",
+                "wiki_llm_curator_concurrency",
+                "wiki_llm_curator_mode",
+                "wiki_llm_curator_require_quote_match",
+                "wiki_llm_curator_require_chunk_id",
+                "wiki_llm_curator_run_on_ingest",
+                "wiki_llm_curator_run_on_query",
+                "wiki_llm_curator_run_on_manual",
+                "wiki_enabled",
+                "wiki_compile_on_ingest",
+                "wiki_compile_on_query",
+                "wiki_compile_after_indexing",
+                "wiki_lint_enabled",
+            )
+        }
+        os.environ.pop("ALLOW_LOCAL_CURATOR", None)
+
+        self.db = str(Path(self.tmp) / "app.db")
+
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        with _pool_cache_lock:
+            for _, p in list(_pool_cache.items()):
+                p.close_all()
+            _pool_cache.clear()
+
+        run_migrations(self.db)
+        self.pool = _SimplePool(self.db)
+
+        def override_db():
+            conn = self.pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.pool.release_connection(conn)
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_db_pool] = lambda: self.pool
+
+        # Seed an admin user.
+        conn = self.pool.get_connection()
+        try:
+            conn.execute("DELETE FROM users WHERE id != 0")
+            pw = self.hash_password("pw")
+            conn.execute(
+                "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (1, 'admin1', ?, 'Admin', 'admin', 1)",
+                (pw,),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        self.client = TestClient(app)
+        self.token = self.create_token(1, "admin1", "admin")
+
+    def tearDown(self):
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        self.app.dependency_overrides.clear()
+        with _pool_cache_lock:
+            for _, p in list(_pool_cache.items()):
+                p.close_all()
+            _pool_cache.clear()
+        self.pool.close_all()
+        # Restore curator settings so tests don't bleed.
+        for f, v in self._curator_snapshot.items():
+            setattr(settings, f, v)
+        settings.data_dir = self._original_data_dir
+        settings.jwt_secret_key = self._original_jwt
+        settings.users_enabled = self._original_users
+        os.environ.pop("ALLOW_LOCAL_CURATOR", None)
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _hdr(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def test_get_settings_includes_wiki_and_curator_fields_and_effective_sources(self):
+        r = self.client.get("/api/settings", headers=self._hdr())
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        # Wiki fields
+        for f in (
+            "wiki_enabled",
+            "wiki_compile_on_ingest",
+            "wiki_compile_on_query",
+            "wiki_compile_after_indexing",
+            "wiki_lint_enabled",
+        ):
+            self.assertIn(f, body)
+        # Curator fields
+        for f in (
+            "wiki_llm_curator_enabled",
+            "wiki_llm_curator_url",
+            "wiki_llm_curator_model",
+            "wiki_llm_curator_temperature",
+            "wiki_llm_curator_max_input_chars",
+            "wiki_llm_curator_max_output_tokens",
+            "wiki_llm_curator_timeout_sec",
+            "wiki_llm_curator_concurrency",
+            "wiki_llm_curator_mode",
+            "wiki_llm_curator_require_quote_match",
+            "wiki_llm_curator_require_chunk_id",
+            "wiki_llm_curator_run_on_ingest",
+            "wiki_llm_curator_run_on_query",
+            "wiki_llm_curator_run_on_manual",
+        ):
+            self.assertIn(f, body)
+        # Curator off by default
+        self.assertFalse(body["wiki_llm_curator_enabled"])
+        # effective_sources map present and well-formed
+        es = body.get("effective_sources")
+        self.assertIsInstance(es, dict)
+        self.assertIn("wiki_llm_curator_enabled", es)
+        self.assertIn(es["wiki_llm_curator_enabled"], ("kv", "env", "default"))
+
+    def test_put_persists_curator_fields_and_round_trips(self):
+        # Save curator settings (disabled) along with chosen URL/model.
+        body = {
+            "wiki_llm_curator_enabled": False,
+            "wiki_llm_curator_url": "https://api.example.com",
+            "wiki_llm_curator_model": "qwen-1b",
+            "wiki_llm_curator_temperature": 0.0,
+            "wiki_llm_curator_mode": "draft",
+        }
+        r = self.client.put("/api/settings", headers=self._hdr(), json=body)
+        self.assertEqual(r.status_code, 200, r.text)
+        # Reload and confirm round-trip.
+        r2 = self.client.get("/api/settings", headers=self._hdr())
+        self.assertEqual(r2.status_code, 200, r2.text)
+        data = r2.json()
+        self.assertEqual(data["wiki_llm_curator_url"], "https://api.example.com")
+        self.assertEqual(data["wiki_llm_curator_model"], "qwen-1b")
+        self.assertEqual(data["wiki_llm_curator_mode"], "draft")
+        # effective_sources marks them as kv after PUT.
+        self.assertEqual(
+            data["effective_sources"]["wiki_llm_curator_url"], "kv"
+        )
+
+    def test_put_rejects_curator_enabled_without_url_or_model(self):
+        body = {
+            "wiki_llm_curator_enabled": True,
+            # url and model intentionally omitted.
+        }
+        r = self.client.put("/api/settings", headers=self._hdr(), json=body)
+        self.assertEqual(r.status_code, 422, r.text)
+        detail = r.json().get("detail", "")
+        self.assertIn("wiki_llm_curator_url", str(detail))
+        self.assertIn("wiki_llm_curator_model", str(detail))
+
+    def test_put_rejects_invalid_curator_temperature(self):
+        body = {"wiki_llm_curator_temperature": 2.5}
+        r = self.client.put("/api/settings", headers=self._hdr(), json=body)
+        self.assertEqual(r.status_code, 422, r.text)
+
+    def test_put_rejects_invalid_curator_mode(self):
+        body = {"wiki_llm_curator_mode": "yolo"}
+        r = self.client.put("/api/settings", headers=self._hdr(), json=body)
+        self.assertEqual(r.status_code, 422, r.text)
+
+    def test_put_rejects_invalid_curator_concurrency(self):
+        body = {"wiki_llm_curator_concurrency": 99}
+        r = self.client.put("/api/settings", headers=self._hdr(), json=body)
+        self.assertEqual(r.status_code, 422, r.text)
+
+    def test_curator_test_endpoint_blocks_loopback_without_opt_in(self):
+        body = {"url": "http://127.0.0.1:11434", "model": "qwen"}
+        r = self.client.post(
+            "/api/settings/curator/test", headers=self._hdr(), json=body
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        out = r.json()
+        self.assertFalse(out["ok"])
+        self.assertIn("ALLOW_LOCAL_CURATOR=1", out["error"])
+
+    def test_curator_test_endpoint_requires_url_and_model(self):
+        body = {"url": "", "model": ""}
+        r = self.client.post(
+            "/api/settings/curator/test", headers=self._hdr(), json=body
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        out = r.json()
+        self.assertFalse(out["ok"])
+        self.assertIn("required", out["error"].lower())
+
+    def test_effective_sources_treats_empty_env_var_as_default(self):
+        """Critic Fix #4: ``X=""`` must NOT be labelled "env" since
+        Pydantic falls back to the field default for empty strings.
+        Otherwise the Models tab would mislead operators."""
+        # Pick a field that has no kv override on this fresh DB.
+        os.environ["RERANKER_URL"] = ""
+        try:
+            r = self.client.get("/api/settings", headers=self._hdr())
+            self.assertEqual(r.status_code, 200, r.text)
+            es = r.json()["effective_sources"]
+            self.assertEqual(es["reranker_url"], "default")
+        finally:
+            os.environ.pop("RERANKER_URL", None)
+
+    def test_curator_test_endpoint_requires_admin(self):
+        """Reviewer Fix #2: non-admin must NOT reach the curator-test
+        endpoint. Otherwise any authenticated viewer can probe outbound
+        URLs and exfiltrate latency / model info."""
+        # Seed a viewer-role user.
+        conn = self.pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (9, 'viewer1', ?, 'V', 'viewer', 1)",
+                (self.hash_password("pw"),),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+        viewer_token = self.create_token(9, "viewer1", "viewer")
+        body = {"url": "https://api.example.com", "model": "qwen"}
+        r = self.client.post(
+            "/api/settings/curator/test",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+            json=body,
+        )
+        # require_role("admin") returns 403 (forbidden) for non-admins.
+        self.assertEqual(r.status_code, 403, r.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_wiki_curator.py
+++ b/backend/tests/test_wiki_curator.py
@@ -1,0 +1,1209 @@
+"""PR C: tests for the optional LLM Wiki Curator.
+
+Covers:
+  - The wiki_claims migration widens status CHECK to include
+    'needs_review', adds created_by_kind, and preserves FTS triggers.
+  - WikiCurator verification: source_quote substring + rapidfuzz fuzzy
+    match; missing quote / wrong chunk_id / quote_mismatch all
+    rejected; mode 'draft' stamps needs_review even on quote match.
+  - Compiler integration: curator disabled => no calls. Curator enabled
+    + ingest flag false => no calls. Curator enabled + ingest flag true
+    => candidates flow through. Curator failures never fail the job.
+  - extract_json handles strict / fenced / trailing-prose JSON.
+  - PUT /wiki/claims with status=active on a curator claim re-verifies
+    the source_quote and 400s on mismatch.
+  - SSRF guard fires inside CuratorClient.propose, not just settings.
+"""
+
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from queue import Empty, Queue
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Shared optional-dep stubs.
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    import types
+    _u = types.ModuleType("unstructured")
+    _u.__path__ = []
+    _u.partition = types.ModuleType("unstructured.partition")
+    _u.partition.__path__ = []
+    _u.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _u.partition.auto.partition = lambda *a, **k: []
+    _u.chunking = types.ModuleType("unstructured.chunking")
+    _u.chunking.__path__ = []
+    _u.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _u.chunking.title.chunk_by_title = lambda *a, **k: []
+    _u.documents = types.ModuleType("unstructured.documents")
+    _u.documents.__path__ = []
+    _u.documents.elements = types.ModuleType("unstructured.documents.elements")
+    _u.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _u
+    sys.modules["unstructured.partition"] = _u.partition
+    sys.modules["unstructured.partition.auto"] = _u.partition.auto
+    sys.modules["unstructured.chunking"] = _u.chunking
+    sys.modules["unstructured.chunking.title"] = _u.chunking.title
+    sys.modules["unstructured.documents"] = _u.documents
+    sys.modules["unstructured.documents.elements"] = _u.documents.elements
+
+from app.config import settings
+from app.models.database import (
+    init_db,
+    migrate_add_curator_claim_support,
+    run_migrations,
+)
+from app.services.wiki_curator import (
+    CuratorChunk,
+    WikiCurator,
+    _quote_matches,
+    deterministic_dedupe_key,
+)
+from app.services.wiki_curator_client import (
+    CuratorClient,
+    extract_json,
+)
+from app.services.wiki_store import WikiStore
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCuratorClaimMigration(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "app.db")
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        os.rmdir(self.tmp)
+
+    def test_fresh_init_includes_widened_check_and_new_column(self):
+        # Fresh init via run_migrations triggers init_db (SCHEMA) +
+        # migrate_add_wiki_tables (which now also includes the new
+        # columns) + the explicit migrate_add_curator_claim_support.
+        run_migrations(self.db)
+        conn = sqlite3.connect(self.db)
+        try:
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()
+            }
+            self.assertIn("created_by_kind", cols)
+            # 'needs_review' must be writable.
+            conn.execute(
+                "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+                "VALUES (1, 't', 'document', 'needs_review')"
+            )
+            conn.commit()
+            # And every other valid status.
+            for s in ("active", "contradicted", "superseded", "unverified", "archived"):
+                conn.execute(
+                    "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+                    "VALUES (1, ?, 'document', ?)",
+                    (f"t_{s}", s),
+                )
+            conn.commit()
+            # Forbidden status must still fail.
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+                    "VALUES (1, 'bad', 'document', 'invalid_status')"
+                )
+            conn.rollback()
+        finally:
+            conn.close()
+
+    def test_migration_idempotent(self):
+        # First run via run_migrations.
+        run_migrations(self.db)
+        # Second explicit call must be a no-op.
+        migrate_add_curator_claim_support(self.db)
+        # Still fine.
+        conn = sqlite3.connect(self.db)
+        try:
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()
+            }
+            self.assertIn("created_by_kind", cols)
+        finally:
+            conn.close()
+
+    def test_upgrade_path_preserves_fk_cascades(self):
+        """Reviewer Fix #1 (CRITICAL): construct the pre-PR-C schema
+        directly and run the migration. After the swap, deleting a
+        wiki_claims row MUST cascade to wiki_claim_sources and
+        wiki_relations. Without ``legacy_alter_table=ON`` SQLite
+        rewrites the child FK references to point at wiki_claims_old,
+        and after the DROP the cascade silently no-ops."""
+        # Build the pre-PR-C schema by hand.
+        conn = sqlite3.connect(self.db, isolation_level=None)
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.executescript(
+                """
+                CREATE TABLE wiki_pages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL,
+                    slug TEXT, title TEXT, page_type TEXT, markdown TEXT,
+                    summary TEXT, status TEXT, confidence REAL,
+                    created_by INTEGER, created_at TIMESTAMP, updated_at TIMESTAMP
+                );
+                -- Pre-PR-C wiki_claims: status CHECK does NOT include
+                -- needs_review and there is no created_by_kind column.
+                CREATE TABLE wiki_claims (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL,
+                    page_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
+                    claim_text TEXT NOT NULL,
+                    claim_type TEXT NOT NULL DEFAULT 'fact',
+                    subject TEXT, predicate TEXT, object TEXT,
+                    source_type TEXT NOT NULL CHECK (source_type IN (
+                        'document','memory','chat_synthesis','manual','mixed')),
+                    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active','contradicted','superseded','unverified','archived')),
+                    confidence REAL DEFAULT 0.0,
+                    created_by INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE TABLE wiki_claim_sources (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    claim_id INTEGER NOT NULL REFERENCES wiki_claims(id) ON DELETE CASCADE,
+                    source_kind TEXT NOT NULL,
+                    file_id INTEGER, chunk_id TEXT, source_label TEXT,
+                    quote TEXT
+                );
+                CREATE TABLE wiki_relations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL,
+                    subject_entity_id INTEGER,
+                    predicate TEXT, object_entity_id INTEGER, object_text TEXT,
+                    claim_id INTEGER REFERENCES wiki_claims(id) ON DELETE CASCADE,
+                    confidence REAL DEFAULT 0.0
+                );
+                CREATE VIRTUAL TABLE wiki_claims_fts USING fts5(
+                    claim_text, subject, predicate, object,
+                    content='wiki_claims', content_rowid='id'
+                );
+                CREATE TRIGGER wiki_claims_fts_insert AFTER INSERT ON wiki_claims BEGIN
+                    INSERT INTO wiki_claims_fts(rowid, claim_text, subject, predicate, object)
+                    VALUES (new.id, new.claim_text, new.subject, new.predicate, new.object);
+                END;
+                CREATE TRIGGER wiki_claims_fts_delete AFTER DELETE ON wiki_claims BEGIN
+                    INSERT INTO wiki_claims_fts(wiki_claims_fts, rowid, claim_text, subject, predicate, object)
+                    VALUES ('delete', old.id, old.claim_text, old.subject, old.predicate, old.object);
+                END;
+                CREATE TRIGGER wiki_claims_fts_update AFTER UPDATE ON wiki_claims BEGIN
+                    INSERT INTO wiki_claims_fts(wiki_claims_fts, rowid, claim_text, subject, predicate, object)
+                    VALUES ('delete', old.id, old.claim_text, old.subject, old.predicate, old.object);
+                    INSERT INTO wiki_claims_fts(rowid, claim_text, subject, predicate, object)
+                    VALUES (new.id, new.claim_text, new.subject, new.predicate, new.object);
+                END;
+                """
+            )
+            # Seed a claim + source row + relation that should cascade.
+            conn.execute(
+                "INSERT INTO wiki_claims (id, vault_id, claim_text, source_type, status) "
+                "VALUES (1, 1, 'Alice founded the company', 'document', 'active')"
+            )
+            conn.execute(
+                "INSERT INTO wiki_claim_sources (claim_id, source_kind, quote) "
+                "VALUES (1, 'document', 'Alice founded the company')"
+            )
+            conn.execute(
+                "INSERT INTO wiki_relations (vault_id, predicate, claim_id) "
+                "VALUES (1, 'founded', 1)"
+            )
+            # Sanity: cascade works pre-migration.
+            conn.execute("PRAGMA foreign_keys = ON")
+        finally:
+            conn.close()
+
+        # Run the migration against the pre-PR-C schema.
+        migrate_add_curator_claim_support(self.db)
+
+        # Re-open and verify (a) the new column / status work, (b) the
+        # FK references in dependent tables still point at wiki_claims
+        # (NOT wiki_claims_old), (c) cascades fire end to end, (d)
+        # foreign_key_check is clean.
+        conn = sqlite3.connect(self.db, isolation_level=None)
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()
+            }
+            self.assertIn("created_by_kind", cols)
+            # FK target is the canonical name, not wiki_claims_old.
+            for child in ("wiki_claim_sources", "wiki_relations"):
+                fks = conn.execute(f"PRAGMA foreign_key_list({child})").fetchall()
+                ref_tables = {row[2] for row in fks}
+                self.assertIn(
+                    "wiki_claims",
+                    ref_tables,
+                    f"{child} FK should reference wiki_claims, got {ref_tables}",
+                )
+                self.assertNotIn(
+                    "wiki_claims_old",
+                    ref_tables,
+                    f"{child} FK still points at wiki_claims_old after migration",
+                )
+            # Cascade integrity check.
+            self.assertEqual([], conn.execute("PRAGMA foreign_key_check").fetchall())
+            # Now actually delete the parent and ensure the cascade runs.
+            conn.execute("DELETE FROM wiki_claims WHERE id = 1")
+            self.assertEqual(
+                [], conn.execute("SELECT * FROM wiki_claim_sources").fetchall()
+            )
+            self.assertEqual(
+                [], conn.execute("SELECT * FROM wiki_relations").fetchall()
+            )
+        finally:
+            conn.close()
+
+    def test_recovery_drops_stale_old_table_alongside_pre_pr_c_new_table(self):
+        """Critic Fix #1 (LOW): if a previous run somehow left
+        ``wiki_claims_old`` lingering AND ``wiki_claims`` is still in
+        the pre-PR-C shape, the next run must drop the stale old table
+        before re-renaming, otherwise ALTER TABLE fails with
+        'table wiki_claims_old already exists'."""
+        conn = sqlite3.connect(self.db, isolation_level=None)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE wiki_pages (id INTEGER PRIMARY KEY);
+                CREATE TABLE wiki_claims (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL,
+                    page_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
+                    claim_text TEXT NOT NULL,
+                    claim_type TEXT NOT NULL DEFAULT 'fact',
+                    subject TEXT, predicate TEXT, object TEXT,
+                    source_type TEXT NOT NULL CHECK (source_type IN (
+                        'document','memory','chat_synthesis','manual','mixed')),
+                    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active','contradicted','superseded','unverified','archived')),
+                    confidence REAL DEFAULT 0.0,
+                    created_by INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+                -- Stale wiki_claims_old left behind by a prior crash.
+                CREATE TABLE wiki_claims_old (
+                    id INTEGER PRIMARY KEY,
+                    vault_id INTEGER NOT NULL,
+                    claim_text TEXT NOT NULL,
+                    claim_type TEXT NOT NULL DEFAULT 'fact',
+                    source_type TEXT NOT NULL CHECK (source_type IN (
+                        'document','memory','chat_synthesis','manual','mixed')),
+                    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active','contradicted','superseded','unverified','archived')),
+                    confidence REAL DEFAULT 0.0,
+                    created_by INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE TABLE wiki_claim_sources (
+                    id INTEGER PRIMARY KEY,
+                    claim_id INTEGER NOT NULL REFERENCES wiki_claims(id) ON DELETE CASCADE
+                );
+                CREATE TABLE wiki_relations (
+                    id INTEGER PRIMARY KEY,
+                    vault_id INTEGER, predicate TEXT,
+                    claim_id INTEGER REFERENCES wiki_claims(id) ON DELETE CASCADE
+                );
+                CREATE VIRTUAL TABLE wiki_claims_fts USING fts5(
+                    claim_text, subject, predicate, object,
+                    content='wiki_claims', content_rowid='id'
+                );
+                """
+            )
+            # Seed a row in the live table; stale table can stay empty.
+            conn.execute(
+                "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+                "VALUES (1, 'live row', 'document', 'active')"
+            )
+        finally:
+            conn.close()
+
+        # Should NOT raise — the migration must drop the stale table first.
+        migrate_add_curator_claim_support(self.db)
+
+        conn = sqlite3.connect(self.db)
+        try:
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()
+            }
+            self.assertIn("created_by_kind", cols)
+            # Stale table is gone.
+            old = conn.execute(
+                "SELECT name FROM sqlite_master WHERE name='wiki_claims_old'"
+            ).fetchone()
+            self.assertIsNone(old)
+            # Live row preserved.
+            self.assertEqual(
+                conn.execute(
+                    "SELECT claim_text FROM wiki_claims WHERE claim_text='live row'"
+                ).fetchone()[0],
+                "live row",
+            )
+        finally:
+            conn.close()
+
+    def test_upgrade_path_recovers_from_interrupted_rename(self):
+        """Reviewer Fix #3 (HIGH): if a previous run died after the
+        rename but before the new CREATE TABLE, ``wiki_claims_old`` is
+        present and ``wiki_claims`` is missing. The migration must
+        detect this and restore ``wiki_claims`` by renaming back."""
+        # Pre-create a stub wiki_claims_old (mimicking a crash after
+        # rename). No wiki_claims present.
+        conn = sqlite3.connect(self.db, isolation_level=None)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE wiki_pages (id INTEGER PRIMARY KEY);
+                CREATE TABLE wiki_claims_old (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL,
+                    page_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
+                    claim_text TEXT NOT NULL,
+                    claim_type TEXT NOT NULL DEFAULT 'fact',
+                    subject TEXT, predicate TEXT, object TEXT,
+                    source_type TEXT NOT NULL CHECK (source_type IN (
+                        'document','memory','chat_synthesis','manual','mixed')),
+                    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active','contradicted','superseded','unverified','archived')),
+                    confidence REAL DEFAULT 0.0,
+                    created_by INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE TABLE wiki_claim_sources (
+                    id INTEGER PRIMARY KEY,
+                    claim_id INTEGER NOT NULL REFERENCES wiki_claims(id) ON DELETE CASCADE
+                );
+                CREATE TABLE wiki_relations (
+                    id INTEGER PRIMARY KEY,
+                    vault_id INTEGER, predicate TEXT,
+                    claim_id INTEGER REFERENCES wiki_claims(id) ON DELETE CASCADE
+                );
+                CREATE VIRTUAL TABLE wiki_claims_fts USING fts5(
+                    claim_text, subject, predicate, object
+                );
+                """
+            )
+            conn.execute(
+                "INSERT INTO wiki_claims_old (vault_id, claim_text, source_type, status) "
+                "VALUES (1, 'recovered', 'document', 'active')"
+            )
+        finally:
+            conn.close()
+
+        migrate_add_curator_claim_support(self.db)
+        # After recovery the data should land in wiki_claims with the
+        # new column and the old table should be gone.
+        conn = sqlite3.connect(self.db)
+        try:
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()
+            }
+            self.assertIn("created_by_kind", cols)
+            rows = conn.execute(
+                "SELECT claim_text FROM wiki_claims WHERE claim_text = 'recovered'"
+            ).fetchall()
+            self.assertEqual(len(rows), 1)
+            old = conn.execute(
+                "SELECT name FROM sqlite_master WHERE name='wiki_claims_old'"
+            ).fetchone()
+            self.assertIsNone(old)
+        finally:
+            conn.close()
+
+    def test_fts_search_works_after_migration(self):
+        run_migrations(self.db)
+        conn = sqlite3.connect(self.db)
+        try:
+            cur = conn.execute(
+                "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+                "VALUES (1, 'CEO Alice founded the company', 'document', 'active')"
+            )
+            conn.commit()
+            cid = cur.lastrowid
+            # FTS triggers should populate the FTS table.
+            rows = conn.execute(
+                "SELECT rowid FROM wiki_claims_fts WHERE wiki_claims_fts MATCH 'Alice'"
+            ).fetchall()
+            self.assertTrue(any(r[0] == cid for r in rows))
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJson(unittest.TestCase):
+    def test_strict(self):
+        self.assertEqual(extract_json('{"a": 1}'), {"a": 1})
+
+    def test_fenced_json_block(self):
+        text = "Sure!\n```json\n{\"a\": [1,2]}\n```\nDone."
+        self.assertEqual(extract_json(text), {"a": [1, 2]})
+
+    def test_trailing_prose(self):
+        text = '{"a": 1}\n\nLet me know if anything else is needed.'
+        self.assertEqual(extract_json(text), {"a": 1})
+
+    def test_garbage(self):
+        self.assertIsNone(extract_json("hello world"))
+        self.assertIsNone(extract_json(""))
+
+    def test_balanced_brace_with_strings_containing_braces(self):
+        text = 'prefix {"a": "x{y}z"} suffix'
+        self.assertEqual(extract_json(text), {"a": "x{y}z"})
+
+    def test_balanced_brace_with_escaped_quotes(self):
+        # The harder case: a JSON string field containing an escaped
+        # double-quote. The scanner must track escape state so it
+        # doesn't think the string ends mid-content.
+        text = r'prefix {"a": "has \"quote\" inside"} suffix'
+        self.assertEqual(extract_json(text), {"a": 'has "quote" inside'})
+
+    def test_balanced_brace_with_brace_after_escaped_quote(self):
+        # A `}` inside a string that ends with `\"` — the scanner must
+        # leave string mode AT the closing real quote, not at the
+        # escaped one.
+        text = r'{"a": "ends with \"x\" }", "b": 1} trailing'
+        self.assertEqual(extract_json(text), {"a": 'ends with "x" }', "b": 1})
+
+
+# ---------------------------------------------------------------------------
+# Quote verification
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteMatches(unittest.TestCase):
+    def test_exact_substring(self):
+        self.assertTrue(_quote_matches("hello world", "say hello world to me"))
+
+    def test_whitespace_normalized(self):
+        self.assertTrue(_quote_matches("hello   world", "say hello world to me"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(_quote_matches("Hello World", "say hello world to me"))
+
+    def test_fuzzy_above_threshold(self):
+        # 1 typo out of 11 chars — partial_ratio ~95
+        self.assertTrue(
+            _quote_matches("hello wrold", "say hello world to me", fuzzy_threshold=85)
+        )
+
+    def test_unrelated_quote_rejected(self):
+        self.assertFalse(_quote_matches("foo bar baz", "completely different text"))
+
+    def test_empty_inputs(self):
+        self.assertFalse(_quote_matches("", "anything"))
+        self.assertFalse(_quote_matches("anything", ""))
+
+
+# ---------------------------------------------------------------------------
+# WikiCurator verification logic (no real HTTP)
+# ---------------------------------------------------------------------------
+
+
+class _StubClient:
+    """Fake CuratorClient.propose returning a canned string.
+
+    We don't need a real httpx server; the verification logic happens
+    after the JSON is parsed. Stubbing at this boundary keeps tests
+    fast and deterministic.
+    """
+
+    def __init__(self, payload: str, *, raise_exc: Exception = None):
+        self.payload = payload
+        self.raise_exc = raise_exc
+        self.calls = 0
+
+    async def propose(self, *_args, **_kwargs):
+        self.calls += 1
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return self.payload
+
+
+class TestWikiCurator(unittest.TestCase):
+    def setUp(self):
+        # Snapshot + override curator settings per test for isolation.
+        self._snap = {
+            f: getattr(settings, f)
+            for f in (
+                "wiki_llm_curator_enabled",
+                "wiki_llm_curator_url",
+                "wiki_llm_curator_model",
+                "wiki_llm_curator_mode",
+                "wiki_llm_curator_require_quote_match",
+                "wiki_llm_curator_require_chunk_id",
+                "wiki_llm_curator_max_input_chars",
+            )
+        }
+        settings.wiki_llm_curator_enabled = True
+        settings.wiki_llm_curator_url = "https://api.example.com"
+        settings.wiki_llm_curator_model = "qwen-1b"
+        settings.wiki_llm_curator_mode = "active_if_verified"
+        settings.wiki_llm_curator_require_quote_match = True
+        settings.wiki_llm_curator_require_chunk_id = True
+        settings.wiki_llm_curator_max_input_chars = 6000
+
+    def tearDown(self):
+        for f, v in self._snap.items():
+            setattr(settings, f, v)
+
+    def _curator(self, payload: str, *, raise_exc=None) -> WikiCurator:
+        return WikiCurator(client=_StubClient(payload, raise_exc=raise_exc))
+
+    def _chunks(self) -> list[CuratorChunk]:
+        return [
+            CuratorChunk(
+                chunk_id="42_0",
+                source_text="Alice founded the company. Bob is the CTO.",
+                file_id=42,
+                source_label="file:42",
+            )
+        ]
+
+    def test_accepts_when_quote_matches_chunk(self):
+        payload = json.dumps({
+            "claims": [
+                {
+                    "claim_text": "Alice founded the company",
+                    "claim_type": "fact",
+                    "subject": "Alice",
+                    "predicate": "founded",
+                    "object": "the company",
+                    "source_quote": "Alice founded the company",
+                    "chunk_id": "42_0",
+                    "confidence": 0.9,
+                }
+            ]
+        })
+        cur = self._curator(payload)
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 1)
+        self.assertEqual(out.accepted[0].status, "active")  # mode=active_if_verified
+        self.assertEqual(out.accepted[0].chunk_id, "42_0")
+        self.assertEqual(out.accepted[0].file_id, 42)
+        self.assertEqual(len(out.rejected), 0)
+
+    def test_draft_mode_stamps_needs_review_even_on_quote_match(self):
+        settings.wiki_llm_curator_mode = "draft"
+        payload = json.dumps({
+            "claims": [
+                {
+                    "claim_text": "Bob is the CTO",
+                    "claim_type": "role",
+                    "subject": "Bob",
+                    "predicate": "is",
+                    "object": "the CTO",
+                    "source_quote": "Bob is the CTO",
+                    "chunk_id": "42_0",
+                    "confidence": 0.95,
+                }
+            ]
+        })
+        cur = self._curator(payload)
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 1)
+        self.assertEqual(out.accepted[0].status, "needs_review")
+
+    def test_rejects_missing_quote_and_emits_lint(self):
+        payload = json.dumps({
+            "claims": [
+                {
+                    "claim_text": "An unsupported assertion",
+                    "source_quote": "",
+                    "chunk_id": "42_0",
+                }
+            ]
+        })
+        store = MagicMock()
+        cur = WikiCurator(client=_StubClient(payload), store=store)
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 0)
+        self.assertEqual(len(out.rejected), 1)
+        self.assertEqual(out.rejected[0].reason, "missing_quote")
+        # Lint finding emitted.
+        self.assertEqual(len(out.lint_findings), 1)
+        self.assertEqual(
+            out.lint_findings[0]["finding_type"], "unsupported_claim"
+        )
+
+    def test_rejects_unknown_chunk_id(self):
+        payload = json.dumps({
+            "claims": [
+                {
+                    "claim_text": "x",
+                    "source_quote": "Alice founded the company",
+                    "chunk_id": "999_0",
+                }
+            ]
+        })
+        cur = self._curator(payload)
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 0)
+        self.assertEqual(len(out.rejected), 1)
+        self.assertEqual(out.rejected[0].reason, "missing_chunk_id")
+
+    def test_rejects_quote_mismatch(self):
+        payload = json.dumps({
+            "claims": [
+                {
+                    "claim_text": "x",
+                    "source_quote": "completely fabricated text not in source",
+                    "chunk_id": "42_0",
+                }
+            ]
+        })
+        cur = self._curator(payload)
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 0)
+        self.assertEqual(len(out.rejected), 1)
+        self.assertEqual(out.rejected[0].reason, "quote_mismatch")
+
+    def test_dedupes_against_deterministic_keys(self):
+        payload = json.dumps({
+            "claims": [
+                {
+                    "claim_text": "Alice founded the company",
+                    "subject": "Alice",
+                    "predicate": "founded",
+                    "object": "the company",
+                    "source_quote": "Alice founded the company",
+                    "chunk_id": "42_0",
+                }
+            ]
+        })
+        seed = {
+            deterministic_dedupe_key(
+                "Alice", "founded", "the company", "Alice founded the company"
+            )
+        }
+        cur = self._curator(payload)
+        out = asyncio.run(
+            cur.curate(
+                vault_id=1,
+                file_id=42,
+                chunks=self._chunks(),
+                deterministic_dedupe_keys=seed,
+            )
+        )
+        # Already covered by deterministic — silent drop, no lint.
+        self.assertEqual(len(out.accepted), 0)
+        self.assertEqual(len(out.rejected), 0)
+        self.assertEqual(len(out.lint_findings), 0)
+
+    def test_malformed_json_records_error_no_crash(self):
+        cur = self._curator("not even json")
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 0)
+        self.assertIn("json_parse_failed", out.errors)
+
+    def test_transport_exception_records_error_no_crash(self):
+        cur = self._curator("", raise_exc=RuntimeError("boom"))
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 0)
+        self.assertTrue(any("transport_error" in e for e in out.errors))
+
+    def test_per_chunk_parallelism_uses_concurrency_setting(self):
+        """Reviewer Fix #4 (HIGH): wiki_llm_curator_concurrency must
+        actually bound parallel curator calls. We track concurrent
+        in-flight calls inside a stub and assert it never exceeds the
+        configured cap."""
+        settings.wiki_llm_curator_concurrency = 2
+
+        in_flight = {"now": 0, "max": 0, "calls": 0}
+
+        class _ConcurrencyStub:
+            def __init__(self, payload: str):
+                self.payload = payload
+
+            async def propose(self, *_args, **_kwargs):
+                in_flight["now"] += 1
+                in_flight["calls"] += 1
+                in_flight["max"] = max(in_flight["max"], in_flight["now"])
+                # Yield so other gather() coroutines can interleave.
+                await asyncio.sleep(0.02)
+                in_flight["now"] -= 1
+                return self.payload
+
+        # 5 chunks; with concurrency=2 the stub should observe at most
+        # 2 in-flight calls at any moment.
+        chunks = [
+            CuratorChunk(
+                chunk_id=f"42_{i}",
+                source_text=f"sentence {i}.",
+                file_id=42,
+                source_label="file:42",
+            )
+            for i in range(5)
+        ]
+        payload = json.dumps({"claims": []})
+        cur = WikiCurator(client=_ConcurrencyStub(payload))
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=chunks)
+        )
+        self.assertEqual(out.calls, 5)
+        self.assertEqual(in_flight["calls"], 5)
+        self.assertLessEqual(in_flight["max"], 2)
+        self.assertGreaterEqual(in_flight["max"], 1)
+
+    def test_contradictions_become_lint_only(self):
+        payload = json.dumps({
+            "claims": [],
+            "contradictions": [
+                {
+                    "claim_a": "A says X",
+                    "claim_b": "B says not X",
+                    "reason": "conflict",
+                    "source_quote": "ignored",
+                }
+            ],
+        })
+        cur = self._curator(payload)
+        out = asyncio.run(
+            cur.curate(vault_id=1, file_id=42, chunks=self._chunks())
+        )
+        self.assertEqual(len(out.accepted), 0)
+        self.assertEqual(len(out.lint_findings), 1)
+        self.assertEqual(out.lint_findings[0]["finding_type"], "contradiction")
+
+
+# ---------------------------------------------------------------------------
+# CuratorClient SSRF guard
+# ---------------------------------------------------------------------------
+
+
+class TestCuratorClientSSRF(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("ALLOW_LOCAL_CURATOR", None)
+
+    def tearDown(self):
+        os.environ.pop("ALLOW_LOCAL_CURATOR", None)
+
+    def test_propose_blocks_loopback_without_opt_in(self):
+        from app.services.curator_ssrf import CuratorURLBlocked
+
+        client = CuratorClient(
+            base_url="http://127.0.0.1:11434", model="qwen", timeout=5
+        )
+
+        async def runner():
+            await client.propose([{"role": "user", "content": "hi"}])
+
+        with self.assertRaises(CuratorURLBlocked):
+            asyncio.run(runner())
+
+
+# ---------------------------------------------------------------------------
+# Compiler integration: curator gating
+# ---------------------------------------------------------------------------
+
+
+class TestCompilerCuratorGating(unittest.TestCase):
+    """Sanity: when curator settings disable it, no client construction."""
+
+    def setUp(self):
+        self._snap = {
+            f: getattr(settings, f)
+            for f in (
+                "wiki_llm_curator_enabled",
+                "wiki_llm_curator_run_on_ingest",
+                "wiki_llm_curator_run_on_query",
+                "wiki_llm_curator_run_on_manual",
+                "wiki_llm_curator_url",
+                "wiki_llm_curator_model",
+            )
+        }
+
+    def tearDown(self):
+        for f, v in self._snap.items():
+            setattr(settings, f, v)
+
+    def _patched_compiler(self):
+        # Build a WikiCompiler instance with stubbed db/store. We only
+        # exercise the gate, not the full compile_ingest_job.
+        from app.services.wiki_compiler import WikiCompiler
+
+        store = MagicMock()
+        compiler = WikiCompiler.__new__(WikiCompiler)  # type: ignore
+        compiler._db = MagicMock()
+        compiler._store = store
+        return compiler, store
+
+    def _ext(self):
+        # The deterministic extractor's class name varies; the compiler
+        # only reads .acronyms / .persons / .role_claims, so duck-type.
+        class _E:
+            acronyms: list = []
+            persons: list = []
+            role_claims: list = []
+
+        return _E()
+
+    def test_disabled_curator_returns_none(self):
+        settings.wiki_llm_curator_enabled = False
+        compiler, _ = self._patched_compiler()
+        with patch(
+            "app.services.wiki_compiler.CuratorClient"
+        ) as ctor, patch(
+            "app.services.wiki_compiler.WikiCurator"
+        ) as cur_ctor:
+            res = compiler._maybe_run_curator(
+                vault_id=1,
+                file_id=42,
+                text="text",
+                trigger="ingest",
+                deterministic_extraction=self._ext(),
+                page_id=1,
+                existing_entities=[],
+            )
+        self.assertIsNone(res)
+        ctor.assert_not_called()
+        cur_ctor.assert_not_called()
+
+    def test_enabled_but_query_flag_off_returns_none(self):
+        settings.wiki_llm_curator_enabled = True
+        settings.wiki_llm_curator_url = "https://api.example.com"
+        settings.wiki_llm_curator_model = "qwen-1b"
+        settings.wiki_llm_curator_run_on_query = False
+        compiler, _ = self._patched_compiler()
+        with patch(
+            "app.services.wiki_compiler.CuratorClient"
+        ) as ctor, patch(
+            "app.services.wiki_compiler.WikiCurator"
+        ) as cur_ctor:
+            res = compiler._maybe_run_curator(
+                vault_id=1,
+                file_id=42,
+                text="text",
+                trigger="query",
+                deterministic_extraction=self._ext(),
+                page_id=1,
+                existing_entities=[],
+            )
+        self.assertIsNone(res)
+        ctor.assert_not_called()
+        cur_ctor.assert_not_called()
+
+    def test_enabled_but_url_blank_records_disabled(self):
+        settings.wiki_llm_curator_enabled = True
+        settings.wiki_llm_curator_run_on_ingest = True
+        settings.wiki_llm_curator_url = ""
+        settings.wiki_llm_curator_model = "qwen-1b"
+        compiler, _ = self._patched_compiler()
+        res = compiler._maybe_run_curator(
+            vault_id=1,
+            file_id=42,
+            text="text",
+            trigger="ingest",
+            deterministic_extraction=self._ext(),
+            page_id=1,
+            existing_entities=[],
+        )
+        self.assertIsNotNone(res)
+        self.assertEqual(res["accepted"], 0)
+        self.assertTrue(any("disabled" in e for e in res["errors"]))
+
+
+# ---------------------------------------------------------------------------
+# PUT /wiki/claims re-verification
+# ---------------------------------------------------------------------------
+
+
+class _Pool:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self._pool = Queue(maxsize=5)
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def get_connection(self):
+        if self._closed:
+            raise RuntimeError("Pool closed")
+        try:
+            return self._pool.get_nowait()
+        except Empty:
+            return self._create_connection()
+
+    def _create_connection(self):
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def release_connection(self, conn):
+        if not self._closed:
+            try:
+                self._pool.put_nowait(conn)
+            except Exception:
+                conn.close()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def connection(self):
+        conn = self.get_connection()
+        try:
+            yield conn
+        finally:
+            self.release_connection(conn)
+
+    def close_all(self):
+        self._closed = True
+        while True:
+            try:
+                conn = self._pool.get_nowait()
+                conn.close()
+            except Empty:
+                break
+
+
+class TestPutClaimReverify(unittest.TestCase):
+    def setUp(self):
+        from fastapi.testclient import TestClient
+
+        from app.api.deps import get_db, get_db_pool
+        from app.main import app
+        from app.services.auth_service import create_access_token, hash_password
+
+        self.app = app
+        self.client = TestClient(app)
+        self.create_token = create_access_token
+        self.hash_password = hash_password
+
+        self.tmp = tempfile.mkdtemp()
+        self._original_data_dir = settings.data_dir
+        self._original_jwt = settings.jwt_secret_key
+        self._original_users = settings.users_enabled
+        settings.data_dir = Path(self.tmp)
+        settings.users_enabled = True
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+
+        self.db = str(Path(self.tmp) / "app.db")
+
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        with _pool_cache_lock:
+            for _, p in list(_pool_cache.items()):
+                p.close_all()
+            _pool_cache.clear()
+
+        run_migrations(self.db)
+        self.pool = _Pool(self.db)
+
+        def override_db():
+            conn = self.pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.pool.release_connection(conn)
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_db_pool] = lambda: self.pool
+
+        # Seed admin + vault membership.
+        conn = self.pool.get_connection()
+        try:
+            conn.execute("DELETE FROM users WHERE id != 0")
+            conn.execute(
+                "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (1, 'admin1', ?, 'A', 'admin', 1)",
+                (self.hash_password("pw"),),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (2, 'V2', '')"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) "
+                "VALUES (2, 1, 'write', 1)"
+            )
+            # Files row with parsed_text.
+            conn.execute(
+                "INSERT INTO files (id, vault_id, file_path, file_name, file_size, status, parsed_text) "
+                "VALUES (100, 2, '/uploads/x.txt', 'x.txt', 10, 'indexed', ?)",
+                ("Alice founded the company. Bob is the CTO.",),
+            )
+            # Curator-authored claim with verifiable quote.
+            cur = conn.execute(
+                """
+                INSERT INTO wiki_claims
+                (vault_id, claim_text, claim_type, source_type, status, created_by_kind)
+                VALUES (2, 'Alice founded the company', 'fact', 'document',
+                        'needs_review', 'llm_curator')
+                """
+            )
+            self.good_claim_id = cur.lastrowid
+            conn.execute(
+                """
+                INSERT INTO wiki_claim_sources
+                (claim_id, source_kind, file_id, chunk_id, source_label, quote)
+                VALUES (?, 'document', 100, '100_0', 'file:100', ?)
+                """,
+                (self.good_claim_id, "Alice founded the company"),
+            )
+            # Curator-authored claim whose quote NO LONGER appears.
+            cur2 = conn.execute(
+                """
+                INSERT INTO wiki_claims
+                (vault_id, claim_text, claim_type, source_type, status, created_by_kind)
+                VALUES (2, 'Carol is the CFO', 'role', 'document',
+                        'needs_review', 'llm_curator')
+                """
+            )
+            self.bad_claim_id = cur2.lastrowid
+            conn.execute(
+                """
+                INSERT INTO wiki_claim_sources
+                (claim_id, source_kind, file_id, chunk_id, source_label, quote)
+                VALUES (?, 'document', 100, '100_0', 'file:100', ?)
+                """,
+                (self.bad_claim_id, "Carol is the CFO"),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        self.token = self.create_token(1, "admin1", "admin")
+
+    def tearDown(self):
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        self.app.dependency_overrides.clear()
+        with _pool_cache_lock:
+            for _, p in list(_pool_cache.items()):
+                p.close_all()
+            _pool_cache.clear()
+        self.pool.close_all()
+        settings.data_dir = self._original_data_dir
+        settings.jwt_secret_key = self._original_jwt
+        settings.users_enabled = self._original_users
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _hdr(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def test_promotion_with_verifiable_quote_succeeds(self):
+        r = self.client.put(
+            f"/api/wiki/claims/{self.good_claim_id}",
+            headers=self._hdr(),
+            json={"vault_id": 2, "status": "active"},
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["status"], "active")
+
+    def test_promotion_with_unverifiable_quote_returns_400(self):
+        r = self.client.put(
+            f"/api/wiki/claims/{self.bad_claim_id}",
+            headers=self._hdr(),
+            json={"vault_id": 2, "status": "active"},
+        )
+        self.assertEqual(r.status_code, 400, r.text)
+        self.assertIn("source_quote", r.json()["detail"])
+
+    def test_promotion_with_no_file_source_returns_actionable_400(self):
+        """Critic Fix #3 (LOW): curator claims authored on the
+        query/manual trigger have file_id=NULL on every source row.
+        The PUT must surface a clear 'no file source attached' message
+        rather than the generic 'no longer verifiable' so operators
+        know the claim CAN'T be auto-promoted (vs has just drifted)."""
+        # Insert a curator claim whose only source has file_id=NULL +
+        # a quote (mimics the query/manual curator trigger).
+        conn = self.pool.get_connection()
+        try:
+            cur = conn.execute(
+                """
+                INSERT INTO wiki_claims
+                (vault_id, claim_text, claim_type, source_type, status, created_by_kind)
+                VALUES (2, 'Sourceless curator claim', 'fact', 'document',
+                        'needs_review', 'llm_curator')
+                """
+            )
+            sourceless_claim_id = cur.lastrowid
+            conn.execute(
+                """
+                INSERT INTO wiki_claim_sources
+                (claim_id, source_kind, file_id, chunk_id, source_label, quote)
+                VALUES (?, 'document', NULL, 'text_0', 'curator', 'Sourceless curator claim')
+                """,
+                (sourceless_claim_id,),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+        r = self.client.put(
+            f"/api/wiki/claims/{sourceless_claim_id}",
+            headers=self._hdr(),
+            json={"vault_id": 2, "status": "active"},
+        )
+        self.assertEqual(r.status_code, 400, r.text)
+        detail = r.json()["detail"]
+        self.assertIn("no source row references a document file", detail)
+        self.assertIn("manual", detail)
+
+    def test_non_active_status_change_skips_reverify(self):
+        # Switching from needs_review to archived should not require quote
+        # verification (it's only the active gate that needs proof).
+        r = self.client.put(
+            f"/api/wiki/claims/{self.bad_claim_id}",
+            headers=self._hdr(),
+            json={"vault_id": 2, "status": "archived"},
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/chat/Composer.queued.test.tsx
+++ b/frontend/src/components/chat/Composer.queued.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * PR A regression: chat composer must handle the new async upload path.
+ *
+ * The async POST /documents route returns immediately with status="pending".
+ * The polling loop then sees status="pending" / "processing" plus phase
+ * strings (queued / parsing / embedding / ...). The composer chip must
+ * stay in its "indexing" state through the whole pipeline and flip to
+ * "indexed" only on a terminal status, never on phase alone.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { uploadDocumentMock, getDocumentStatusMock } = vi.hoisted(() => ({
+  uploadDocumentMock: vi.fn(),
+  getDocumentStatusMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    uploadDocument: uploadDocumentMock,
+    getDocumentStatus: getDocumentStatusMock,
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  uploadDocumentMock.mockReset();
+  getDocumentStatusMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+/**
+ * The Composer's startIndexPoll callback is the unit under test. We
+ * exercise it via a thin wrapper because mounting the full <Composer />
+ * in JSDOM would require dragging in the chat shell and dropzone
+ * scaffolding for behavior that is decoupled from rendering.
+ */
+async function runPollCycles(cycles: number) {
+  // Composer polls at 1s.
+  for (let i = 0; i < cycles; i += 1) {
+    await vi.advanceTimersByTimeAsync(1000);
+  }
+}
+
+describe("Composer polling — async upload path", () => {
+  it("status='pending' (queued / parsing / embedding) keeps chip in indexing-style state, not error", async () => {
+    // Hot-import to ensure module captures the latest mocks.
+    const { useUploadStore } = await import("@/stores/useUploadStore");
+    // The chat composer's startIndexPoll lives inside the component, but
+    // its branching contract mirrors the upload store's snapshot mapping.
+    // We assert the upload store contract directly here as a proxy: the
+    // store maps every backend status in {pending, processing} -> chip
+    // state "processing" (which the composer aliases to "indexing").
+
+    useUploadStore.setState({
+      uploads: [],
+      isProcessing: false,
+      activeVaultId: 1,
+    });
+
+    uploadDocumentMock.mockResolvedValue({
+      id: 1,
+      filename: "f.txt",
+      status: "pending",
+    });
+
+    let call = 0;
+    getDocumentStatusMock.mockImplementation(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          id: 1,
+          filename: "f.txt",
+          status: "pending",
+          chunk_count: 0,
+          phase: "queued",
+        };
+      }
+      if (call === 2) {
+        return {
+          id: 1,
+          filename: "f.txt",
+          status: "processing",
+          chunk_count: 0,
+          phase: "parsing",
+        };
+      }
+      if (call === 3) {
+        return {
+          id: 1,
+          filename: "f.txt",
+          status: "processing",
+          chunk_count: 0,
+          phase: "embedding",
+          progress_percent: 40,
+        };
+      }
+      return {
+        id: 1,
+        filename: "f.txt",
+        status: "indexed",
+        chunk_count: 5,
+        phase: "indexed",
+        wiki_status: "completed",
+      };
+    });
+
+    useUploadStore.getState().addUploads([
+      new File([new Uint8Array(8)], "f.txt", { type: "text/plain" }),
+    ], 1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Cycle 1: queued
+    await vi.advanceTimersByTimeAsync(1600);
+    let u = useUploadStore.getState().uploads[0];
+    expect(u.status).toBe("processing");
+    expect(u.phase).toBe("queued");
+    expect(u.error).toBeUndefined();
+
+    // Cycle 2: parsing
+    await vi.advanceTimersByTimeAsync(1600);
+    u = useUploadStore.getState().uploads[0];
+    expect(u.phase).toBe("parsing");
+    expect(u.status).toBe("processing");
+
+    // Cycle 3: embedding 40%
+    await vi.advanceTimersByTimeAsync(1600);
+    u = useUploadStore.getState().uploads[0];
+    expect(u.phase).toBe("embedding");
+    expect(u.processingProgress).toBe(40);
+
+    // Cycle 4: indexed
+    await vi.advanceTimersByTimeAsync(1600);
+    u = useUploadStore.getState().uploads[0];
+    expect(u.status).toBe("indexed");
+  });
+});

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -248,18 +248,26 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
 
   /**
    * Begin polling the backend indexing status for an attachment that
-   * finished uploading. Polls every 1s, gives up after ~2 minutes (120
-   * attempts) and marks the chip as ``error`` with an explanatory message
-   * — the user can still send their query but is warned the file isn't
-   * searchable yet. Pollers self-cancel when the row is removed.
+   * finished uploading. The async upload route returns immediately with
+   * ``status="pending"`` and ``phase="queued"``; the worker advances the
+   * row through the canonical 4-value status enum
+   * (pending -> processing -> indexed | error). Phase strings
+   * (queued/parsing/embedding/...) are treated as mid-pipeline by mapping
+   * to the chip's "indexing" state.
+   *
+   * No frontend timeout: large files legitimately take many minutes. A
+   * 4-hour absolute cap stops a runaway poller. Transient fetch errors
+   * are tolerated until many consecutive failures.
    */
   const startIndexPoll = useCallback((rowId: string, fileId: string) => {
-    let attempts = 0;
-    const maxAttempts = 120;
+    const startedAt = Date.now();
+    const HARD_CAP_MS = 4 * 60 * 60 * 1000;
+    let consecutiveFailures = 0;
     const handle = setInterval(async () => {
-      attempts += 1;
+      const elapsedMs = Date.now() - startedAt;
       try {
         const status = await getDocumentStatus(fileId);
+        consecutiveFailures = 0;
         if (status.status === "indexed") {
           clearInterval(handle);
           pollersRef.current.delete(rowId);
@@ -280,7 +288,11 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
             )
           );
           toast.error(`Indexing failed for ${fileId}`, { description: msg });
-        } else if (status.status === "processing" || status.status === "pending") {
+        } else {
+          // "pending" / "processing" / any other non-terminal status
+          // means the worker is mid-pipeline. Phase string detail
+          // (queued/parsing/...) doesn't change the chip but is a
+          // healthy heartbeat from the backend.
           setAttachments((prev) =>
             prev.map((a) =>
               a.id === rowId && a.status !== "indexing"
@@ -288,17 +300,18 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
                 : a
             )
           );
-          if (attempts >= maxAttempts) {
+          if (elapsedMs >= HARD_CAP_MS) {
             clearInterval(handle);
             pollersRef.current.delete(rowId);
+            // Don't mark "error" — backend may still be working; just
+            // stop polling and let the chip show a soft notice.
             setAttachments((prev) =>
               prev.map((a) =>
                 a.id === rowId
                   ? {
                       ...a,
-                      status: "error",
                       error:
-                        "Indexing did not complete within 2 minutes. The file may still be processing.",
+                        "Indexing is taking longer than expected. The file may still be processing — refresh to recheck.",
                     }
                   : a
               )
@@ -306,8 +319,14 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
           }
         }
       } catch (err) {
-        // Transient fetch error: keep polling unless we've exhausted attempts.
-        if (attempts >= maxAttempts) {
+        consecutiveFailures += 1;
+        // 30 consecutive 1-second-spaced failures = ~30s of network
+        // blackout before the chat chip flips to error. Chosen to ride
+        // through brief LAN drops without blocking the user; any longer
+        // and the UX feels stuck. Tunable independently of the upload
+        // store's adaptive cadence (which uses the same constant but
+        // 1.5/3/6s spacing => much larger real-world tolerance).
+        if (consecutiveFailures >= 30 || elapsedMs >= HARD_CAP_MS) {
           clearInterval(handle);
           pollersRef.current.delete(rowId);
           const msg = err instanceof Error ? err.message : "Status check failed";
@@ -352,9 +371,11 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
           activeVaultId
         );
         const fileId = String(resp.id);
-        // Server may already report ``indexed`` for tiny files; otherwise
-        // start polling. Treat "uploaded" as the bridge state between the
-        // POST returning and the first indexer pass landing.
+        // The async upload route returns immediately with status="pending".
+        // We transition the chip to "uploaded" as the bridge state and let
+        // startIndexPoll drive subsequent transitions. The "indexed"
+        // short-circuit is preserved for any client that still sees the
+        // legacy synchronous response.
         const initialStatus: AttachmentStatus =
           resp.status === "indexed" ? "indexed" : "uploaded";
         setAttachments((prev) =>

--- a/frontend/src/components/settings/MaintenanceSettings.tsx
+++ b/frontend/src/components/settings/MaintenanceSettings.tsx
@@ -1,0 +1,242 @@
+/**
+ * Settings → Maintenance tab.
+ *
+ * Action buttons that hit existing backend endpoints only (per the
+ * approved plan, the unwired "Reindex current vault" button is dropped
+ * — we'll add it once a real /documents/reindex endpoint ships).
+ *
+ * Buttons:
+ *   - Recompile wiki current vault   → POST /wiki/recompile
+ *   - Run wiki lint                  → POST /wiki/lint/run
+ *   - Test connections               → GET /settings/connection
+ *
+ * Plus a "Recent jobs" mini-list using GET /wiki/jobs?limit=10 so the
+ * operator can see the effect of a recompile without leaving the tab.
+ */
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Loader2, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import {
+  recompileVaultWiki,
+  runWikiLint,
+  listWikiJobs,
+  testConnections,
+} from "@/lib/api";
+import type { WikiCompileJob } from "@/lib/api";
+
+export interface MaintenanceSettingsProps {
+  /** Active vault id, used for wiki recompile/lint scoping. */
+  vaultId: number | null;
+}
+
+export function MaintenanceSettings({ vaultId }: MaintenanceSettingsProps) {
+  const [busy, setBusy] = useState<
+    null | "recompile" | "lint" | "connections" | "jobs"
+  >(null);
+  const [recentJobs, setRecentJobs] = useState<WikiCompileJob[]>([]);
+
+  const refreshJobs = async () => {
+    if (!vaultId) {
+      setRecentJobs([]);
+      return;
+    }
+    setBusy("jobs");
+    try {
+      const out = await listWikiJobs({ vault_id: vaultId });
+      // Latest 10 by id desc — backend may already sort, but we don't rely.
+      const jobs = (out.jobs ?? []).slice(0, 10);
+      setRecentJobs(jobs);
+    } catch (e) {
+      // Non-fatal: wiki tables may not exist on a fresh install.
+      setRecentJobs([]);
+      void e;
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  useEffect(() => {
+    void refreshJobs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vaultId]);
+
+  const handleRecompile = async () => {
+    if (!vaultId) {
+      toast.error("Select an active vault before recompiling.");
+      return;
+    }
+    setBusy("recompile");
+    try {
+      const out = await recompileVaultWiki(vaultId);
+      toast.success(`Wiki recompile queued (job ${out.job_id})`);
+      void refreshJobs();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to queue wiki recompile",
+      );
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleLint = async () => {
+    if (!vaultId) {
+      toast.error("Select an active vault before running lint.");
+      return;
+    }
+    setBusy("lint");
+    try {
+      const out = await runWikiLint(vaultId);
+      toast.success(
+        `Wiki lint produced ${out.count ?? out.findings?.length ?? 0} finding(s)`,
+      );
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to run wiki lint");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleTestConnections = async () => {
+    setBusy("connections");
+    try {
+      const out = await testConnections();
+      const okCount = Object.values(out).filter((v) => v?.ok).length;
+      toast.success(
+        `Connection test ok for ${okCount}/${Object.keys(out).length} services`,
+      );
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to test connections",
+      );
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Maintenance actions</CardTitle>
+          <CardDescription>
+            Trigger wiki / lint / connection checks. Each button hits a real
+            backend endpoint — nothing here is decorative.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRecompile}
+              disabled={busy !== null || !vaultId}
+            >
+              {busy === "recompile" && (
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              )}
+              Recompile wiki (current vault)
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleLint}
+              disabled={busy !== null || !vaultId}
+            >
+              {busy === "lint" && (
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              )}
+              Run wiki lint
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleTestConnections}
+              disabled={busy !== null}
+            >
+              {busy === "connections" && (
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              )}
+              Test connections
+            </Button>
+          </div>
+          {!vaultId && (
+            <p className="text-xs text-muted-foreground pt-2">
+              Recompile and lint require an active vault. Pick one in the
+              top-bar vault selector.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="text-base">Recent wiki jobs</CardTitle>
+            <CardDescription>
+              Last 10 wiki compile jobs across the system.
+            </CardDescription>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={refreshJobs}
+            disabled={busy === "jobs"}
+            aria-label="Refresh wiki jobs"
+          >
+            {busy === "jobs" ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <RefreshCw className="w-4 h-4" />
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {recentJobs.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No recent jobs.</p>
+          ) : (
+            <div className="space-y-1 text-xs">
+              {recentJobs.map((job) => (
+                <div
+                  key={job.id}
+                  className="flex items-center justify-between gap-2 border-b border-border/40 py-1 last:border-0"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-mono text-muted-foreground">
+                      #{job.id}
+                    </span>
+                    <span className="truncate">{job.trigger_type}</span>
+                    {job.trigger_id && (
+                      <span className="truncate text-muted-foreground">
+                        ({job.trigger_id})
+                      </span>
+                    )}
+                  </div>
+                  <span
+                    className={
+                      job.status === "completed"
+                        ? "text-emerald-600"
+                        : job.status === "failed"
+                        ? "text-destructive"
+                        : "text-muted-foreground"
+                    }
+                  >
+                    {job.status}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/ModelsTab.tsx
+++ b/frontend/src/components/settings/ModelsTab.tsx
@@ -1,0 +1,206 @@
+/**
+ * Settings → Models tab.
+ *
+ * Replaces the legacy "AI" + "Advanced" tabs that contradicted each other
+ * (AI claimed read-only via env vars; Advanced edited the same fields).
+ *
+ * All fields are runtime-editable. Each field shows a source badge derived
+ * from ``effective_sources`` so the operator can see whether the displayed
+ * value came from a settings_kv override, an env var, or the Pydantic
+ * default. Per actual lifespan order in the backend (kv > env > default),
+ * saving here will shadow any env var at runtime — that's documented in
+ * the help text rather than enforced by disabling inputs.
+ */
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import type { SettingsErrors, SettingsFormData } from "@/stores/useSettingsStore";
+
+export interface ModelsTabProps {
+  formData: SettingsFormData;
+  errors: SettingsErrors;
+  onChange: <K extends keyof SettingsFormData>(
+    field: K,
+    value: SettingsFormData[K],
+  ) => void;
+  effectiveSources: Record<string, "kv" | "env" | "default">;
+}
+
+function SourceBadge({
+  source,
+}: {
+  source?: "kv" | "env" | "default";
+}) {
+  if (!source) return null;
+  const label =
+    source === "kv"
+      ? "Runtime override"
+      : source === "env"
+      ? "From env"
+      : "Default";
+  const variant: "secondary" | "outline" =
+    source === "kv" ? "secondary" : "outline";
+  return (
+    <Badge variant={variant} className="text-[10px] uppercase">
+      {label}
+    </Badge>
+  );
+}
+
+interface FieldProps {
+  field: keyof SettingsFormData;
+  label: string;
+  placeholder: string;
+  description: string;
+  type?: string;
+  formData: SettingsFormData;
+  errors: SettingsErrors;
+  onChange: ModelsTabProps["onChange"];
+  source?: "kv" | "env" | "default";
+}
+
+function StringField({
+  field,
+  label,
+  placeholder,
+  description,
+  type = "text",
+  formData,
+  errors,
+  onChange,
+  source,
+}: FieldProps) {
+  const value = (formData as unknown as Record<string, string>)[field as string] ?? "";
+  const err = (errors as Record<string, string | undefined>)[field as string];
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label htmlFor={String(field)} className="text-sm font-medium">
+          {label}
+        </Label>
+        <SourceBadge source={source} />
+      </div>
+      <Input
+        id={String(field)}
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) =>
+          onChange(field, e.target.value as SettingsFormData[typeof field])
+        }
+        aria-invalid={err ? true : undefined}
+        className={err ? "border-destructive" : undefined}
+      />
+      {err && (
+        <p className="text-xs text-destructive" role="alert">
+          {err}
+        </p>
+      )}
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export function ModelsTab({
+  formData,
+  errors,
+  onChange,
+  effectiveSources,
+}: ModelsTabProps) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Model endpoints</CardTitle>
+          <CardDescription>
+            All fields are runtime-editable. Saving overrides any env value
+            at runtime; env values seed defaults at startup but do not
+            enforce precedence.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <StringField
+            field="ollama_embedding_url"
+            label="Embedding service URL"
+            placeholder="http://localhost:11434"
+            description="OpenAI-compatible / Ollama / TEI URL for embeddings."
+            type="url"
+            formData={formData}
+            errors={errors}
+            onChange={onChange}
+            source={effectiveSources.ollama_embedding_url}
+          />
+          <StringField
+            field="ollama_chat_url"
+            label="Chat / LLM service URL"
+            placeholder="http://localhost:11434"
+            description="Chat model endpoint. For Docker, use http://host.docker.internal:11434 to reach a host Ollama."
+            type="url"
+            formData={formData}
+            errors={errors}
+            onChange={onChange}
+            source={effectiveSources.ollama_chat_url}
+          />
+          <StringField
+            field="reranker_url"
+            label="Reranker service URL"
+            placeholder="http://localhost:8082"
+            description="Reranker endpoint. Leave empty to use local sentence-transformers."
+            type="url"
+            formData={formData}
+            errors={errors}
+            onChange={onChange}
+            source={effectiveSources.reranker_url}
+          />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Model names</CardTitle>
+          <CardDescription>
+            Names are passed verbatim to the configured endpoints.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <StringField
+            field="embedding_model"
+            label="Embedding model"
+            placeholder="microsoft/harrier-oss-v1-0.6b"
+            description="Used for document embeddings."
+            formData={formData}
+            errors={errors}
+            onChange={onChange}
+            source={effectiveSources.embedding_model}
+          />
+          <StringField
+            field="chat_model"
+            label="Chat model"
+            placeholder="llama3"
+            description="Used for chat responses."
+            formData={formData}
+            errors={errors}
+            onChange={onChange}
+            source={effectiveSources.chat_model}
+          />
+          <StringField
+            field="reranker_model"
+            label="Reranker model"
+            placeholder="BAAI/bge-reranker-v2-m3"
+            description="Cross-encoder model used by the reranker."
+            formData={formData}
+            errors={errors}
+            onChange={onChange}
+            source={effectiveSources.reranker_model}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/NumberInput.tsx
+++ b/frontend/src/components/settings/NumberInput.tsx
@@ -1,0 +1,121 @@
+/**
+ * NumberInput primitive — draft-string semantics.
+ *
+ * The legacy SettingsPage coerced empty input to 0 on every keystroke,
+ * making numeric fields hostile to editing (you couldn't temporarily
+ * blank a field to retype it). This primitive keeps the user's raw
+ * string locally and only commits a coerced number on blur.
+ *
+ * Contract:
+ *   - `value` (number | undefined) is the *committed* value held by the
+ *     parent store. Undefined is treated as "no value yet".
+ *   - On focus / typing, the input shows the user's draft string
+ *     verbatim — including the empty string. The parent store is NOT
+ *     updated until blur.
+ *   - On blur, if the draft parses to a finite number, `onCommit` is
+ *     called with that number. If the draft is blank, `onCommit` is
+ *     called with `undefined` (so the parent can decide whether to
+ *     treat blank as "use default" or "validation error").
+ *   - If the draft is non-blank and unparseable, `onCommit` is NOT
+ *     called and the field surfaces a `data-invalid` attribute the
+ *     parent / styles can use to show an error.
+ *   - Pressing Enter forces a blur (and therefore a commit).
+ *
+ * Tests for this primitive live in NumberInput.test.tsx.
+ */
+import { useEffect, useState, type InputHTMLAttributes } from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface NumberInputProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "value" | "onChange" | "type"
+  > {
+  /** Committed numeric value (or undefined for "blank"). */
+  value: number | undefined;
+  /**
+   * Called on blur (or Enter) with the parsed number, or with
+   * `undefined` if the field was blanked. Not called for unparseable
+   * non-empty input.
+   */
+  onCommit: (value: number | undefined) => void;
+  /** Use parseFloat (default) vs parseInt. */
+  parseAs?: "float" | "int";
+  /** Inline error message — sets data-invalid="true". */
+  error?: string;
+}
+
+function formatForDisplay(value: number | undefined): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "";
+  return String(value);
+}
+
+export function NumberInput({
+  value,
+  onCommit,
+  parseAs = "float",
+  error,
+  className,
+  onBlur,
+  onKeyDown,
+  ...rest
+}: NumberInputProps) {
+  // draft is the raw string the user is typing; it can be "" or "12.3" or "-".
+  const [draft, setDraft] = useState<string>(formatForDisplay(value));
+  const [invalid, setInvalid] = useState(false);
+
+  // When the parent updates the committed value (e.g. discard / load),
+  // resync the draft. If the user is currently editing (draft and value
+  // disagree but the draft parses to value), don't clobber.
+  useEffect(() => {
+    const next = formatForDisplay(value);
+    setDraft((prev) => {
+      const parsed = parseAs === "int" ? parseInt(prev, 10) : parseFloat(prev);
+      if (!Number.isFinite(parsed) && prev === next) return prev;
+      if (Number.isFinite(parsed) && parsed === value) return prev;
+      return next;
+    });
+    setInvalid(false);
+  }, [value, parseAs]);
+
+  return (
+    <Input
+      {...rest}
+      type="text"
+      inputMode="decimal"
+      data-invalid={error || invalid ? "true" : undefined}
+      aria-invalid={error || invalid ? true : undefined}
+      value={draft}
+      className={cn(error || invalid ? "border-destructive" : undefined, className)}
+      onChange={(e) => {
+        setDraft(e.target.value);
+        if (invalid) setInvalid(false);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.currentTarget.blur();
+        }
+        onKeyDown?.(e);
+      }}
+      onBlur={(e) => {
+        const raw = draft.trim();
+        if (raw === "") {
+          setInvalid(false);
+          onCommit(undefined);
+        } else {
+          const parsed = parseAs === "int" ? parseInt(raw, 10) : parseFloat(raw);
+          if (Number.isFinite(parsed)) {
+            setInvalid(false);
+            onCommit(parsed);
+          } else {
+            setInvalid(true);
+            // Don't call onCommit — keep the parent state intact so the
+            // user can correct without losing the previous value.
+          }
+        }
+        onBlur?.(e);
+      }}
+    />
+  );
+}

--- a/frontend/src/components/settings/OverviewTab.tsx
+++ b/frontend/src/components/settings/OverviewTab.tsx
@@ -1,0 +1,138 @@
+/**
+ * Settings → Overview tab.
+ *
+ * Read-only health snapshot. Reuses the existing health hook + connection
+ * test API. No editable fields here, so dirty tracking is not relevant.
+ */
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Loader2 } from "lucide-react";
+import type { HealthStatus } from "@/types/health";
+import type { ConnectionTestResult } from "@/lib/api";
+
+export interface OverviewTabProps {
+  health: HealthStatus;
+  connectionResult: ConnectionTestResult | null;
+  isTestingConnections: boolean;
+  onTestConnections: () => void;
+  curatorEnabled: boolean;
+  wikiEnabled: boolean;
+}
+
+function StatusDot({ ok }: { ok: boolean }) {
+  return (
+    <span
+      className={`inline-block h-2 w-2 rounded-full ${
+        ok ? "bg-emerald-500" : "bg-destructive"
+      }`}
+      aria-hidden
+    />
+  );
+}
+
+export function OverviewTab({
+  health,
+  connectionResult,
+  isTestingConnections,
+  onTestConnections,
+  curatorEnabled,
+  wikiEnabled,
+}: OverviewTabProps) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Service health</CardTitle>
+            <CardDescription>
+              Live readiness for the chat / embedding / reranker stack.
+            </CardDescription>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onTestConnections}
+            disabled={isTestingConnections}
+          >
+            {isTestingConnections && (
+              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+            )}
+            Test connections
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2">
+              <StatusDot ok={health.backend} />
+              Backend
+            </span>
+            <span className="text-muted-foreground">
+              {health.backend ? "ok" : "down"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2">
+              <StatusDot ok={health.embeddings} />
+              Embedding service
+            </span>
+            <span className="text-muted-foreground">
+              {health.embeddings ? "ok" : "down"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2">
+              <StatusDot ok={health.chat} />
+              Chat service
+            </span>
+            <span className="text-muted-foreground">
+              {health.chat ? "ok" : "down"}
+            </span>
+          </div>
+          {connectionResult && (
+            <div className="text-xs text-muted-foreground pt-2 border-t">
+              Last connection test:{" "}
+              {Object.entries(connectionResult)
+                .map(([k, v]) => `${k}=${v?.ok ? "ok" : "fail"}`)
+                .join(" · ")}
+            </div>
+          )}
+          {health.lastChecked && (
+            <p className="text-xs text-muted-foreground">
+              Last checked: {health.lastChecked.toLocaleTimeString()}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Wiki / Curator status</CardTitle>
+          <CardDescription>
+            Quick view of wiki + optional curator enablement.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <Badge variant={wikiEnabled ? "secondary" : "outline"}>
+              Wiki: {wikiEnabled ? "enabled" : "disabled"}
+            </Badge>
+            <Badge variant={curatorEnabled ? "secondary" : "outline"}>
+              Curator: {curatorEnabled ? "enabled" : "disabled"}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Configure curator on the Wiki &amp; Curator tab. Curator output
+            never becomes an active claim without source-quote verification.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SaveDiscardFooter.tsx
+++ b/frontend/src/components/settings/SaveDiscardFooter.tsx
@@ -1,0 +1,76 @@
+/**
+ * Sticky save/discard footer for the Settings page.
+ *
+ * Visible across tab switches so the user never loses sight of unsaved
+ * changes. Save is disabled when invalid; Discard is disabled when
+ * clean. Surfaces the count of dirty fields and a per-tab summary so
+ * the user knows what's pending without scrolling.
+ */
+import { Button } from "@/components/ui/button";
+import { Loader2, Undo2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface SaveDiscardFooterProps {
+  dirtyCount: number;
+  invalid: boolean;
+  saving: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}
+
+export function SaveDiscardFooter({
+  dirtyCount,
+  invalid,
+  saving,
+  onSave,
+  onDiscard,
+}: SaveDiscardFooterProps) {
+  const visible = dirtyCount > 0 || saving;
+  return (
+    <div
+      className={cn(
+        "sticky bottom-0 inset-x-0 z-10 -mx-4 mt-6 border-t bg-card/95 backdrop-blur",
+        "transition-all",
+        visible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0",
+      )}
+      role="region"
+      aria-label="Unsaved changes"
+    >
+      <div className="flex items-center justify-between gap-4 px-4 py-3">
+        <div className="text-sm">
+          {invalid ? (
+            <span className="text-destructive">
+              Fix highlighted errors before saving
+            </span>
+          ) : dirtyCount > 0 ? (
+            <span>
+              {dirtyCount} unsaved {dirtyCount === 1 ? "change" : "changes"}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Saving…</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onDiscard}
+            disabled={dirtyCount === 0 || saving}
+            aria-label="Discard unsaved changes"
+          >
+            <Undo2 className="w-4 h-4 mr-1" />
+            Discard
+          </Button>
+          <Button
+            size="sm"
+            onClick={onSave}
+            disabled={invalid || dirtyCount === 0 || saving}
+          >
+            {saving && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+            Save Changes
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/WikiCuratorSettings.tsx
+++ b/frontend/src/components/settings/WikiCuratorSettings.tsx
@@ -1,0 +1,457 @@
+/**
+ * Settings → Wiki & Curator tab.
+ *
+ * Wires every wiki + curator field defined in the backend config to the
+ * settings store. Curator inputs are visually grouped and explain that
+ * "claims become active only when source quotes are verified", so the
+ * operator never thinks the curator can write authoritative claims
+ * without provenance.
+ *
+ * The "Test connection" button is wired to POST /settings/curator/test.
+ * The local-model UX hint is rendered inline so operators know the
+ * ALLOW_LOCAL_CURATOR=1 opt-in exists.
+ */
+import { useEffect, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { Loader2, ShieldCheck, AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
+import { NumberInput } from "./NumberInput";
+import { testCuratorConnection } from "@/lib/api";
+
+/**
+ * Tiny "always reflect the latest value" ref helper. Used by handleTest
+ * so the post-await guard can compare the URL/model the test was
+ * launched with against whatever the operator has now typed.
+ */
+function useLatestRef<T>(value: T) {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+import type { CuratorTestResult } from "@/lib/api";
+import type { SettingsErrors, SettingsFormData } from "@/stores/useSettingsStore";
+
+export interface WikiCuratorSettingsProps {
+  formData: SettingsFormData;
+  errors: SettingsErrors;
+  onChange: <K extends keyof SettingsFormData>(
+    field: K,
+    value: SettingsFormData[K],
+  ) => void;
+}
+
+export function WikiCuratorSettings({
+  formData,
+  errors,
+  onChange,
+}: WikiCuratorSettingsProps) {
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<CuratorTestResult | null>(null);
+
+  // Clear any stale test result when the operator toggles curator off,
+  // changes the URL, or changes the model — the previous OK / error no
+  // longer reflects the current configuration and would mislead.
+  useEffect(() => {
+    setTestResult(null);
+  }, [
+    formData.wiki_llm_curator_enabled,
+    formData.wiki_llm_curator_url,
+    formData.wiki_llm_curator_model,
+  ]);
+
+  const handleTest = async () => {
+    // Capture the URL/model snapshot we are testing. If the operator
+    // edits the URL/model while the request is in flight, the
+    // useEffect below will null out testResult; we additionally
+    // guard the post-await write so a late response can't repaint
+    // a stale OK label against the now-changed config.
+    const requestedUrl = formData.wiki_llm_curator_url;
+    const requestedModel = formData.wiki_llm_curator_model;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const out = await testCuratorConnection(requestedUrl, requestedModel);
+      // Latest formData read AFTER await — guard against in-flight edits.
+      const latest = useFormDataSnapshot.current;
+      if (
+        latest.url === requestedUrl &&
+        latest.model === requestedModel
+      ) {
+        setTestResult(out);
+      }
+    } catch (e) {
+      const latest = useFormDataSnapshot.current;
+      if (
+        latest.url === requestedUrl &&
+        latest.model === requestedModel
+      ) {
+        setTestResult({
+          ok: false,
+          model: requestedModel,
+          latency_ms: null,
+          error: e instanceof Error ? e.message : "Test failed",
+        });
+      }
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  // Live snapshot of the URL/model used by the test handler's
+  // post-await guard. We need a ref so the closure inside handleTest
+  // sees the latest values without re-binding the callback.
+  const useFormDataSnapshot = useLatestRef({
+    url: formData.wiki_llm_curator_url,
+    model: formData.wiki_llm_curator_model,
+  });
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Wiki / Knowledge Compiler</CardTitle>
+          <CardDescription>
+            Toggle when the wiki compiler runs and which sources it processes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_enabled}
+              onCheckedChange={(v) => onChange("wiki_enabled", Boolean(v))}
+            />
+            Wiki enabled
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_compile_on_ingest}
+              onCheckedChange={(v) =>
+                onChange("wiki_compile_on_ingest", Boolean(v))
+              }
+            />
+            Compile on document ingest
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_compile_on_query}
+              onCheckedChange={(v) =>
+                onChange("wiki_compile_on_query", Boolean(v))
+              }
+            />
+            Compile on chat query
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_compile_after_indexing}
+              onCheckedChange={(v) =>
+                onChange("wiki_compile_after_indexing", Boolean(v))
+              }
+            />
+            Compile after document indexing finishes
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_lint_enabled}
+              onCheckedChange={(v) => onChange("wiki_lint_enabled", Boolean(v))}
+            />
+            Wiki lint enabled
+          </label>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="w-4 h-4" />
+            LLM Wiki Curator (optional)
+          </CardTitle>
+          <CardDescription>
+            The curator proposes wiki updates from a small local model.
+            Claims become active only when source quotes are verified —
+            unsupported output never becomes an active claim.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_llm_curator_enabled}
+              onCheckedChange={(v) =>
+                onChange("wiki_llm_curator_enabled", Boolean(v))
+              }
+            />
+            Enable LLM curator
+          </label>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="curator-url"
+              className="text-sm font-medium block"
+            >
+              Endpoint URL
+            </label>
+            <Input
+              id="curator-url"
+              type="url"
+              placeholder="https://localhost:11434"
+              value={formData.wiki_llm_curator_url}
+              onChange={(e) =>
+                onChange("wiki_llm_curator_url", e.target.value)
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+              data-invalid={errors.wiki_llm_curator_url ? "true" : undefined}
+              aria-invalid={errors.wiki_llm_curator_url ? true : undefined}
+            />
+            {errors.wiki_llm_curator_url && (
+              <p className="text-xs text-destructive">
+                {errors.wiki_llm_curator_url}
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              OpenAI-compatible /v1/chat/completions base URL. Local
+              endpoints (loopback / RFC1918) require{" "}
+              <code className="rounded bg-muted px-1">ALLOW_LOCAL_CURATOR=1</code>.
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="curator-model"
+              className="text-sm font-medium block"
+            >
+              Model name
+            </label>
+            <Input
+              id="curator-model"
+              type="text"
+              placeholder="qwen2.5:1.5b"
+              value={formData.wiki_llm_curator_model}
+              onChange={(e) =>
+                onChange("wiki_llm_curator_model", e.target.value)
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+              data-invalid={errors.wiki_llm_curator_model ? "true" : undefined}
+              aria-invalid={errors.wiki_llm_curator_model ? true : undefined}
+            />
+            {errors.wiki_llm_curator_model && (
+              <p className="text-xs text-destructive">
+                {errors.wiki_llm_curator_model}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label
+                htmlFor="curator-temp"
+                className="text-sm font-medium block"
+              >
+                Temperature (0.0–1.0)
+              </label>
+              <NumberInput
+                id="curator-temp"
+                value={formData.wiki_llm_curator_temperature}
+                onCommit={(v) =>
+                  onChange("wiki_llm_curator_temperature", v ?? 0)
+                }
+                error={errors.wiki_llm_curator_temperature}
+                disabled={!formData.wiki_llm_curator_enabled}
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="curator-max-input"
+                className="text-sm font-medium block"
+              >
+                Max input chars (1000–24000)
+              </label>
+              <NumberInput
+                id="curator-max-input"
+                parseAs="int"
+                value={formData.wiki_llm_curator_max_input_chars}
+                onCommit={(v) =>
+                  onChange("wiki_llm_curator_max_input_chars", v ?? 6000)
+                }
+                error={errors.wiki_llm_curator_max_input_chars}
+                disabled={!formData.wiki_llm_curator_enabled}
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="curator-max-output"
+                className="text-sm font-medium block"
+              >
+                Max output tokens
+              </label>
+              <NumberInput
+                id="curator-max-output"
+                parseAs="int"
+                value={formData.wiki_llm_curator_max_output_tokens}
+                onCommit={(v) =>
+                  onChange("wiki_llm_curator_max_output_tokens", v ?? 2048)
+                }
+                error={errors.wiki_llm_curator_max_output_tokens}
+                disabled={!formData.wiki_llm_curator_enabled}
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="curator-timeout"
+                className="text-sm font-medium block"
+              >
+                Timeout seconds (10–600)
+              </label>
+              <NumberInput
+                id="curator-timeout"
+                value={formData.wiki_llm_curator_timeout_sec}
+                onCommit={(v) =>
+                  onChange("wiki_llm_curator_timeout_sec", v ?? 120)
+                }
+                error={errors.wiki_llm_curator_timeout_sec}
+                disabled={!formData.wiki_llm_curator_enabled}
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="curator-concurrency"
+                className="text-sm font-medium block"
+              >
+                Concurrency (1–4)
+              </label>
+              <NumberInput
+                id="curator-concurrency"
+                parseAs="int"
+                value={formData.wiki_llm_curator_concurrency}
+                onCommit={(v) =>
+                  onChange("wiki_llm_curator_concurrency", v ?? 1)
+                }
+                error={errors.wiki_llm_curator_concurrency}
+                disabled={!formData.wiki_llm_curator_enabled}
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="curator-mode"
+                className="text-sm font-medium block"
+              >
+                Mode
+              </label>
+              <select
+                id="curator-mode"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                value={formData.wiki_llm_curator_mode}
+                onChange={(e) =>
+                  onChange("wiki_llm_curator_mode", e.target.value)
+                }
+                disabled={!formData.wiki_llm_curator_enabled}
+              >
+                <option value="draft">draft (always needs review)</option>
+                <option value="active_if_verified">
+                  active if verified
+                </option>
+              </select>
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_llm_curator_require_quote_match}
+              onCheckedChange={(v) =>
+                onChange(
+                  "wiki_llm_curator_require_quote_match",
+                  Boolean(v),
+                )
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+            />
+            Require source-quote match
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_llm_curator_require_chunk_id}
+              onCheckedChange={(v) =>
+                onChange("wiki_llm_curator_require_chunk_id", Boolean(v))
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+            />
+            Require chunk ID
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_llm_curator_run_on_ingest}
+              onCheckedChange={(v) =>
+                onChange("wiki_llm_curator_run_on_ingest", Boolean(v))
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+            />
+            Run on ingest
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_llm_curator_run_on_query}
+              onCheckedChange={(v) =>
+                onChange("wiki_llm_curator_run_on_query", Boolean(v))
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+            />
+            Run on query (default off)
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={formData.wiki_llm_curator_run_on_manual}
+              onCheckedChange={(v) =>
+                onChange("wiki_llm_curator_run_on_manual", Boolean(v))
+              }
+              disabled={!formData.wiki_llm_curator_enabled}
+            />
+            Run on manual / recompile
+          </label>
+
+          <div className="flex items-center gap-3 pt-2 border-t">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleTest}
+              disabled={
+                testing ||
+                !formData.wiki_llm_curator_url.trim() ||
+                !formData.wiki_llm_curator_model.trim()
+              }
+            >
+              {testing && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+              Test curator connection
+            </Button>
+            {testResult && (
+              <div
+                className={
+                  testResult.ok
+                    ? "flex items-center gap-1 text-xs text-emerald-600"
+                    : "flex items-center gap-1 text-xs text-destructive"
+                }
+                role="status"
+              >
+                {testResult.ok ? (
+                  <>
+                    <CheckCircle2 className="w-3 h-3" />
+                    OK · {testResult.latency_ms}ms
+                  </>
+                ) : (
+                  <>
+                    <XCircle className="w-3 h-3" />
+                    {testResult.error ?? "Failed"}
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+          <p className="flex items-start gap-1 text-xs text-muted-foreground">
+            <AlertTriangle className="w-3 h-3 mt-0.5" />
+            The curator proposes wiki updates. Claims become active only
+            when source quotes are verified.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/handleInputChange.ts
+++ b/frontend/src/components/settings/handleInputChange.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure handler used by the legacy DocumentProcessing / RAG / Retrieval
+ * settings components. Extracted so the regression tests can import the
+ * real implementation rather than a hand-mirrored copy that could drift
+ * silently from the page.
+ *
+ * Numeric coercion contract:
+ *   - Boolean / number values are passed through unchanged.
+ *   - String values for `LEGACY_NUMERIC_FIELDS` are parsed with
+ *     parseFloat. Empty input is intentionally NOT written to the store
+ *     (preserves last good value rather than overwriting with NaN/0).
+ *     Unparseable input is silently dropped — the legacy components
+ *     do not surface invalid state, which is a known limitation; the
+ *     Wiki & Curator tab uses the NumberInput primitive which does.
+ *   - Any other string field passes through (URLs, model names, etc.).
+ */
+import type { SettingsFormData } from "@/stores/useSettingsStore";
+
+export const LEGACY_NUMERIC_FIELDS: ReadonlySet<keyof SettingsFormData> =
+  new Set([
+    "chunk_size_chars",
+    "chunk_overlap_chars",
+    "retrieval_top_k",
+    "auto_scan_interval_minutes",
+    "max_distance_threshold",
+    "retrieval_window",
+    "embedding_batch_size",
+    "hybrid_alpha",
+    "initial_retrieval_top_k",
+    "reranker_top_n",
+  ]);
+
+export type UpdateFormFieldFn = <K extends keyof SettingsFormData>(
+  field: K,
+  value: SettingsFormData[K],
+) => void;
+
+export function handleSettingsInputChange(
+  field: keyof SettingsFormData,
+  value: string | boolean | number,
+  updateFormField: UpdateFormFieldFn,
+): void {
+  if (typeof value === "boolean") {
+    updateFormField(field, value as SettingsFormData[typeof field]);
+    return;
+  }
+  if (typeof value === "string") {
+    if (LEGACY_NUMERIC_FIELDS.has(field)) {
+      if (value === "") {
+        // Preserve last good value: don't write a string blank into a
+        // numeric form field. The user can keep typing and the commit
+        // happens once a parseable number lands.
+        return;
+      }
+      const parsed = parseFloat(value);
+      if (Number.isFinite(parsed)) {
+        updateFormField(field, parsed as SettingsFormData[typeof field]);
+      }
+      return;
+    }
+    updateFormField(field, value as SettingsFormData[typeof field]);
+    return;
+  }
+  updateFormField(field, value as SettingsFormData[typeof field]);
+}

--- a/frontend/src/components/shared/UploadIndicator.tsx
+++ b/frontend/src/components/shared/UploadIndicator.tsx
@@ -10,7 +10,11 @@ export function UploadIndicator() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const activeUploads = uploads.filter(
-    (u) => u.status === "pending" || u.status === "uploading" || u.status === "indexing"
+    (u) =>
+      u.status === "pending" ||
+      u.status === "uploading" ||
+      u.status === "processing" ||
+      u.status === "indexing"
   );
   const completedCount = uploads.filter((u) => u.status === "indexed").length;
   const hasCompleted = uploads.some(
@@ -85,7 +89,7 @@ export function UploadIndicator() {
         {/* Progress bar - always visible if uploading */}
         {currentUpload && (
           <div className="px-3 pb-2">
-            <Progress value={currentUpload.progress} className="h-1" aria-label="Upload progress" />
+            <Progress value={currentUpload.uploadProgress} className="h-1" aria-label="Upload progress" />
           </div>
         )}
 
@@ -103,7 +107,7 @@ export function UploadIndicator() {
                     upload.status === "indexed" && "text-emerald-600",
                     upload.status === "error" && "text-destructive",
                     upload.status === "cancelled" && "text-muted-foreground",
-                    upload.status === "indexing" && "text-blue-600"
+                    (upload.status === "indexing" || upload.status === "processing") && "text-blue-600"
                   )}
                 >
                   {upload.status === "indexed" && "Done"}
@@ -111,8 +115,9 @@ export function UploadIndicator() {
                   {upload.status === "cancelled" && "Cancelled"}
                   {upload.status === "pending" && "Pending"}
                   {upload.status === "uploading" &&
-                    `${upload.progress > 0 ? upload.progress : 0}%`}
-                  {upload.status === "indexing" && "Indexing…"}
+                    `${upload.uploadProgress > 0 ? upload.uploadProgress : 0}%`}
+                  {(upload.status === "indexing" || upload.status === "processing") &&
+                    (upload.phaseLabel ?? "Processing…")}
                 </span>
               </div>
             ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1454,9 +1454,19 @@ export interface WikiClaim {
   predicate: string | null;
   object: string | null;
   source_type: "document" | "memory" | "chat_synthesis" | "manual" | "mixed";
-  status: "active" | "contradicted" | "superseded" | "unverified" | "archived";
+  // 'needs_review' added by PR C — curator-authored claims default to
+  // this status in draft mode.
+  status:
+    | "active"
+    | "contradicted"
+    | "superseded"
+    | "unverified"
+    | "archived"
+    | "needs_review";
   confidence: number;
   created_by: number | null;
+  /** PR C: provenance — null for legacy / deterministic rows. */
+  created_by_kind?: "deterministic" | "llm_curator" | null;
   created_at: string;
   updated_at: string;
   sources: WikiClaimSource[];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -346,6 +346,37 @@ export interface SettingsResponse {
   hybrid_search_enabled?: boolean;
   hybrid_alpha?: number;
 
+  // Wiki / Knowledge Compiler config (PR B)
+  wiki_enabled?: boolean;
+  wiki_compile_on_ingest?: boolean;
+  wiki_compile_on_query?: boolean;
+  wiki_compile_after_indexing?: boolean;
+  wiki_lint_enabled?: boolean;
+
+  // Optional LLM Wiki Curator config (PR B persists, PR C wires)
+  wiki_llm_curator_enabled?: boolean;
+  wiki_llm_curator_url?: string;
+  wiki_llm_curator_model?: string;
+  wiki_llm_curator_temperature?: number;
+  wiki_llm_curator_max_input_chars?: number;
+  wiki_llm_curator_max_output_tokens?: number;
+  wiki_llm_curator_timeout_sec?: number;
+  wiki_llm_curator_concurrency?: number;
+  wiki_llm_curator_mode?: string;
+  wiki_llm_curator_require_quote_match?: boolean;
+  wiki_llm_curator_require_chunk_id?: boolean;
+  wiki_llm_curator_run_on_ingest?: boolean;
+  wiki_llm_curator_run_on_query?: boolean;
+  wiki_llm_curator_run_on_manual?: boolean;
+
+  /**
+   * Per-field source map: which precedence level produced the
+   * effective runtime value. Reflects actual lifespan order
+   * (kv > env > default). Models tab uses this to label inputs
+   * without disabling them on env presence.
+   */
+  effective_sources?: Record<string, "kv" | "env" | "default">;
+
   // Limits
   max_file_size_mb: number;
   allowed_extensions: string[];
@@ -379,6 +410,34 @@ export interface UpdateSettingsRequest {
   ollama_chat_url?: string;
   embedding_model?: string;
   chat_model?: string;
+  // Wiki / Knowledge Compiler config
+  wiki_enabled?: boolean;
+  wiki_compile_on_ingest?: boolean;
+  wiki_compile_on_query?: boolean;
+  wiki_compile_after_indexing?: boolean;
+  wiki_lint_enabled?: boolean;
+  // Optional LLM Wiki Curator config
+  wiki_llm_curator_enabled?: boolean;
+  wiki_llm_curator_url?: string;
+  wiki_llm_curator_model?: string;
+  wiki_llm_curator_temperature?: number;
+  wiki_llm_curator_max_input_chars?: number;
+  wiki_llm_curator_max_output_tokens?: number;
+  wiki_llm_curator_timeout_sec?: number;
+  wiki_llm_curator_concurrency?: number;
+  wiki_llm_curator_mode?: string;
+  wiki_llm_curator_require_quote_match?: boolean;
+  wiki_llm_curator_require_chunk_id?: boolean;
+  wiki_llm_curator_run_on_ingest?: boolean;
+  wiki_llm_curator_run_on_query?: boolean;
+  wiki_llm_curator_run_on_manual?: boolean;
+}
+
+export interface CuratorTestResult {
+  ok: boolean;
+  model: string;
+  latency_ms: number | null;
+  error: string | null;
 }
 
 export interface SearchMemoriesRequest {
@@ -660,6 +719,20 @@ export async function getHealth(): Promise<HealthResponse> {
 
 export async function getSettings(): Promise<SettingsResponse> {
   const response = await apiClient.get<SettingsResponse>("/settings");
+  return response.data;
+}
+
+export async function testCuratorConnection(
+  url?: string,
+  model?: string,
+): Promise<CuratorTestResult> {
+  const body: Record<string, string> = {};
+  if (url !== undefined) body.url = url;
+  if (model !== undefined) body.model = model;
+  const response = await apiClient.post<CuratorTestResult>(
+    "/settings/curator/test",
+    body,
+  );
   return response.data;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -432,18 +432,37 @@ export interface UploadDocumentResponse {
 }
 
 /**
- * Status payload returned by GET /documents/{id}/status. Used by the chat
- * composer to poll whether an uploaded file has finished indexing before
- * letting the user submit a query that depends on it.
+ * Phase-aware status payload returned by GET /documents/{id}/status.
+ *
+ * `status` stays in the canonical 4-value enum
+ * ("pending" | "processing" | "indexed" | "error"). Async lifecycle detail
+ * (queued / parsing / extracting_text / chunking / embedding / writing_index)
+ * lives in `phase`. `wiki_status` is derived server-side from the latest
+ * wiki_compile_jobs row for this file (or "pending" when the processor has
+ * signalled intent but the job row hasn't appeared yet).
  */
 export interface DocumentStatusResponse {
   id: number;
   filename: string;
-  /** "pending" | "processing" | "indexed" | "error" */
   status: string;
   chunk_count: number;
   error_message?: string | null;
   processed_at?: string | null;
+  /** Granular pipeline phase. May be null for very old rows / fresh installs. */
+  phase?: string | null;
+  phase_message?: string | null;
+  progress_percent?: number | null;
+  processed_units?: number | null;
+  total_units?: number | null;
+  unit_label?: string | null;
+  phase_started_at?: string | null;
+  processing_started_at?: string | null;
+  /** Server-computed seconds since processing_started_at; null when not started. */
+  elapsed_seconds?: number | null;
+  /** "pending" | "running" | "completed" | "failed" | "cancelled" | null */
+  wiki_status?: string | null;
+  wiki_phase?: string | null;
+  wiki_job_id?: number | null;
 }
 
 export interface DocumentStatsResponse {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -545,87 +545,221 @@ export default function DocumentsPage() {
               <CardDescription>
                 {uploads.filter((u) => u.status === "pending").length} pending,{" "}
                 {uploads.filter((u) => u.status === "uploading").length} uploading,{" "}
-                {uploads.filter((u) => u.status === "indexing").length} indexing,{" "}
+                {
+                  uploads.filter(
+                    (u) => u.status === "indexing" || u.status === "processing"
+                  ).length
+                }{" "}
+                processing,{" "}
                 {uploads.filter((u) => u.status === "indexed").length} done
               </CardDescription>
             </div>
-            {uploads.some((u) => u.status === "indexed" || u.status === "error" || u.status === "cancelled") && (
+            {uploads.some(
+              (u) =>
+                u.status === "indexed" ||
+                u.status === "error" ||
+                u.status === "cancelled"
+            ) && (
               <Button variant="ghost" size="sm" onClick={clearCompleted}>
                 Clear Completed
               </Button>
             )}
           </CardHeader>
           <CardContent className="space-y-3">
-            {uploads.map((upload) => (
-              <div key={upload.id} className="space-y-2">
-                <div className="flex justify-between items-center text-sm">
-                  <span className="truncate max-w-[250px]" title={upload.file.name}>
-                    {upload.file.name}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    {upload.status === "indexed" && (
-                      <span className="text-success text-xs">Done</span>
-                    )}
-                    {upload.status === "indexing" && (
-                      <span className="text-blue-600 text-xs">Indexing…</span>
-                    )}
-                    {upload.status === "error" && (
-                      <span className="text-destructive text-xs" title={upload.error}>
-                        Error
+            {uploads.map((upload) => {
+              const isUploading = upload.status === "uploading";
+              const isProcessing =
+                upload.status === "processing" || upload.status === "indexing";
+              const wikiActive =
+                upload.wikiStatus === "pending" ||
+                upload.wikiStatus === "running";
+              const wikiTerminal =
+                upload.wikiStatus === "completed" ||
+                upload.wikiStatus === "failed" ||
+                upload.wikiStatus === "cancelled";
+              const elapsedSec =
+                upload.elapsedSeconds != null
+                  ? Math.max(0, Math.round(upload.elapsedSeconds))
+                  : upload.startedAt
+                  ? Math.round((Date.now() - upload.startedAt) / 1000)
+                  : null;
+              const phaseLabel =
+                upload.phaseLabel ??
+                (isUploading
+                  ? "Uploading"
+                  : isProcessing
+                  ? "Processing"
+                  : upload.status === "indexed"
+                  ? wikiActive
+                    ? "Ready for search · Wiki building"
+                    : wikiTerminal && upload.wikiStatus === "completed"
+                    ? "Ready with wiki"
+                    : "Ready"
+                  : upload.status === "error"
+                  ? "Error"
+                  : upload.status === "cancelled"
+                  ? "Cancelled"
+                  : "Pending");
+              const unitsText =
+                upload.processedUnits != null && upload.totalUnits != null
+                  ? `${upload.processedUnits.toLocaleString()} / ${upload.totalUnits.toLocaleString()} ${
+                      upload.unitLabel ?? ""
+                    }`.trim()
+                  : null;
+              return (
+                <div
+                  key={upload.id}
+                  className="space-y-2 rounded-md border border-border/40 p-3"
+                >
+                  <div className="flex justify-between items-center text-sm">
+                    <span
+                      className="truncate max-w-[250px] font-medium"
+                      title={upload.file.name}
+                    >
+                      {upload.file.name}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={
+                          upload.status === "error"
+                            ? "text-destructive text-xs"
+                            : upload.status === "indexed"
+                            ? "text-success text-xs"
+                            : "text-muted-foreground text-xs"
+                        }
+                        title={upload.error ?? upload.phaseMessage ?? undefined}
+                      >
+                        {phaseLabel}
                       </span>
-                    )}
-                    {upload.status === "cancelled" && (
-                      <span className="text-muted-foreground text-xs">Cancelled</span>
-                    )}
-                    {upload.status === "pending" && (
-                      <span className="text-muted-foreground text-xs">Pending</span>
-                    )}
-                    {upload.status === "uploading" && (
-                      <span className="text-muted-foreground text-xs">
-                        {upload.progress > 0 ? `${upload.progress}%` : "Uploading..."}
-                      </span>
-                    )}
-                    
-                    {upload.status === "pending" && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => cancelUpload(upload.id)}
-                        aria-label={`Cancel upload for ${upload.file.name}`}
-                      >
-                        <X className="w-3 h-3" />
-                      </Button>
-                    )}
-                    {upload.status === "error" && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => retryUpload(upload.id)}
-                        aria-label={`Retry upload for ${upload.file.name}`}
-                      >
-                        <RotateCcw className="w-3 h-3" />
-                      </Button>
-                    )}
-                    {(upload.status === "indexed" || upload.status === "cancelled" || upload.status === "error") && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => removeUpload(upload.id)}
-                        aria-label={`Remove ${upload.file.name} from queue`}
-                      >
-                        <X className="w-3 h-3" />
-                      </Button>
-                    )}
+                      {elapsedSec != null && upload.status !== "pending" && (
+                        <span className="text-muted-foreground text-xs tabular-nums">
+                          {Math.floor(elapsedSec / 60)
+                            .toString()
+                            .padStart(2, "0")}
+                          :
+                          {(elapsedSec % 60).toString().padStart(2, "0")}
+                        </span>
+                      )}
+                      {upload.status === "pending" && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => cancelUpload(upload.id)}
+                          aria-label={`Cancel upload for ${upload.file.name}`}
+                        >
+                          <X className="w-3 h-3" />
+                        </Button>
+                      )}
+                      {upload.status === "error" && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => retryUpload(upload.id)}
+                          aria-label={`Retry upload for ${upload.file.name}`}
+                        >
+                          <RotateCcw className="w-3 h-3" />
+                        </Button>
+                      )}
+                      {(upload.status === "indexed" ||
+                        upload.status === "cancelled" ||
+                        upload.status === "error") && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => removeUpload(upload.id)}
+                          aria-label={`Remove ${upload.file.name} from queue`}
+                        >
+                          <X className="w-3 h-3" />
+                        </Button>
+                      )}
+                    </div>
                   </div>
+
+                  {/* Upload progress (network) — only while uploading */}
+                  {isUploading && (
+                    <div className="space-y-1">
+                      <div className="flex justify-between text-xs text-muted-foreground">
+                        <span>Upload</span>
+                        <span className="tabular-nums">
+                          {upload.uploadProgress > 0
+                            ? `${upload.uploadProgress}%`
+                            : "Starting..."}
+                        </span>
+                      </div>
+                      <Progress
+                        value={upload.uploadProgress}
+                        className="h-1.5"
+                        aria-label="Upload progress"
+                      />
+                    </div>
+                  )}
+
+                  {/* Server-side processing — numeric or indeterminate bar */}
+                  {isProcessing && (
+                    <div className="space-y-1">
+                      <div className="flex justify-between text-xs text-muted-foreground">
+                        <span>
+                          {upload.phaseMessage ?? phaseLabel}
+                          {unitsText ? ` · ${unitsText}` : ""}
+                        </span>
+                        {upload.processingProgress != null && (
+                          <span className="tabular-nums">
+                            {Math.round(upload.processingProgress)}%
+                          </span>
+                        )}
+                      </div>
+                      <Progress
+                        value={upload.processingProgress ?? undefined}
+                        className="h-1.5"
+                        aria-label="Indexing progress"
+                      />
+                      {upload.longRunning && (
+                        <div className="text-xs text-muted-foreground italic">
+                          Still working — large files can take many minutes.
+                          You can leave this page; processing continues in the
+                          background.
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Wiki compile — separate from indexing */}
+                  {(wikiActive || wikiTerminal) && (
+                    <div className="space-y-1">
+                      <div className="flex justify-between text-xs text-muted-foreground">
+                        <span>
+                          Wiki:{" "}
+                          {upload.wikiStatus === "running"
+                            ? "compiling"
+                            : upload.wikiStatus ?? "waiting"}
+                        </span>
+                        {upload.wikiProgress != null && (
+                          <span className="tabular-nums">
+                            {Math.round(upload.wikiProgress)}%
+                          </span>
+                        )}
+                      </div>
+                      {upload.wikiStatus === "running" && (
+                        <Progress
+                          value={upload.wikiProgress ?? undefined}
+                          className="h-1.5"
+                          aria-label="Wiki compile progress"
+                        />
+                      )}
+                    </div>
+                  )}
+
+                  {upload.status === "error" && upload.error && (
+                    <div className="text-xs text-destructive">
+                      {upload.error}
+                    </div>
+                  )}
                 </div>
-                {upload.status === "uploading" && (
-                  <Progress value={upload.progress} className="h-1.5" aria-label="Processing progress" />
-                )}
-              </div>
-            ))}
+              );
+            })}
           </CardContent>
         </Card>
       )}

--- a/frontend/src/pages/SettingsPage.handleInputChange.test.tsx
+++ b/frontend/src/pages/SettingsPage.handleInputChange.test.tsx
@@ -1,64 +1,55 @@
 /**
- * Tests for handleInputChange function in SettingsPage.tsx
+ * PR B: input-handling tests for the redesigned SettingsPage.
  *
- * This tests the fix for type-handling in form inputs:
- * - Non-numeric strings (URLs, model names) now correctly update form state
- * - Empty string on numeric field sets to 0
- * - Empty string on string field sets to ""
- * - Valid numeric strings parse to numbers
- * - Booleans work correctly
+ * Behavior change vs. legacy:
+ *   - Empty numeric input is NO LONGER coerced to 0. Numeric fields use
+ *     the NumberInput primitive which keeps a draft string locally and
+ *     only commits on blur. A blank field remains blank in the draft and
+ *     is never sent to the backend until it parses.
+ *   - The page-level handler is now a thin pass-through to the store's
+ *     `updateFormField`; type narrowing happens at the input edge
+ *     (NumberInput), not the page level.
+ *
+ * Coverage:
+ *   - Strings/URLs/model names round-trip unchanged.
+ *   - Booleans round-trip unchanged.
+ *   - Direct number commits round-trip unchanged.
+ *   - NumberInput keeps the draft visually blank and does NOT commit
+ *     until blur (the legacy "blank == 0" assertion is intentionally
+ *     replaced).
+ *   - On a blank blur, NumberInput commits `undefined` (the parent
+ *     keeps the previous value rather than collapsing to 0).
+ *   - On unparseable non-empty input, NumberInput surfaces invalid
+ *     state and does NOT commit a value.
  */
-
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { SettingsFormData } from "@/stores/useSettingsStore";
+import { NumberInput } from "@/components/settings/NumberInput";
+import {
+  handleSettingsInputChange,
+  LEGACY_NUMERIC_FIELDS,
+} from "@/components/settings/handleInputChange";
 
-// Recreate the handleInputChange logic for direct unit testing
-// This mirrors the exact implementation from SettingsPage.tsx lines 83-119
-
-const numericFields: Set<keyof SettingsFormData> = new Set([
-  "chunk_size_chars",
-  "chunk_overlap_chars",
-  "retrieval_top_k",
-  "auto_scan_interval_minutes",
-  "max_distance_threshold",
-  "retrieval_window",
-  "embedding_batch_size",
-  "hybrid_alpha",
-  "initial_retrieval_top_k",
-  "reranker_top_n",
-]);
-
+// Tests exercise the REAL handler used by SettingsPage. Earlier
+// versions of this test mirrored the implementation inline, which
+// silently drifts on every refactor. Importing the actual function
+// guarantees the tests follow the page.
 function handleInputChange(
   field: keyof SettingsFormData,
   value: string | boolean | number,
-  updateFormField: (field: keyof SettingsFormData, value: any) => void
+  updateFormField: (field: keyof SettingsFormData, value: unknown) => void,
 ) {
-  if (typeof value === "boolean") {
-    updateFormField(field, value);
-  } else if (typeof value === "string") {
-    if (value === "") {
-      // Empty string: for numeric fields, set to 0; for string fields, keep as empty string
-      if (numericFields.has(field)) {
-        updateFormField(field, 0);
-      } else {
-        updateFormField(field as any, value);
-      }
-    } else if (numericFields.has(field)) {
-      const numValue = parseFloat(value);
-      if (!isNaN(numValue)) {
-        updateFormField(field, numValue);
-      }
-    } else {
-      // String field - keep as string
-      updateFormField(field, value);
-    }
-  } else {
-    // number
-    updateFormField(field, value);
-  }
+  // Cast so the test helper accepts the loose signature the legacy
+  // components emit; the real handler does the same.
+  handleSettingsInputChange(
+    field,
+    value,
+    updateFormField as (k: keyof SettingsFormData, v: never) => void,
+  );
 }
 
-describe("handleInputChange", () => {
+describe("SettingsPage handleInputChange (loose pass-through)", () => {
   let updateFormField: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -69,319 +60,205 @@ describe("handleInputChange", () => {
     vi.clearAllMocks();
   });
 
-  describe("string fields (URLs, model names, prefixes)", () => {
-    test("should update string field with non-numeric URL value", () => {
-      handleInputChange("reranker_url", "http://localhost:8001", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranker_url", "http://localhost:8001");
-    });
-
-    test("should update string field with non-numeric model name", () => {
-      handleInputChange("reranker_model", "cross-encoder/ms-marco-MiniLM-L-6-v2", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranker_model", "cross-encoder/ms-marco-MiniLM-L-6-v2");
-    });
-
-    test("should update ollama_embedding_url with URL string", () => {
-      handleInputChange("ollama_embedding_url", "http://192.168.1.100:11434", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("ollama_embedding_url", "http://192.168.1.100:11434");
-    });
-
-    test("should update ollama_chat_url with URL string", () => {
-      handleInputChange("ollama_chat_url", "http://localhost:11434", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("ollama_chat_url", "http://localhost:11434");
-    });
-
-    test("should update embedding_model with model name string", () => {
-      handleInputChange("embedding_model", "nomic-embed-text", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_model", "nomic-embed-text");
-    });
-
-    test("should update chat_model with model name string", () => {
-      handleInputChange("chat_model", "llama3.2", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chat_model", "llama3.2");
-    });
-
-    test("should update vector_metric with string value", () => {
-      handleInputChange("vector_metric", "euclidean", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("vector_metric", "euclidean");
-    });
-
-    test("should update embedding_doc_prefix with string value", () => {
-      handleInputChange("embedding_doc_prefix", "Passage: ", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_doc_prefix", "Passage: ");
-    });
-
-    test("should update embedding_query_prefix with string value", () => {
-      handleInputChange("embedding_query_prefix", "Query: ", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_query_prefix", "Query: ");
-    });
-
-    test("should NOT parse URL-like strings as numbers even if they contain digits", () => {
-      // URLs like "http://10.0.0.1:8080" contain numbers but should remain strings
-      handleInputChange("reranker_url", "http://10.0.0.1:8080/api", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranker_url", "http://10.0.0.1:8080/api");
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("string");
-    });
-
-    test("should handle model names with version numbers (remain as strings)", () => {
-      handleInputChange("chat_model", "gpt-4o-2024-08-06", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chat_model", "gpt-4o-2024-08-06");
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("string");
-    });
+  test("string field round-trip", () => {
+    handleInputChange(
+      "reranker_url",
+      "http://localhost:8001",
+      updateFormField,
+    );
+    expect(updateFormField).toHaveBeenCalledWith(
+      "reranker_url",
+      "http://localhost:8001",
+    );
   });
 
-  describe("empty string handling", () => {
-    test("should convert empty string to 0 for numeric field (chunk_size_chars)", () => {
-      handleInputChange("chunk_size_chars", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chunk_size_chars", 0);
-      expect(updateFormField.mock.calls[0][1]).toBe(0);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should convert empty string to 0 for numeric field (retrieval_top_k)", () => {
-      handleInputChange("retrieval_top_k", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("retrieval_top_k", 0);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should convert empty string to 0 for numeric field (embedding_batch_size)", () => {
-      handleInputChange("embedding_batch_size", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_batch_size", 0);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should convert empty string to 0 for numeric field (hybrid_alpha)", () => {
-      handleInputChange("hybrid_alpha", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("hybrid_alpha", 0);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should convert empty string to 0 for numeric field (max_distance_threshold)", () => {
-      handleInputChange("max_distance_threshold", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("max_distance_threshold", 0);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should keep empty string as empty string for string field (reranker_url)", () => {
-      handleInputChange("reranker_url", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranker_url", "");
-      expect(updateFormField.mock.calls[0][1]).toBe("");
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("string");
-    });
-
-    test("should keep empty string as empty string for string field (reranker_model)", () => {
-      handleInputChange("reranker_model", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranker_model", "");
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("string");
-    });
-
-    test("should keep empty string as empty string for string field (ollama_embedding_url)", () => {
-      handleInputChange("ollama_embedding_url", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("ollama_embedding_url", "");
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("string");
-    });
-
-    test("should keep empty string as empty string for string field (vector_metric)", () => {
-      handleInputChange("vector_metric", "", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("vector_metric", "");
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("string");
-    });
+  test("model-name string round-trip preserves slashes / colons / hyphens", () => {
+    handleInputChange(
+      "embedding_model",
+      "BAAI/bge-large-en-v1.5",
+      updateFormField,
+    );
+    expect(updateFormField).toHaveBeenCalledWith(
+      "embedding_model",
+      "BAAI/bge-large-en-v1.5",
+    );
   });
 
-  describe("numeric string parsing", () => {
-    test("should parse valid numeric string to number for chunk_size_chars", () => {
-      handleInputChange("chunk_size_chars", "2048", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chunk_size_chars", 2048);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should parse valid numeric string with decimal for max_distance_threshold", () => {
-      handleInputChange("max_distance_threshold", "0.75", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("max_distance_threshold", 0.75);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should parse valid numeric string for hybrid_alpha", () => {
-      handleInputChange("hybrid_alpha", "0.5", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("hybrid_alpha", 0.5);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should parse valid numeric string for retrieval_top_k", () => {
-      handleInputChange("retrieval_top_k", "10", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("retrieval_top_k", 10);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should parse valid numeric string for embedding_batch_size", () => {
-      handleInputChange("embedding_batch_size", "1024", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_batch_size", 1024);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should NOT call updateFormField for NaN numeric string on numeric field", () => {
-      // When a non-numeric string is entered for a numeric field, parseFloat returns NaN
-      // The implementation should NOT update the field in this case
-      handleInputChange("chunk_size_chars", "not-a-number", updateFormField);
-      expect(updateFormField).not.toHaveBeenCalled();
-    });
-
-    test("should parse negative numbers correctly", () => {
-      // Even though negative might not be valid semantically, parsing should work
-      handleInputChange("max_distance_threshold", "-0.5", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("max_distance_threshold", -0.5);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should parse integer strings correctly", () => {
-      handleInputChange("chunk_overlap_chars", "256", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chunk_overlap_chars", 256);
-      // Note: JS doesn't distinguish int vs float, but verify it's a number
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
-
-    test("should handle leading/trailing whitespace in numeric strings", () => {
-      // parseFloat("  42  ") returns 42, which is correct
-      handleInputChange("retrieval_top_k", "  42  ", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("retrieval_top_k", 42);
-    });
+  test("empty string on a string field stays empty (no coercion)", () => {
+    handleInputChange("reranker_url", "", updateFormField);
+    expect(updateFormField).toHaveBeenCalledWith("reranker_url", "");
   });
 
-  describe("boolean handling", () => {
-    test("should pass boolean true directly for auto_scan_enabled", () => {
-      handleInputChange("auto_scan_enabled", true, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("auto_scan_enabled", true);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("boolean");
-    });
-
-    test("should pass boolean false directly for auto_scan_enabled", () => {
-      handleInputChange("auto_scan_enabled", false, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("auto_scan_enabled", false);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("boolean");
-    });
-
-    test("should pass boolean true directly for reranking_enabled", () => {
-      handleInputChange("reranking_enabled", true, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranking_enabled", true);
-    });
-
-    test("should pass boolean false directly for reranking_enabled", () => {
-      handleInputChange("reranking_enabled", false, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranking_enabled", false);
-    });
-
-    test("should pass boolean true directly for hybrid_search_enabled", () => {
-      handleInputChange("hybrid_search_enabled", true, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("hybrid_search_enabled", true);
-    });
-
-    test("should pass boolean false directly for hybrid_search_enabled", () => {
-      handleInputChange("hybrid_search_enabled", false, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("hybrid_search_enabled", false);
-    });
+  test("boolean field round-trip", () => {
+    handleInputChange("reranking_enabled", true, updateFormField);
+    handleInputChange("reranking_enabled", false, updateFormField);
+    expect(updateFormField).toHaveBeenNthCalledWith(1, "reranking_enabled", true);
+    expect(updateFormField).toHaveBeenNthCalledWith(2, "reranking_enabled", false);
   });
 
-  describe("direct number handling", () => {
-    test("should pass number directly for numeric field", () => {
-      handleInputChange("chunk_size_chars", 2048, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chunk_size_chars", 2048);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
+  test("direct number commit round-trip", () => {
+    handleInputChange("retrieval_top_k", 42, updateFormField);
+    expect(updateFormField).toHaveBeenCalledWith("retrieval_top_k", 42);
+  });
+});
 
-    test("should pass decimal number directly for numeric field", () => {
-      handleInputChange("max_distance_threshold", 0.85, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("max_distance_threshold", 0.85);
-      expect(updateFormField.mock.calls[0][1]).toBeTypeOf("number");
-    });
+describe("SettingsPage handler — legacy numeric coercion (real implementation)", () => {
+  let updateFormField: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    updateFormField = vi.fn();
   });
 
-  describe("edge cases and adversarial inputs", () => {
-    test("should handle special characters in string fields", () => {
-      handleInputChange("reranker_url", "http://localhost:8080/api/v1?query=test&sort=desc", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("reranker_url", "http://localhost:8080/api/v1?query=test&sort=desc");
-    });
-
-    test("should handle Unicode in string fields", () => {
-      handleInputChange("embedding_doc_prefix", "文档: ", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_doc_prefix", "文档: ");
-    });
-
-    test("should handle very long string values", () => {
-      const longUrl = "http://example.com/" + "a".repeat(1000);
-      handleInputChange("ollama_embedding_url", longUrl, updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("ollama_embedding_url", longUrl);
-    });
-
-    test("should handle scientific notation in numeric fields", () => {
-      handleInputChange("embedding_batch_size", "1e3", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("embedding_batch_size", 1000);
-    });
-
-    test("should handle 'Infinity' string on numeric field (parseFloat returns Infinity)", () => {
-      // parseFloat("Infinity") returns Infinity, which is a valid number in JS
-      handleInputChange("chunk_size_chars", "Infinity", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chunk_size_chars", Infinity);
-    });
-
-    test("should handle '-Infinity' string on numeric field (parseFloat returns -Infinity)", () => {
-      handleInputChange("chunk_size_chars", "-Infinity", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("chunk_size_chars", -Infinity);
-    });
-
-    test("should handle 'NaN' string on numeric field (parseFloat returns NaN)", () => {
-      handleInputChange("chunk_size_chars", "NaN", updateFormField);
-      expect(updateFormField).not.toHaveBeenCalled();
-    });
-
-    test("should handle string with only whitespace for numeric field", () => {
-      // parseFloat("   ") returns NaN
-      handleInputChange("chunk_size_chars", "   ", updateFormField);
-      expect(updateFormField).not.toHaveBeenCalled();
-    });
-
-    test("should handle mixed alphanumeric on numeric field (returns NaN)", () => {
-      handleInputChange("chunk_size_chars", "123abc", updateFormField);
-      // parseFloat("123abc") returns 123, so this WILL update
-      expect(updateFormField).toHaveBeenCalledWith("chunk_size_chars", 123);
-    });
-
-    test("should handle string starting with number then text on numeric field", () => {
-      // parseFloat("42px") returns 42 - this is valid parsing behavior
-      handleInputChange("retrieval_top_k", "42px", updateFormField);
-      expect(updateFormField).toHaveBeenCalledWith("retrieval_top_k", 42);
-    });
+  test("LEGACY_NUMERIC_FIELDS covers every store field the legacy components emit", () => {
+    // Sanity check: if a future field gets added to the legacy
+    // components without being added to the Set, this test gives a
+    // clear failure rather than a confusing string-into-number bug.
+    const expected = [
+      "chunk_size_chars",
+      "chunk_overlap_chars",
+      "retrieval_top_k",
+      "auto_scan_interval_minutes",
+      "max_distance_threshold",
+      "retrieval_window",
+      "embedding_batch_size",
+      "hybrid_alpha",
+      "initial_retrieval_top_k",
+      "reranker_top_n",
+    ];
+    for (const f of expected) {
+      expect(LEGACY_NUMERIC_FIELDS.has(f as keyof SettingsFormData)).toBe(
+        true,
+      );
+    }
   });
 
-  describe("type preservation verification", () => {
-    test("string field receives string type (not number)", () => {
-      handleInputChange("reranker_url", "http://localhost:8080", updateFormField);
-      const callValue = updateFormField.mock.calls[0][1];
-      expect(callValue).toBeTypeOf("string");
-    });
+  test.each([
+    ["chunk_size_chars", "2000", 2000],
+    ["chunk_overlap_chars", "150", 150],
+    ["retrieval_top_k", "8", 8],
+    ["auto_scan_interval_minutes", "30", 30],
+    ["max_distance_threshold", "0.65", 0.65],
+    ["retrieval_window", "2", 2],
+    ["embedding_batch_size", "16", 16],
+    ["hybrid_alpha", "0.4", 0.4],
+    ["initial_retrieval_top_k", "25", 25],
+    ["reranker_top_n", "7", 7],
+  ])(
+    "coerces string '%s' on field %s -> number %s",
+    (field, raw, expected) => {
+      handleInputChange(
+        field as keyof SettingsFormData,
+        raw as string,
+        updateFormField,
+      );
+      expect(updateFormField).toHaveBeenCalledTimes(1);
+      expect(updateFormField).toHaveBeenCalledWith(field, expected);
+      expect(typeof updateFormField.mock.calls[0][1]).toBe("number");
+    },
+  );
 
-    test("numeric field receives number type (not string)", () => {
-      handleInputChange("chunk_size_chars", "1024", updateFormField);
-      const callValue = updateFormField.mock.calls[0][1];
-      expect(callValue).toBeTypeOf("number");
-    });
+  test("blank string on numeric field DOES NOT mutate store (preserves last good value)", () => {
+    handleInputChange("chunk_size_chars", "", updateFormField);
+    expect(updateFormField).not.toHaveBeenCalled();
+  });
 
-    test("empty string on numeric field receives number 0 (not string)", () => {
-      handleInputChange("chunk_size_chars", "", updateFormField);
-      const callValue = updateFormField.mock.calls[0][1];
-      expect(callValue).toBeTypeOf("number");
-      expect(callValue).toBe(0);
-    });
+  test("unparseable non-empty input DOES NOT mutate store", () => {
+    handleInputChange("retrieval_top_k", "abc", updateFormField);
+    expect(updateFormField).not.toHaveBeenCalled();
+  });
 
-    test("empty string on string field receives string (not null/undefined)", () => {
-      handleInputChange("reranker_url", "", updateFormField);
-      const callValue = updateFormField.mock.calls[0][1];
-      expect(callValue).toBeTypeOf("string");
-      expect(callValue).toBe("");
-    });
+  test("non-numeric string field still passes through unchanged", () => {
+    handleInputChange(
+      "ollama_chat_url",
+      "http://localhost:11434",
+      updateFormField,
+    );
+    expect(updateFormField).toHaveBeenCalledWith(
+      "ollama_chat_url",
+      "http://localhost:11434",
+    );
+  });
+});
 
-    test("boolean field receives boolean type", () => {
-      handleInputChange("auto_scan_enabled", true, updateFormField);
-      const callValue = updateFormField.mock.calls[0][1];
-      expect(callValue).toBeTypeOf("boolean");
-    });
+describe("NumberInput draft-string behavior (replaces legacy blank-to-0)", () => {
+  test("blank field does NOT commit while the user is typing", () => {
+    const onCommit = vi.fn();
+    render(<NumberInput value={5} onCommit={onCommit} aria-label="x" />);
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    // Still no commit — only on blur.
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input.value).toBe("");
+  });
+
+  test("blanking and blurring commits undefined (NOT zero)", () => {
+    const onCommit = vi.fn();
+    render(<NumberInput value={5} onCommit={onCommit} aria-label="x" />);
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith(undefined);
+  });
+
+  test("typing a valid number and blurring commits the parsed number", () => {
+    const onCommit = vi.fn();
+    render(<NumberInput value={5} onCommit={onCommit} aria-label="x" />);
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "12.5" } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith(12.5);
+  });
+
+  test("non-empty unparseable input does NOT commit and surfaces invalid", () => {
+    const onCommit = vi.fn();
+    render(<NumberInput value={5} onCommit={onCommit} aria-label="x" />);
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "abc" } });
+    fireEvent.blur(input);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input.getAttribute("data-invalid")).toBe("true");
+  });
+
+  test("Enter key triggers blur on the underlying input", () => {
+    const onCommit = vi.fn();
+    render(<NumberInput value={5} onCommit={onCommit} aria-label="x" />);
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    fireEvent.change(input, { target: { value: "7" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // The handler calls e.currentTarget.blur() — JSDOM moves focus
+    // away. The native blur lifecycle may or may not fire the React
+    // onBlur synchronously depending on the runtime; we assert focus
+    // moved as the observable contract.
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  test("parseAs='int' truncates floats", () => {
+    const onCommit = vi.fn();
+    render(
+      <NumberInput
+        value={5}
+        onCommit={onCommit}
+        parseAs="int"
+        aria-label="x"
+      />,
+    );
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "10.7" } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith(10);
+  });
+
+  test("parent-driven value updates resync the draft", () => {
+    const onCommit = vi.fn();
+    const { rerender } = render(
+      <NumberInput value={5} onCommit={onCommit} aria-label="x" />,
+    );
+    const input = screen.getByLabelText("x") as HTMLInputElement;
+    expect(input.value).toBe("5");
+    rerender(<NumberInput value={42} onCommit={onCommit} aria-label="x" />);
+    expect(input.value).toBe("42");
   });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,29 +1,86 @@
-import { useState, useEffect } from "react";
+/**
+ * Settings page — task-based 6-tab redesign (PR B).
+ *
+ * Tabs: Overview · Models · Documents · Retrieval · Wiki & Curator · Maintenance.
+ * The legacy "AI" + "Advanced" tabs were contradictory (AI claimed
+ * read-only via env vars; Advanced edited the same fields) and have been
+ * removed. Models is now the single source of truth, with a per-field
+ * source badge sourced from the backend's ``effective_sources`` map.
+ *
+ * Numeric inputs use the NumberInput primitive (draft-string semantics)
+ * so blanks no longer collapse to 0 mid-edit. The sticky SaveDiscardFooter
+ * persists across tab switches and shows the count of unsaved changes
+ * plus per-tab dot indicators.
+ *
+ * Discard restores the snapshot taken at load. Save persists via PUT
+ * /settings; the backend rejects (422) curator-enabled bodies missing
+ * url/model.
+ */
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Loader2, AlertTriangle } from "lucide-react";
-import { getSettings, updateSettings, testConnections } from "@/lib/api";
-import type { ConnectionTestResult } from "@/lib/api";
-import { useSettingsStore } from "@/stores/useSettingsStore";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { AlertTriangle } from "lucide-react";
+import {
+  getSettings,
+  updateSettings,
+  testConnections,
+} from "@/lib/api";
+import type { ConnectionTestResult, UpdateSettingsRequest } from "@/lib/api";
+import {
+  useSettingsStore,
+  type SettingsFormData,
+  type SettingsTab,
+} from "@/stores/useSettingsStore";
+import { handleSettingsInputChange } from "@/components/settings/handleInputChange";
 import { ConnectionStatusBadges } from "@/components/shared/ConnectionStatusBadges";
 import type { HealthStatus } from "@/types/health";
 import { useHealthCheck } from "@/hooks/useHealthCheck";
 import { ConnectionSettings } from "@/components/settings/ConnectionSettings";
 import { DocumentProcessingSettings } from "@/components/settings/DocumentProcessingSettings";
-import { ModelConnectionSettings } from "@/components/settings/ModelConnectionSettings";
 import { RAGSettings } from "@/components/settings/RAGSettings";
 import { RetrievalSettings } from "@/components/settings/RetrievalSettings";
-import type { SettingsFormData } from "@/stores/useSettingsStore";
+import { ModelsTab } from "@/components/settings/ModelsTab";
+import { OverviewTab } from "@/components/settings/OverviewTab";
+import { WikiCuratorSettings } from "@/components/settings/WikiCuratorSettings";
+import { MaintenanceSettings } from "@/components/settings/MaintenanceSettings";
+import { SaveDiscardFooter } from "@/components/settings/SaveDiscardFooter";
+import { useVaultStore } from "@/stores/useVaultStore";
 
-// Internal component that renders the settings form
-function SettingsPageContent() {
+function pickDirtyPayload(
+  formData: SettingsFormData,
+  loaded: SettingsFormData,
+): UpdateSettingsRequest {
+  const out: Record<string, unknown> = {};
+  (Object.keys(formData) as Array<keyof SettingsFormData>).forEach((k) => {
+    if (formData[k] !== loaded[k]) {
+      out[k as string] = formData[k];
+    }
+  });
+  return out as UpdateSettingsRequest;
+}
+
+function SettingsPageContent({
+  health,
+  connectionResult,
+  isTestingConnections,
+  onTestConnections,
+}: {
+  health: HealthStatus;
+  connectionResult: ConnectionTestResult | null;
+  isTestingConnections: boolean;
+  onTestConnections: () => Promise<void>;
+}) {
   const {
     settings,
     formData,
+    loadedFormData,
     loading,
     saving,
     error,
@@ -31,15 +88,19 @@ function SettingsPageContent() {
     reindexRequired,
     setSettings,
     initializeForm,
-    setLoading,
     setSaving,
     setError,
     setReindexRequired,
     updateFormField,
     validateForm,
-    hasChanges,
+    discard,
+    dirtyFields,
+    dirtyByTab,
     checkReindexRequired,
   } = useSettingsStore();
+
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const [activeTab, setActiveTab] = useState<SettingsTab>("overview");
 
   useEffect(() => {
     let mounted = true;
@@ -53,174 +114,134 @@ function SettingsPageContent() {
       .catch((err) => {
         if (mounted) {
           setError(err instanceof Error ? err.message : "Failed to load settings");
-          setLoading(false);
         }
       });
     return () => {
       mounted = false;
     };
-  }, [setSettings, initializeForm, setError, setLoading]);
+  }, [setSettings, initializeForm, setError]);
 
-  // Fields that should be parsed as numbers
-  const numericFields: Set<keyof SettingsFormData> = new Set([
-    'chunk_size_chars',
-    'chunk_overlap_chars',
-    'retrieval_top_k',
-    'auto_scan_interval_minutes',
-    'max_distance_threshold',
-    'retrieval_window',
-    'embedding_batch_size',
-    'hybrid_alpha',
-    'initial_retrieval_top_k',
-    'reranker_top_n',
-  ]);
+  const dirtySet = dirtyFields();
+  const dirtyCount = dirtySet.size;
+  const tabDots = dirtyByTab();
+  const effectiveSources = settings?.effective_sources ?? {};
 
-const handleInputChange = (field: keyof SettingsFormData, value: string | boolean | number) => {
-  if (typeof value === "boolean") {
-    updateFormField(field, value);
-  } else if (typeof value === "string") {
-    if (value === "") {
-      // Empty string: for numeric fields, set to 0; for string fields, keep as empty string
-      if (numericFields.has(field)) {
-        updateFormField(field, 0);
-      } else {
-        updateFormField(field as any, value);
-      }
-    } else if (numericFields.has(field)) {
-      const numValue = parseFloat(value);
-      if (!isNaN(numValue)) {
-        updateFormField(field, numValue);
-      }
-    } else {
-      // String field - keep as string
-      updateFormField(field, value);
-    }
-  } else {
-    // number
-    updateFormField(field, value);
-  }
-};
+  // Wrapper that the legacy components call with a loose signature.
+  // Implementation lives in components/settings/handleInputChange.ts so
+  // it can be imported and exercised by tests directly. The legacy
+  // components surface `e.target.value` strings; the helper coerces
+  // numeric fields and intentionally drops blank input (preserves last
+  // good value rather than overwriting with NaN/0). Known legacy
+  // limitation: trailing-garbage input ("12abc") commits the partial
+  // parse silently — the legacy components don't surface invalid state.
+  // The Wiki & Curator tab uses NumberInput which owns its own draft
+  // state and surfaces invalid via data-invalid.
+  const handleInputChange = (
+    field: keyof SettingsFormData,
+    value: string | boolean | number,
+  ) => {
+    handleSettingsInputChange(field, value, updateFormField);
+  };
 
   const handleSave = async () => {
     if (!validateForm()) {
       toast.error("Please fix the highlighted errors before saving.");
       return;
     }
-
-    // Check before save so we know whether embeddings will be invalidated.
     const willRequireReindex = checkReindexRequired();
-
     setSaving(true);
     setError(null);
-
     try {
-      const updated = await updateSettings({
-        chunk_size_chars: formData.chunk_size_chars,
-        chunk_overlap_chars: formData.chunk_overlap_chars,
-        retrieval_top_k: formData.retrieval_top_k,
-        max_distance_threshold: formData.max_distance_threshold,
-        auto_scan_enabled: formData.auto_scan_enabled,
-        auto_scan_interval_minutes: formData.auto_scan_interval_minutes,
-        retrieval_window: formData.retrieval_window,
-        vector_metric: formData.vector_metric,
-        embedding_doc_prefix: formData.embedding_doc_prefix,
-        embedding_query_prefix: formData.embedding_query_prefix,
-        embedding_batch_size: formData.embedding_batch_size,
-        // New retrieval settings
-        reranking_enabled: formData.reranking_enabled,
-        reranker_url: formData.reranker_url,
-        reranker_model: formData.reranker_model,
-        initial_retrieval_top_k: formData.initial_retrieval_top_k,
-        reranker_top_n: formData.reranker_top_n,
-        hybrid_search_enabled: formData.hybrid_search_enabled,
-        hybrid_alpha: formData.hybrid_alpha,
-        // Model connection settings
-        ollama_embedding_url: formData.ollama_embedding_url,
-        ollama_chat_url: formData.ollama_chat_url,
-        embedding_model: formData.embedding_model,
-        chat_model: formData.chat_model,
-      });
+      const payload = pickDirtyPayload(formData, loadedFormData);
+      const updated = await updateSettings(payload);
       setSettings(updated);
+      // Re-initialize so the snapshot reflects the new persisted state
+      // and dirtyFields drops to zero.
+      initializeForm(updated);
       if (willRequireReindex) {
         setReindexRequired(true);
-        toast.warning("Settings saved. Existing document embeddings are stale — reindex required.");
+        toast.warning(
+          "Settings saved. Existing document embeddings are stale — reindex required.",
+        );
       } else {
-        toast.success("Settings saved successfully");
+        toast.success("Settings saved");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save settings");
-      toast.error(err instanceof Error ? err.message : "Failed to save settings");
+      const msg = err instanceof Error ? err.message : "Failed to save settings";
+      setError(msg);
+      toast.error(msg);
     } finally {
       setSaving(false);
     }
   };
 
-  return (
-    <>
-      {loading && (
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-6 w-[180px]" />
-              <Skeleton className="h-4 w-[250px]" />
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-[100px]" />
-                <Skeleton className="h-10 w-full" />
-              </div>
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-[120px]" />
-                <Skeleton className="h-10 w-full" />
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-6 w-[150px]" />
-              <Skeleton className="h-4 w-[200px]" />
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-[80px]" />
-                <Skeleton className="h-10 w-full" />
-              </div>
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-[100px]" />
-                <Skeleton className="h-10 w-full" />
-              </div>
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-[140px]" />
-                <div className="flex items-center gap-4">
-                  <Skeleton className="h-10 w-24" />
-                  <Skeleton className="h-2 flex-1" />
-                </div>
-              </div>
-              <div className="flex items-center gap-2 pt-4">
-                <Skeleton className="h-4 w-4" />
-                <Skeleton className="h-4 w-[120px]" />
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      )}
+  const handleDiscard = () => {
+    discard();
+    toast.info("Discarded unsaved changes");
+  };
 
-      {error && (
+  const validationFailed = useMemo(() => {
+    return Object.keys(errors).length > 0;
+  }, [errors]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
         <Card>
-          <CardContent className="py-8">
-            <p className="text-destructive text-center">Error: {error}</p>
+          <CardHeader>
+            <Skeleton className="h-6 w-[180px]" />
+            <Skeleton className="h-4 w-[250px]" />
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
           </CardContent>
         </Card>
-      )}
+      </div>
+    );
+  }
 
+  if (error && !settings) {
+    return (
+      <Card>
+        <CardContent className="py-8">
+          <p className="text-destructive text-center">Error: {error}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const tabTrigger = (value: SettingsTab, label: string) => (
+    <TabsTrigger value={value}>
+      <span className="flex items-center gap-1">
+        {label}
+        {tabDots[value] > 0 && (
+          <span
+            className="h-1.5 w-1.5 rounded-full bg-primary"
+            aria-label={`${tabDots[value]} unsaved changes in ${label}`}
+          />
+        )}
+      </span>
+    </TabsTrigger>
+  );
+
+  return (
+    <>
       {reindexRequired && (
         <div className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800 p-4">
-          <AlertTriangle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" aria-hidden />
+          <AlertTriangle
+            className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5"
+            aria-hidden
+          />
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Reindex required</p>
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+              Reindex required
+            </p>
             <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">
-              Changes to embedding model, chunk size, or vector settings invalidate existing document
-              embeddings. Re-process your documents via the Documents page to restore accurate retrieval.
+              Changes to embedding model, chunk size, or vector settings
+              invalidate existing document embeddings. Re-process documents
+              from the Documents page or run a wiki recompile from the
+              Maintenance tab.
             </p>
           </div>
           <button
@@ -232,107 +253,101 @@ const handleInputChange = (field: keyof SettingsFormData, value: string | boolea
         </div>
       )}
 
-      {!loading && !error && (
-        <Tabs defaultValue="ai" className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-2">
-            <TabsTrigger value="ai">AI</TabsTrigger>
-            <TabsTrigger value="advanced">Advanced</TabsTrigger>
-          </TabsList>
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as SettingsTab)}
+        className="w-full"
+      >
+        <TabsList className="grid w-full max-w-3xl grid-cols-6">
+          {tabTrigger("overview", "Overview")}
+          {tabTrigger("models", "Models")}
+          {tabTrigger("documents", "Documents")}
+          {tabTrigger("retrieval", "Retrieval")}
+          {tabTrigger("wiki", "Wiki & Curator")}
+          {tabTrigger("maintenance", "Maintenance")}
+        </TabsList>
 
-          <TabsContent value="ai">
-            <Card>
-              <CardHeader>
-                <CardTitle>AI Configuration</CardTitle>
-                <CardDescription>Configure AI model and behavior (read-only, set via environment variables)</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <label htmlFor="chat-model" className="text-sm font-medium">Chat Model</label>
-                  <Input
-                    id="chat-model"
-                    value={settings?.chat_model || "Not configured"}
-                    readOnly
-                    className="bg-muted"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    LLM model used for chat responses (set via CHAT_MODEL env var)
-                  </p>
-                </div>
-                <div className="space-y-2">
-                  <label htmlFor="embedding-model" className="text-sm font-medium">Embedding Model</label>
-                  <Input
-                    id="embedding-model"
-                    value={settings?.embedding_model || "Not configured"}
-                    readOnly
-                    className="bg-muted"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Model used for document embeddings (set via EMBEDDING_MODEL env var)
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
+        <TabsContent value="overview">
+          <OverviewTab
+            health={health}
+            connectionResult={connectionResult}
+            isTestingConnections={isTestingConnections}
+            onTestConnections={() => {
+              void onTestConnections();
+            }}
+            curatorEnabled={formData.wiki_llm_curator_enabled}
+            wikiEnabled={formData.wiki_enabled}
+          />
+        </TabsContent>
 
-<TabsContent value="advanced" className="space-y-4">
-				{/* Model Connection Settings */}
-      <ModelConnectionSettings
-        formData={formData}
-        errors={errors}
-        onChange={handleInputChange}
+        <TabsContent value="models">
+          <ModelsTab
+            formData={formData}
+            errors={errors}
+            onChange={(f, v) =>
+              updateFormField(f, v as SettingsFormData[typeof f])
+            }
+            effectiveSources={
+              effectiveSources as Record<string, "kv" | "env" | "default">
+            }
+          />
+        </TabsContent>
+
+        <TabsContent value="documents" className="space-y-4">
+          <DocumentProcessingSettings
+            formData={formData}
+            errors={errors}
+            onChange={handleInputChange}
+          />
+        </TabsContent>
+
+        <TabsContent value="retrieval" className="space-y-4">
+          <RAGSettings
+            formData={formData}
+            errors={errors}
+            onChange={handleInputChange}
+          />
+          <RetrievalSettings
+            formData={formData}
+            errors={errors}
+            onChange={handleInputChange}
+          />
+        </TabsContent>
+
+        <TabsContent value="wiki" className="space-y-4">
+          <WikiCuratorSettings
+            formData={formData}
+            errors={errors}
+            onChange={(f, v) =>
+              updateFormField(f, v as SettingsFormData[typeof f])
+            }
+          />
+        </TabsContent>
+
+        <TabsContent value="maintenance" className="space-y-4">
+          <MaintenanceSettings vaultId={activeVaultId} />
+        </TabsContent>
+      </Tabs>
+
+      <SaveDiscardFooter
+        dirtyCount={dirtyCount}
+        invalid={validationFailed}
+        saving={saving}
+        onSave={handleSave}
+        onDiscard={handleDiscard}
       />
-
-      {/* Document Processing Settings */}
-      <DocumentProcessingSettings
-              formData={formData}
-              errors={errors}
-              onChange={handleInputChange}
-            />
-
-            {/* RAG Settings */}
-            <RAGSettings
-              formData={formData}
-              errors={errors}
-              onChange={handleInputChange}
-            />
-
-            {/* Retrieval Settings */}
-            <RetrievalSettings
-              formData={formData}
-              errors={errors}
-              onChange={handleInputChange}
-            />
-
-            {/* Save Button and Status */}
-            <div className="flex items-center gap-4 pt-4 border-t">
-              <Button
-                onClick={handleSave}
-                disabled={saving || !hasChanges()}
-              >
-                {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-                Save Changes
-              </Button>
-
-              {hasChanges() && (
-                <span className="text-sm text-muted-foreground">You have unsaved changes</span>
-              )}
-            </div>
-          </TabsContent>
-
-        </Tabs>
-      )}
     </>
   );
 }
 
-// Wrapper that provides health status and connection test
 function SettingsPageWithStatus({ health }: { health: HealthStatus }) {
   const formatLastChecked = (date: Date | null) => {
     if (!date) return "Not checked";
     return `Last checked: ${date.toLocaleTimeString()}`;
   };
 
-  const [connectionResult, setConnectionResult] = useState<ConnectionTestResult | null>(null);
+  const [connectionResult, setConnectionResult] =
+    useState<ConnectionTestResult | null>(null);
   const [isTestingConnections, setIsTestingConnections] = useState(false);
 
   const handleConnectionTest = async () => {
@@ -350,29 +365,35 @@ function SettingsPageWithStatus({ health }: { health: HealthStatus }) {
     }
   };
 
+  // Hide the unused-warning for dropped ConnectionSettings consumer.
+  void ConnectionSettings;
+
   return (
     <div className="space-y-6 animate-in fade-in duration-300">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
-          <p className="text-muted-foreground mt-1">Configure your application preferences</p>
+          <p className="text-muted-foreground mt-1">
+            Configure your application preferences
+          </p>
         </div>
         <div className="flex flex-col items-end gap-1">
           <ConnectionStatusBadges health={health} />
-          <span className="text-xs text-muted-foreground">{formatLastChecked(health.lastChecked)}</span>
-          <ConnectionSettings
-            onTestConnections={handleConnectionTest}
-            isTesting={isTestingConnections}
-            connectionStatus={connectionResult}
-          />
+          <span className="text-xs text-muted-foreground">
+            {formatLastChecked(health.lastChecked)}
+          </span>
         </div>
       </div>
-      <SettingsPageContent />
+      <SettingsPageContent
+        health={health}
+        connectionResult={connectionResult}
+        isTestingConnections={isTestingConnections}
+        onTestConnections={handleConnectionTest}
+      />
     </div>
   );
 }
 
-// Main SettingsPage that checks health
 export default function SettingsPage() {
   const health = useHealthCheck();
   return <SettingsPageWithStatus health={health} />;

--- a/frontend/src/pages/WikiJobsPanel.tsx
+++ b/frontend/src/pages/WikiJobsPanel.tsx
@@ -170,6 +170,9 @@ export function WikiJobsPanel({ vaultId }: WikiJobsPanelProps) {
               </p>
             )}
 
+            {/* PR C: optional curator summary, parsed from result_json. */}
+            <CuratorSummary resultJson={job.result_json} />
+
             {/* Actions */}
             <div className="flex gap-1.5 mt-0.5">
               {job.status === "failed" && (
@@ -208,6 +211,68 @@ export function WikiJobsPanel({ vaultId }: WikiJobsPanelProps) {
           </CardContent>
         </Card>
       ))}
+    </div>
+  );
+}
+
+/**
+ * PR C — curator summary block for a wiki compile job.
+ *
+ * Reads the optional ``curator`` block from the job's ``result_json``
+ * and renders accepted / rejected / lint / errors counts. Tolerates
+ * missing/malformed data; renders nothing when there is no curator
+ * activity (curator was disabled for this trigger or short-circuited
+ * before any output).
+ */
+function CuratorSummary({
+  resultJson,
+}: {
+  resultJson: string | null | undefined;
+}) {
+  if (!resultJson) return null;
+  let parsed: unknown;
+  try {
+    parsed =
+      typeof resultJson === "string" ? JSON.parse(resultJson) : resultJson;
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const curator = (parsed as { curator?: unknown }).curator;
+  if (!curator || typeof curator !== "object") return null;
+  const c = curator as {
+    accepted?: number;
+    rejected?: number;
+    lint?: number;
+    errors?: unknown;
+    calls?: number;
+  };
+  const accepted = Number(c.accepted ?? 0);
+  const rejected = Number(c.rejected ?? 0);
+  const lint = Number(c.lint ?? 0);
+  const calls = Number(c.calls ?? 0);
+  const errors = Array.isArray(c.errors) ? c.errors.length : 0;
+  if (accepted + rejected + lint + calls + errors === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2 text-[11px] text-muted-foreground pt-0.5">
+      <span title="LLM curator candidates accepted (with verified source quote)">
+        Curator accepted: <strong className="text-foreground">{accepted}</strong>
+      </span>
+      <span title="Curator candidates rejected by quote/chunk verification">
+        rejected: <strong className="text-foreground">{rejected}</strong>
+      </span>
+      <span title="Curator-derived lint findings (e.g. unsupported_claim)">
+        lint: <strong className="text-foreground">{lint}</strong>
+      </span>
+      <span title="Curator transport / parse errors (job still completed)">
+        errors:{" "}
+        <strong className={errors ? "text-destructive" : "text-foreground"}>
+          {errors}
+        </strong>
+      </span>
+      <span title="HTTP calls issued to the curator">
+        calls: <strong className="text-foreground">{calls}</strong>
+      </span>
     </div>
   );
 }

--- a/frontend/src/pages/WikiPageDetail.curator.test.tsx
+++ b/frontend/src/pages/WikiPageDetail.curator.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * PR C: Wiki UI extensions for the optional LLM curator.
+ *
+ * Covers:
+ *   - WikiPageDetail renders a "deterministic" chip for legacy /
+ *     deterministic claims.
+ *   - WikiPageDetail renders an "LLM curator" chip for curator-authored
+ *     claims (created_by_kind === "llm_curator").
+ *   - WikiPageDetail surfaces "Needs review" for status==='needs_review'
+ *     so reviewers see candidates pending verification clearly.
+ *   - WikiJobsPanel curator summary parses result_json and renders
+ *     accepted/rejected/lint/errors counts only when present.
+ *   - The summary renders nothing when curator block is missing or
+ *     result_json is malformed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WikiPageDetail } from "./WikiPageDetail";
+import type { WikiClaim, WikiPage, WikiCompileJob } from "@/lib/api";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function makeClaim(overrides: Partial<WikiClaim> = {}): WikiClaim {
+  return {
+    id: 1,
+    vault_id: 2,
+    page_id: 10,
+    claim_text: "Alice founded the company",
+    claim_type: "fact",
+    subject: "Alice",
+    predicate: "founded",
+    object: "the company",
+    source_type: "document",
+    status: "active",
+    confidence: 0.9,
+    created_by: null,
+    created_by_kind: null,
+    created_at: "2024-01-01T00:00:00",
+    updated_at: "2024-01-01T00:00:00",
+    sources: [],
+    ...overrides,
+  } as WikiClaim;
+}
+
+function makePage(claims: WikiClaim[]): WikiPage {
+  return {
+    id: 10,
+    vault_id: 2,
+    slug: "doc/alice",
+    title: "Alice doc",
+    page_type: "entity",
+    summary: "",
+    markdown: "",
+    status: "draft",
+    confidence: 0.0,
+    created_by: null,
+    created_at: "2024-01-01T00:00:00",
+    updated_at: "2024-01-01T00:00:00",
+    last_compiled_at: null,
+    claims,
+    entities: [],
+    lint_findings: [],
+  } as unknown as WikiPage;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WikiPageDetail provenance chips", () => {
+  it("renders 'deterministic' chip for legacy / deterministic claims", () => {
+    const page = makePage([makeClaim({ created_by_kind: "deterministic" })]);
+    render(
+      <WikiPageDetail
+        page={page}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    expect(screen.getByText(/deterministic/i)).toBeInTheDocument();
+    expect(screen.queryByText(/LLM curator/i)).not.toBeInTheDocument();
+  });
+
+  it("renders 'LLM curator' chip for curator-authored claims", () => {
+    const page = makePage([makeClaim({ created_by_kind: "llm_curator" })]);
+    render(
+      <WikiPageDetail
+        page={page}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    expect(screen.getByText(/LLM curator/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Needs review' badge when status is needs_review", () => {
+    const page = makePage([
+      makeClaim({
+        created_by_kind: "llm_curator",
+        status: "needs_review",
+      }),
+    ]);
+    render(
+      <WikiPageDetail
+        page={page}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Needs review/i)).toBeInTheDocument();
+  });
+
+  it("treats null created_by_kind as deterministic for display", () => {
+    const page = makePage([makeClaim({ created_by_kind: null })]);
+    render(
+      <WikiPageDetail
+        page={page}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    expect(screen.getByText(/deterministic/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------
+// CuratorSummary parses result_json defensively.
+// ---------------------------------------------------------------------
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    listWikiJobs: vi.fn(async () => ({
+      jobs: ((globalThis as unknown as { __wikiJobsForTest: WikiCompileJob[] })
+        .__wikiJobsForTest ?? []),
+    })),
+    retryWikiJob: vi.fn(async () => ({} as WikiCompileJob)),
+    cancelWikiJob: vi.fn(async () => ({ job_id: 0, status: "cancelled" })),
+    recompileVaultWiki: vi.fn(async () => ({ job_id: 999, status: "pending" })),
+  };
+});
+
+import { WikiJobsPanel } from "./WikiJobsPanel";
+
+function withTestJobs(jobs: WikiCompileJob[]) {
+  (globalThis as unknown as { __wikiJobsForTest: WikiCompileJob[] }).__wikiJobsForTest =
+    jobs;
+}
+
+function makeJob(overrides: Partial<WikiCompileJob> = {}): WikiCompileJob {
+  return {
+    id: 1,
+    vault_id: 2,
+    trigger_type: "ingest",
+    trigger_id: "file:42",
+    status: "completed",
+    error: null,
+    result_json: "{}",
+    created_at: "2024-01-01T00:00:00",
+    started_at: "2024-01-01T00:00:00",
+    completed_at: "2024-01-01T00:00:01",
+    ...overrides,
+  } as WikiCompileJob;
+}
+
+describe("WikiJobsPanel curator summary", () => {
+  it("renders curator counts when present in result_json", async () => {
+    withTestJobs([
+      makeJob({
+        result_json: JSON.stringify({
+          curator: {
+            accepted: 3,
+            rejected: 2,
+            lint: 1,
+            errors: ["timeout"],
+            calls: 1,
+          },
+        }),
+      }),
+    ]);
+    render(<WikiJobsPanel vaultId={2} />);
+    expect(await screen.findByText(/Curator accepted:/i)).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    // errors=1 from the array length
+    expect(screen.getByText("1", { selector: "strong.text-destructive" })).toBeInTheDocument();
+  });
+
+  it("renders nothing when curator block is missing", async () => {
+    withTestJobs([makeJob({ result_json: "{}" })]);
+    render(<WikiJobsPanel vaultId={2} />);
+    // Wait for the panel to settle.
+    expect(await screen.findByText("Compile Jobs")).toBeInTheDocument();
+    expect(screen.queryByText(/Curator accepted:/i)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for malformed result_json", async () => {
+    withTestJobs([makeJob({ result_json: "{not even json" })]);
+    render(<WikiJobsPanel vaultId={2} />);
+    expect(await screen.findByText("Compile Jobs")).toBeInTheDocument();
+    expect(screen.queryByText(/Curator accepted:/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WikiPageDetail.tsx
+++ b/frontend/src/pages/WikiPageDetail.tsx
@@ -20,13 +20,54 @@ const SEVERITY_COLORS: Record<string, string> = {
 };
 
 function ClaimRow({ claim }: { claim: WikiClaim }) {
+  // PR C: surface curator provenance + needs_review state distinctly.
+  // ``created_by_kind`` is "deterministic" | "llm_curator" | null.
+  // Null = legacy / unknown row; treat as deterministic for display.
+  const isCurator = claim.created_by_kind === "llm_curator";
+  const isNeedsReview = claim.status === "needs_review";
+  const rowBg = isNeedsReview
+    ? "bg-blue-50/60 dark:bg-blue-950/20 rounded-md px-2 -mx-2"
+    : "";
   return (
-    <div className="border-b border-border pb-2 mb-2 last:border-0 last:mb-0 last:pb-0">
+    <div
+      className={`border-b border-border pb-2 mb-2 last:border-0 last:mb-0 last:pb-0 ${rowBg}`}
+    >
       <p className="text-sm">{claim.claim_text}</p>
-      <div className="flex gap-2 mt-1 flex-wrap">
-        {claim.subject && <span className="text-xs text-muted-foreground">Subject: {claim.subject}</span>}
-        {claim.predicate && <span className="text-xs text-muted-foreground">· {claim.predicate}</span>}
-        {claim.object && <span className="text-xs text-muted-foreground">→ {claim.object}</span>}
+      <div className="flex gap-2 mt-1 flex-wrap items-center">
+        {claim.subject && (
+          <span className="text-xs text-muted-foreground">
+            Subject: {claim.subject}
+          </span>
+        )}
+        {claim.predicate && (
+          <span className="text-xs text-muted-foreground">· {claim.predicate}</span>
+        )}
+        {claim.object && (
+          <span className="text-xs text-muted-foreground">→ {claim.object}</span>
+        )}
+        {/* Provenance chip — distinguishes curator output from
+            deterministic extraction so reviewers know which claims to
+            scrutinise harder. */}
+        <Badge
+          variant={isCurator ? "secondary" : "outline"}
+          className="text-[10px] uppercase"
+          title={
+            isCurator
+              ? "Authored by the optional LLM curator. Active only when source quote verifies."
+              : "Authored by deterministic regex/parser extraction."
+          }
+        >
+          {isCurator ? "LLM curator" : "deterministic"}
+        </Badge>
+        {isNeedsReview && (
+          <Badge
+            variant="outline"
+            className="text-[10px] uppercase border-blue-300 text-blue-700 dark:text-blue-300"
+            title="Needs operator review before becoming an active claim."
+          >
+            Needs review
+          </Badge>
+        )}
       </div>
       {claim.sources && claim.sources.length > 0 && (
         <div className="flex gap-1 flex-wrap mt-1">

--- a/frontend/src/stores/useSettingsStore.test.ts
+++ b/frontend/src/stores/useSettingsStore.test.ts
@@ -1,0 +1,196 @@
+/**
+ * PR B: settings store regression tests for the redesigned dirty/discard
+ * snapshot logic and curator validation.
+ *
+ * Covers:
+ *   - Initial dirty count is zero after initializeForm.
+ *   - Editing a field flips dirtyFields to include exactly that key.
+ *   - dirtyByTab correctly partitions across tabs (using FIELD_TAB).
+ *   - discard restores the snapshot and zeroes dirty.
+ *   - validateForm flags curator-enabled-without-url/model.
+ *   - validateForm enforces curator numeric ranges.
+ *   - hasChanges follows dirtyFields rather than the old cascade.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useSettingsStore,
+  type SettingsFormData,
+} from "./useSettingsStore";
+import type { SettingsResponse } from "@/lib/api";
+
+function baseSettings(): SettingsResponse {
+  return {
+    port: 9090,
+    data_dir: "/tmp/data",
+    ollama_embedding_url: "http://localhost:11434",
+    ollama_chat_url: "http://localhost:11434",
+    embedding_model: "harrier",
+    chat_model: "llama3",
+    chunk_size_chars: 2000,
+    chunk_overlap_chars: 200,
+    retrieval_top_k: 5,
+    max_distance_threshold: 0.7,
+    retrieval_window: 1,
+    vector_metric: "cosine",
+    embedding_doc_prefix: "Passage: ",
+    embedding_query_prefix: "Query: ",
+    maintenance_mode: false,
+    auto_scan_enabled: false,
+    auto_scan_interval_minutes: 60,
+    enable_model_validation: false,
+    embedding_batch_size: 32,
+    reranking_enabled: false,
+    reranker_url: "",
+    reranker_model: "",
+    initial_retrieval_top_k: 20,
+    reranker_top_n: 5,
+    hybrid_search_enabled: false,
+    hybrid_alpha: 0.5,
+    wiki_enabled: true,
+    wiki_compile_on_ingest: true,
+    wiki_compile_on_query: true,
+    wiki_compile_after_indexing: true,
+    wiki_lint_enabled: true,
+    wiki_llm_curator_enabled: false,
+    wiki_llm_curator_url: "",
+    wiki_llm_curator_model: "",
+    wiki_llm_curator_temperature: 0.0,
+    wiki_llm_curator_max_input_chars: 6000,
+    wiki_llm_curator_max_output_tokens: 2048,
+    wiki_llm_curator_timeout_sec: 120,
+    wiki_llm_curator_concurrency: 1,
+    wiki_llm_curator_mode: "draft",
+    wiki_llm_curator_require_quote_match: true,
+    wiki_llm_curator_require_chunk_id: true,
+    wiki_llm_curator_run_on_ingest: true,
+    wiki_llm_curator_run_on_query: false,
+    wiki_llm_curator_run_on_manual: true,
+    effective_sources: { ollama_chat_url: "kv" },
+    max_file_size_mb: 100,
+    allowed_extensions: [".pdf", ".txt"],
+    backend_cors_origins: ["http://localhost:3000"],
+  } as unknown as SettingsResponse;
+}
+
+beforeEach(() => {
+  useSettingsStore.getState().resetState();
+});
+
+describe("useSettingsStore (PR B)", () => {
+  it("initializes the snapshot so dirtyFields is empty after load", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    expect(useSettingsStore.getState().dirtyFields().size).toBe(0);
+    expect(useSettingsStore.getState().hasChanges()).toBe(false);
+  });
+
+  it("editing a single field marks exactly that field dirty", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore.getState().updateFormField("retrieval_top_k", 17);
+    const dirty = useSettingsStore.getState().dirtyFields();
+    expect(dirty.size).toBe(1);
+    expect(dirty.has("retrieval_top_k")).toBe(true);
+    expect(useSettingsStore.getState().hasChanges()).toBe(true);
+  });
+
+  it("dirtyByTab partitions across tabs correctly", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore.getState().updateFormField("retrieval_top_k", 17); // retrieval
+    useSettingsStore.getState().updateFormField("chat_model", "newmodel"); // models
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_enabled", true); // wiki
+    const tabs = useSettingsStore.getState().dirtyByTab();
+    expect(tabs.retrieval).toBe(1);
+    expect(tabs.models).toBe(1);
+    expect(tabs.wiki).toBe(1);
+    expect(tabs.documents).toBe(0);
+    expect(tabs.maintenance).toBe(0);
+    expect(tabs.overview).toBe(0);
+  });
+
+  it("discard restores the snapshot and clears dirty + errors", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore.getState().updateFormField("retrieval_top_k", 17);
+    useSettingsStore.getState().updateFormField("chat_model", "newmodel");
+    useSettingsStore.getState().setErrors({ retrieval_top_k: "bad" });
+    expect(useSettingsStore.getState().hasChanges()).toBe(true);
+
+    useSettingsStore.getState().discard();
+    expect(useSettingsStore.getState().hasChanges()).toBe(false);
+    expect(useSettingsStore.getState().dirtyFields().size).toBe(0);
+    expect(useSettingsStore.getState().formData.retrieval_top_k).toBe(5);
+    expect(useSettingsStore.getState().formData.chat_model).toBe("llama3");
+    expect(useSettingsStore.getState().errors).toEqual({});
+  });
+
+  it("validateForm flags curator-enabled-without-url-or-model", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_enabled", true);
+    const ok = useSettingsStore.getState().validateForm();
+    expect(ok).toBe(false);
+    const errs = useSettingsStore.getState().errors;
+    expect(errs.wiki_llm_curator_url).toBeTruthy();
+    expect(errs.wiki_llm_curator_model).toBeTruthy();
+  });
+
+  it("validateForm passes when curator enabled with url + model", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_enabled", true);
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_url", "https://api.example.com");
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_model", "qwen-1b");
+    const ok = useSettingsStore.getState().validateForm();
+    expect(ok).toBe(true);
+  });
+
+  it("validateForm rejects out-of-range curator numeric fields", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_temperature", 2.5);
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_max_input_chars", 100);
+    useSettingsStore
+      .getState()
+      .updateFormField("wiki_llm_curator_concurrency", 99);
+    useSettingsStore.getState().validateForm();
+    const errs = useSettingsStore.getState().errors;
+    expect(errs.wiki_llm_curator_temperature).toBeTruthy();
+    expect(errs.wiki_llm_curator_max_input_chars).toBeTruthy();
+    expect(errs.wiki_llm_curator_concurrency).toBeTruthy();
+  });
+
+  it("validateForm rejects unknown curator mode", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore
+      .getState()
+      .updateFormField(
+        "wiki_llm_curator_mode" as keyof SettingsFormData,
+        "yolo" as never,
+      );
+    const ok = useSettingsStore.getState().validateForm();
+    expect(ok).toBe(false);
+    expect(
+      useSettingsStore.getState().errors.wiki_llm_curator_mode,
+    ).toBeTruthy();
+  });
+
+  it("save snapshot resync via initializeForm zeroes dirty after persist round-trip", () => {
+    useSettingsStore.getState().initializeForm(baseSettings());
+    useSettingsStore.getState().updateFormField("retrieval_top_k", 11);
+    expect(useSettingsStore.getState().hasChanges()).toBe(true);
+    // Simulate the post-save flow: SettingsPage calls initializeForm with
+    // the freshly-persisted settings.
+    const persisted = { ...baseSettings(), retrieval_top_k: 11 };
+    useSettingsStore.getState().initializeForm(persisted);
+    expect(useSettingsStore.getState().hasChanges()).toBe(false);
+  });
+});

--- a/frontend/src/stores/useSettingsStore.ts
+++ b/frontend/src/stores/useSettingsStore.ts
@@ -1,19 +1,41 @@
 import { create } from "zustand";
 import type { SettingsResponse } from "@/lib/api";
 
+/**
+ * Settings store — phase-aware (PR B).
+ *
+ * Form fields are read/written by the new SettingsPage tabs. Numeric inputs
+ * use draft-string state in the UI: an empty string is a transient
+ * "user is editing" state, not the value zero. The store only sees the
+ * coerced value once the user blurs / saves, so blanks never accidentally
+ * become zero in the persisted payload.
+ *
+ * Dirty tracking compares the live ``formData`` against a snapshot taken
+ * at load time (``loadedFormData``). ``discard()`` restores the snapshot.
+ * ``dirtyByTab`` powers the SaveDiscardFooter dot indicators.
+ */
+export type SettingsTab =
+  | "overview"
+  | "models"
+  | "documents"
+  | "retrieval"
+  | "wiki"
+  | "maintenance";
+
 export interface SettingsFormData {
+  // Document processing
   chunk_size_chars: number;
   chunk_overlap_chars: number;
   retrieval_top_k: number;
   auto_scan_enabled: boolean;
   auto_scan_interval_minutes: number;
+  // Retrieval
   max_distance_threshold: number;
   retrieval_window: number;
   vector_metric: string;
   embedding_doc_prefix: string;
   embedding_query_prefix: string;
   embedding_batch_size: number;
-  // Retrieval settings
   reranking_enabled: boolean;
   reranker_url: string;
   reranker_model: string;
@@ -21,35 +43,82 @@ export interface SettingsFormData {
   reranker_top_n: number;
   hybrid_search_enabled: boolean;
   hybrid_alpha: number;
-  // Model connection settings
+  // Models tab
   ollama_embedding_url: string;
   ollama_chat_url: string;
   embedding_model: string;
   chat_model: string;
+  // Wiki & curator (PR B + PR C)
+  wiki_enabled: boolean;
+  wiki_compile_on_ingest: boolean;
+  wiki_compile_on_query: boolean;
+  wiki_compile_after_indexing: boolean;
+  wiki_lint_enabled: boolean;
+  wiki_llm_curator_enabled: boolean;
+  wiki_llm_curator_url: string;
+  wiki_llm_curator_model: string;
+  wiki_llm_curator_temperature: number;
+  wiki_llm_curator_max_input_chars: number;
+  wiki_llm_curator_max_output_tokens: number;
+  wiki_llm_curator_timeout_sec: number;
+  wiki_llm_curator_concurrency: number;
+  wiki_llm_curator_mode: string;
+  wiki_llm_curator_require_quote_match: boolean;
+  wiki_llm_curator_require_chunk_id: boolean;
+  wiki_llm_curator_run_on_ingest: boolean;
+  wiki_llm_curator_run_on_query: boolean;
+  wiki_llm_curator_run_on_manual: boolean;
 }
 
-export interface SettingsErrors {
-  chunk_size_chars?: string;
-  chunk_overlap_chars?: string;
-  retrieval_top_k?: string;
-  auto_scan_interval_minutes?: string;
-  max_distance_threshold?: string;
-  retrieval_window?: string;
-  vector_metric?: string;
-  embedding_doc_prefix?: string;
-  embedding_query_prefix?: string;
-  embedding_batch_size?: string;
-  reranker_url?: string;
-  reranker_model?: string;
-  initial_retrieval_top_k?: string;
-  reranker_top_n?: string;
-  hybrid_alpha?: string;
-  // Model connection settings
-  ollama_embedding_url?: string;
-  ollama_chat_url?: string;
-  embedding_model?: string;
-  chat_model?: string;
-}
+export type SettingsErrors = Partial<Record<keyof SettingsFormData, string>>;
+
+/**
+ * Mapping of each form field to its tab. Used by ``dirtyByTab`` so the
+ * SaveDiscardFooter can show a dot per tab with unsaved changes.
+ */
+export const FIELD_TAB: Record<keyof SettingsFormData, SettingsTab> = {
+  chunk_size_chars: "documents",
+  chunk_overlap_chars: "documents",
+  auto_scan_enabled: "documents",
+  auto_scan_interval_minutes: "documents",
+  embedding_doc_prefix: "documents",
+  embedding_query_prefix: "documents",
+  embedding_batch_size: "documents",
+  retrieval_top_k: "retrieval",
+  max_distance_threshold: "retrieval",
+  retrieval_window: "retrieval",
+  vector_metric: "retrieval",
+  reranking_enabled: "retrieval",
+  reranker_url: "retrieval",
+  reranker_model: "retrieval",
+  initial_retrieval_top_k: "retrieval",
+  reranker_top_n: "retrieval",
+  hybrid_search_enabled: "retrieval",
+  hybrid_alpha: "retrieval",
+  ollama_embedding_url: "models",
+  ollama_chat_url: "models",
+  embedding_model: "models",
+  chat_model: "models",
+  wiki_enabled: "wiki",
+  wiki_compile_on_ingest: "wiki",
+  wiki_compile_on_query: "wiki",
+  wiki_compile_after_indexing: "wiki",
+  wiki_lint_enabled: "wiki",
+  wiki_llm_curator_enabled: "wiki",
+  wiki_llm_curator_url: "wiki",
+  wiki_llm_curator_model: "wiki",
+  wiki_llm_curator_temperature: "wiki",
+  wiki_llm_curator_max_input_chars: "wiki",
+  wiki_llm_curator_max_output_tokens: "wiki",
+  wiki_llm_curator_timeout_sec: "wiki",
+  wiki_llm_curator_concurrency: "wiki",
+  wiki_llm_curator_mode: "wiki",
+  wiki_llm_curator_require_quote_match: "wiki",
+  wiki_llm_curator_require_chunk_id: "wiki",
+  wiki_llm_curator_run_on_ingest: "wiki",
+  wiki_llm_curator_run_on_query: "wiki",
+  wiki_llm_curator_run_on_manual: "wiki",
+};
 
 // Fields that invalidate existing embeddings when changed — reindex required.
 export const REINDEX_REQUIRED_FIELDS = new Set<keyof SettingsFormData>([
@@ -62,28 +131,25 @@ export const REINDEX_REQUIRED_FIELDS = new Set<keyof SettingsFormData>([
 ]);
 
 export interface SettingsState {
-  // Data state
   settings: SettingsResponse | null;
   formData: SettingsFormData;
+  /** Snapshot taken at load time; restored by ``discard()``. */
+  loadedFormData: SettingsFormData;
 
-  // Loading state
   loading: boolean;
   saving: boolean;
-
-  // Error/Status state
   error: string | null;
   errors: SettingsErrors;
   saveStatus: "idle" | "success" | "error";
 
-  // Reindex-required banner — true after saving a change that invalidates embeddings
   reindexRequired: boolean;
   setReindexRequired: (value: boolean) => void;
-  /** Returns true if any currently-changed field requires a reindex. */
   checkReindexRequired: () => boolean;
 
-  // Actions
   setSettings: (settings: SettingsResponse | null) => void;
-  setFormData: (formData: SettingsFormData | ((prev: SettingsFormData) => SettingsFormData)) => void;
+  setFormData: (
+    formData: SettingsFormData | ((prev: SettingsFormData) => SettingsFormData)
+  ) => void;
   updateFormField: <K extends keyof SettingsFormData>(
     field: K,
     value: SettingsFormData[K]
@@ -93,17 +159,19 @@ export interface SettingsState {
   setError: (error: string | null) => void;
   setErrors: (errors: SettingsErrors) => void;
   setSaveStatus: (status: "idle" | "success" | "error") => void;
-  
-  // Initialize form from settings
+
   initializeForm: (settings: SettingsResponse) => void;
-  
-  // Validation
+
   validateForm: () => boolean;
-  
-  // Check if form has changes
+
   hasChanges: () => boolean;
-  
-  // Reset state
+  /** Set of currently-dirty field names. */
+  dirtyFields: () => Set<keyof SettingsFormData>;
+  /** Per-tab dirty count, used by SaveDiscardFooter dots. */
+  dirtyByTab: () => Record<SettingsTab, number>;
+  /** Restore form to the last-loaded snapshot. */
+  discard: () => void;
+
   resetState: () => void;
 }
 
@@ -130,12 +198,101 @@ const defaultFormData: SettingsFormData = {
   ollama_chat_url: "",
   embedding_model: "",
   chat_model: "",
+  wiki_enabled: true,
+  wiki_compile_on_ingest: true,
+  wiki_compile_on_query: true,
+  wiki_compile_after_indexing: true,
+  wiki_lint_enabled: true,
+  wiki_llm_curator_enabled: false,
+  wiki_llm_curator_url: "",
+  wiki_llm_curator_model: "",
+  wiki_llm_curator_temperature: 0.0,
+  wiki_llm_curator_max_input_chars: 6000,
+  wiki_llm_curator_max_output_tokens: 2048,
+  wiki_llm_curator_timeout_sec: 120,
+  wiki_llm_curator_concurrency: 1,
+  wiki_llm_curator_mode: "draft",
+  wiki_llm_curator_require_quote_match: true,
+  wiki_llm_curator_require_chunk_id: true,
+  wiki_llm_curator_run_on_ingest: true,
+  wiki_llm_curator_run_on_query: false,
+  wiki_llm_curator_run_on_manual: true,
 };
 
+// Unwrap legacy json.dumps-encoded strings ('"x"' -> 'x').
+function decodeStr(v: string | null | undefined, fallback: string): string {
+  if (v == null) return fallback;
+  if (v.length >= 2 && v.startsWith('"') && v.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(v);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      /* not JSON */
+    }
+  }
+  return v;
+}
+
+function fromSettings(settings: SettingsResponse): SettingsFormData {
+  const validMetrics = ["cosine", "euclidean", "dot_product"];
+  const rawMetric = decodeStr(settings.vector_metric, "cosine");
+  const validModes = ["draft", "active_if_verified"];
+  const curatorMode = settings.wiki_llm_curator_mode ?? "draft";
+  return {
+    chunk_size_chars: settings.chunk_size_chars ?? 2000,
+    chunk_overlap_chars: settings.chunk_overlap_chars ?? 200,
+    retrieval_top_k: settings.retrieval_top_k ?? 5,
+    auto_scan_enabled: settings.auto_scan_enabled ?? false,
+    auto_scan_interval_minutes: settings.auto_scan_interval_minutes ?? 60,
+    max_distance_threshold: settings.max_distance_threshold ?? 0.7,
+    retrieval_window: settings.retrieval_window ?? 1,
+    vector_metric: validMetrics.includes(rawMetric) ? rawMetric : "cosine",
+    embedding_doc_prefix: decodeStr(settings.embedding_doc_prefix, ""),
+    embedding_query_prefix: decodeStr(settings.embedding_query_prefix, ""),
+    embedding_batch_size: settings.embedding_batch_size ?? 32,
+    reranking_enabled: settings.reranking_enabled ?? false,
+    reranker_url: decodeStr(settings.reranker_url, ""),
+    reranker_model: decodeStr(settings.reranker_model, ""),
+    initial_retrieval_top_k: settings.initial_retrieval_top_k ?? 20,
+    reranker_top_n: settings.reranker_top_n ?? 5,
+    hybrid_search_enabled: settings.hybrid_search_enabled ?? false,
+    hybrid_alpha: settings.hybrid_alpha ?? 0.5,
+    ollama_embedding_url: decodeStr(settings.ollama_embedding_url, ""),
+    ollama_chat_url: decodeStr(settings.ollama_chat_url, ""),
+    embedding_model: decodeStr(settings.embedding_model, ""),
+    chat_model: decodeStr(settings.chat_model, ""),
+    wiki_enabled: settings.wiki_enabled ?? true,
+    wiki_compile_on_ingest: settings.wiki_compile_on_ingest ?? true,
+    wiki_compile_on_query: settings.wiki_compile_on_query ?? true,
+    wiki_compile_after_indexing: settings.wiki_compile_after_indexing ?? true,
+    wiki_lint_enabled: settings.wiki_lint_enabled ?? true,
+    wiki_llm_curator_enabled: settings.wiki_llm_curator_enabled ?? false,
+    wiki_llm_curator_url: decodeStr(settings.wiki_llm_curator_url ?? "", ""),
+    wiki_llm_curator_model: decodeStr(settings.wiki_llm_curator_model ?? "", ""),
+    wiki_llm_curator_temperature: settings.wiki_llm_curator_temperature ?? 0.0,
+    wiki_llm_curator_max_input_chars:
+      settings.wiki_llm_curator_max_input_chars ?? 6000,
+    wiki_llm_curator_max_output_tokens:
+      settings.wiki_llm_curator_max_output_tokens ?? 2048,
+    wiki_llm_curator_timeout_sec: settings.wiki_llm_curator_timeout_sec ?? 120,
+    wiki_llm_curator_concurrency: settings.wiki_llm_curator_concurrency ?? 1,
+    wiki_llm_curator_mode: validModes.includes(curatorMode) ? curatorMode : "draft",
+    wiki_llm_curator_require_quote_match:
+      settings.wiki_llm_curator_require_quote_match ?? true,
+    wiki_llm_curator_require_chunk_id:
+      settings.wiki_llm_curator_require_chunk_id ?? true,
+    wiki_llm_curator_run_on_ingest:
+      settings.wiki_llm_curator_run_on_ingest ?? true,
+    wiki_llm_curator_run_on_query: settings.wiki_llm_curator_run_on_query ?? false,
+    wiki_llm_curator_run_on_manual:
+      settings.wiki_llm_curator_run_on_manual ?? true,
+  };
+}
+
 export const useSettingsStore = create<SettingsState>((set, get) => ({
-  // Initial state
   settings: null,
   formData: { ...defaultFormData },
+  loadedFormData: { ...defaultFormData },
   loading: true,
   saving: false,
   error: null,
@@ -148,33 +305,24 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   checkReindexRequired: () => {
     const { settings, formData } = get();
     if (!settings) return false;
-    const decodeStr = (v: string | null | undefined, fallback: string): string => {
-      if (v == null) return fallback;
-      if (v.length >= 2 && v.startsWith('"') && v.endsWith('"')) {
-        try {
-          const parsed = JSON.parse(v);
-          if (typeof parsed === "string") return parsed;
-        } catch {} // eslint-disable-line no-empty
-      }
-      return v;
-    };
     for (const field of REINDEX_REQUIRED_FIELDS) {
       const current = formData[field];
       let saved: unknown;
-      if (field === "embedding_model") saved = decodeStr(settings.embedding_model, "");
-      else if (field === "vector_metric") saved = decodeStr(settings.vector_metric, "cosine");
-      else if (field === "embedding_doc_prefix") saved = decodeStr(settings.embedding_doc_prefix, "");
-      else if (field === "embedding_query_prefix") saved = decodeStr(settings.embedding_query_prefix, "");
+      if (field === "embedding_model")
+        saved = decodeStr(settings.embedding_model, "");
+      else if (field === "vector_metric")
+        saved = decodeStr(settings.vector_metric, "cosine");
+      else if (field === "embedding_doc_prefix")
+        saved = decodeStr(settings.embedding_doc_prefix, "");
+      else if (field === "embedding_query_prefix")
+        saved = decodeStr(settings.embedding_query_prefix, "");
       else saved = (settings as unknown as Record<string, unknown>)[field];
       if (current !== saved) return true;
     }
     return false;
   },
 
-  // Actions
-  setSettings: (settings) => {
-    set({ settings });
-  },
+  setSettings: (settings) => set({ settings }),
 
   setFormData: (formData) => {
     if (typeof formData === "function") {
@@ -191,67 +339,17 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     }));
   },
 
-  setLoading: (loading) => {
-    set({ loading });
-  },
-
-  setSaving: (saving) => {
-    set({ saving });
-  },
-
-  setError: (error) => {
-    set({ error });
-  },
-
-  setErrors: (errors) => {
-    set({ errors });
-  },
-
-  setSaveStatus: (saveStatus) => {
-    set({ saveStatus });
-  },
+  setLoading: (loading) => set({ loading }),
+  setSaving: (saving) => set({ saving }),
+  setError: (error) => set({ error }),
+  setErrors: (errors) => set({ errors }),
+  setSaveStatus: (saveStatus) => set({ saveStatus }),
 
   initializeForm: (settings) => {
-    // Unwrap JSON-encoded strings that may have been persisted with json.dumps()
-    // e.g. '"cosine"' → 'cosine', '""' → ''
-    const decodeStr = (v: string | null | undefined, fallback: string): string => {
-      if (v == null) return fallback;
-      if (v.length >= 2 && v.startsWith('"') && v.endsWith('"')) {
-        try {
-          const parsed = JSON.parse(v);
-          if (typeof parsed === "string") return parsed;
-        } catch {} // eslint-disable-line no-empty
-      }
-      return v;
-    };
-    const validMetrics = ["cosine", "euclidean", "dot_product"];
-    const rawMetric = decodeStr(settings.vector_metric, "cosine");
+    const next = fromSettings(settings);
     set({
-      formData: {
-        chunk_size_chars: settings.chunk_size_chars ?? 2000,
-        chunk_overlap_chars: settings.chunk_overlap_chars ?? 200,
-        retrieval_top_k: settings.retrieval_top_k ?? 5,
-        auto_scan_enabled: settings.auto_scan_enabled ?? false,
-        auto_scan_interval_minutes: settings.auto_scan_interval_minutes ?? 60,
-        max_distance_threshold: settings.max_distance_threshold ?? 0.7,
-        retrieval_window: settings.retrieval_window ?? 1,
-        vector_metric: validMetrics.includes(rawMetric) ? rawMetric : "cosine",
-        embedding_doc_prefix: decodeStr(settings.embedding_doc_prefix, ""),
-        embedding_query_prefix: decodeStr(settings.embedding_query_prefix, ""),
-        embedding_batch_size: settings.embedding_batch_size ?? 32,
-        reranking_enabled: settings.reranking_enabled ?? false,
-        reranker_url: decodeStr(settings.reranker_url, ""),
-        reranker_model: decodeStr(settings.reranker_model, ""),
-        initial_retrieval_top_k: settings.initial_retrieval_top_k ?? 20,
-        reranker_top_n: settings.reranker_top_n ?? 5,
-        hybrid_search_enabled: settings.hybrid_search_enabled ?? false,
-        hybrid_alpha: settings.hybrid_alpha ?? 0.5,
-        // Model connection settings
-        ollama_embedding_url: decodeStr(settings.ollama_embedding_url, ""),
-        ollama_chat_url: decodeStr(settings.ollama_chat_url, ""),
-        embedding_model: decodeStr(settings.embedding_model, ""),
-        chat_model: decodeStr(settings.chat_model, ""),
-      },
+      formData: next,
+      loadedFormData: next,
       loading: false,
       error: null,
     });
@@ -261,61 +359,125 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const { formData } = get();
     const newErrors: SettingsErrors = {};
 
-    // Validate positive integers
     if (formData.chunk_size_chars <= 0) {
       newErrors.chunk_size_chars = "Chunk size must be a positive integer";
     }
-    if (formData.chunk_overlap_chars <= 0) {
-      newErrors.chunk_overlap_chars = "Chunk overlap must be a positive integer";
+    if (formData.chunk_overlap_chars < 0) {
+      newErrors.chunk_overlap_chars = "Chunk overlap must be a non-negative integer";
     }
     if (formData.retrieval_top_k <= 0) {
       newErrors.retrieval_top_k = "Retrieval top-k must be a positive integer";
     }
     if (formData.auto_scan_interval_minutes <= 0) {
-      newErrors.auto_scan_interval_minutes = "Scan interval must be a positive integer";
+      newErrors.auto_scan_interval_minutes =
+        "Scan interval must be a positive integer";
     }
-    if (formData.embedding_batch_size < 1 || formData.embedding_batch_size > 128) {
-      newErrors.embedding_batch_size = "Embedding batch size must be between 1 and 128";
+    if (
+      formData.embedding_batch_size < 1 ||
+      formData.embedding_batch_size > 128
+    ) {
+      newErrors.embedding_batch_size =
+        "Embedding batch size must be between 1 and 128";
     }
-
-    // Validate overlap < size
     if (formData.chunk_overlap_chars >= formData.chunk_size_chars) {
-      newErrors.chunk_overlap_chars = "Chunk overlap must be less than chunk size";
+      newErrors.chunk_overlap_chars =
+        "Chunk overlap must be less than chunk size";
     }
-
-    // Validate threshold is between 0 and 1
-    if (formData.max_distance_threshold < 0 || formData.max_distance_threshold > 1) {
-      newErrors.max_distance_threshold = "Distance threshold must be between 0 and 1";
+    if (
+      formData.max_distance_threshold < 0 ||
+      formData.max_distance_threshold > 1
+    ) {
+      newErrors.max_distance_threshold =
+        "Distance threshold must be between 0 and 1";
     }
-
-    // Validate retrieval window (0-3)
     if (formData.retrieval_window < 0 || formData.retrieval_window > 3) {
       newErrors.retrieval_window = "Retrieval window must be between 0 and 3";
     }
-
-    // Validate vector metric
     const validMetrics = ["cosine", "euclidean", "dot_product"];
     if (!validMetrics.includes(formData.vector_metric)) {
-      newErrors.vector_metric = "Vector metric must be cosine, euclidean, or dot_product";
+      newErrors.vector_metric =
+        "Vector metric must be cosine, euclidean, or dot_product";
     }
-
-    // Validate retrieval settings
-    if (formData.initial_retrieval_top_k !== undefined && (formData.initial_retrieval_top_k < 5 || formData.initial_retrieval_top_k > 100)) {
-      newErrors.initial_retrieval_top_k = "Initial retrieval top-k must be between 5 and 100";
+    if (
+      formData.initial_retrieval_top_k !== undefined &&
+      (formData.initial_retrieval_top_k < 5 ||
+        formData.initial_retrieval_top_k > 100)
+    ) {
+      newErrors.initial_retrieval_top_k =
+        "Initial retrieval top-k must be between 5 and 100";
     }
-    if (formData.reranker_top_n !== undefined && (formData.reranker_top_n < 1 || formData.reranker_top_n > 20)) {
+    if (
+      formData.reranker_top_n !== undefined &&
+      (formData.reranker_top_n < 1 || formData.reranker_top_n > 20)
+    ) {
       newErrors.reranker_top_n = "Reranker top-n must be between 1 and 20";
     }
-    if (formData.hybrid_alpha !== undefined && (formData.hybrid_alpha < 0 || formData.hybrid_alpha > 1)) {
+    if (
+      formData.hybrid_alpha !== undefined &&
+      (formData.hybrid_alpha < 0 || formData.hybrid_alpha > 1)
+    ) {
       newErrors.hybrid_alpha = "Hybrid alpha must be between 0 and 1";
     }
-
-    // Validate model connection settings
-    if (formData.ollama_embedding_url && !/^https?:\/\//.test(formData.ollama_embedding_url)) {
+    if (
+      formData.ollama_embedding_url &&
+      !/^https?:\/\//.test(formData.ollama_embedding_url)
+    ) {
       newErrors.ollama_embedding_url = "URL must start with http:// or https://";
     }
-    if (formData.ollama_chat_url && !/^https?:\/\//.test(formData.ollama_chat_url)) {
+    if (
+      formData.ollama_chat_url &&
+      !/^https?:\/\//.test(formData.ollama_chat_url)
+    ) {
       newErrors.ollama_chat_url = "URL must start with http:// or https://";
+    }
+
+    // Curator: required-when-enabled (frontend mirror of backend invariant).
+    if (formData.wiki_llm_curator_enabled) {
+      if (!formData.wiki_llm_curator_url.trim()) {
+        newErrors.wiki_llm_curator_url =
+          "Curator URL is required when curator is enabled";
+      } else if (!/^https?:\/\//.test(formData.wiki_llm_curator_url)) {
+        newErrors.wiki_llm_curator_url =
+          "Curator URL must start with http:// or https://";
+      }
+      if (!formData.wiki_llm_curator_model.trim()) {
+        newErrors.wiki_llm_curator_model =
+          "Curator model is required when curator is enabled";
+      }
+    }
+    if (
+      formData.wiki_llm_curator_temperature < 0 ||
+      formData.wiki_llm_curator_temperature > 1
+    ) {
+      newErrors.wiki_llm_curator_temperature =
+        "Temperature must be between 0.0 and 1.0";
+    }
+    if (
+      formData.wiki_llm_curator_max_input_chars < 1000 ||
+      formData.wiki_llm_curator_max_input_chars > 24000
+    ) {
+      newErrors.wiki_llm_curator_max_input_chars =
+        "Max input chars must be between 1000 and 24000";
+    }
+    if (
+      formData.wiki_llm_curator_timeout_sec < 10 ||
+      formData.wiki_llm_curator_timeout_sec > 600
+    ) {
+      newErrors.wiki_llm_curator_timeout_sec =
+        "Timeout must be between 10 and 600 seconds";
+    }
+    if (
+      formData.wiki_llm_curator_concurrency < 1 ||
+      formData.wiki_llm_curator_concurrency > 4
+    ) {
+      newErrors.wiki_llm_curator_concurrency =
+        "Concurrency must be between 1 and 4";
+    }
+    if (
+      !["draft", "active_if_verified"].includes(formData.wiki_llm_curator_mode)
+    ) {
+      newErrors.wiki_llm_curator_mode =
+        "Mode must be 'draft' or 'active_if_verified'";
     }
 
     set({ errors: newErrors });
@@ -323,52 +485,52 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   },
 
   hasChanges: () => {
-    const { settings, formData } = get();
-    if (!settings) return false;
-    return (
-      formData.chunk_size_chars !== (settings.chunk_size_chars ?? 2000) ||
-      formData.chunk_overlap_chars !== (settings.chunk_overlap_chars ?? 200) ||
-      formData.retrieval_top_k !== (settings.retrieval_top_k ?? 5) ||
-      formData.auto_scan_enabled !== (settings.auto_scan_enabled ?? false) ||
-      formData.auto_scan_interval_minutes !== (settings.auto_scan_interval_minutes ?? 60) ||
-      formData.max_distance_threshold !== (settings.max_distance_threshold ?? 0.7) ||
-      formData.retrieval_window !== (settings.retrieval_window ?? 1) ||
-      formData.vector_metric !== (settings.vector_metric ?? "cosine") ||
-      formData.embedding_doc_prefix !== (settings.embedding_doc_prefix ?? "Passage: ") ||
-      formData.embedding_query_prefix !== (settings.embedding_query_prefix ?? "Query: ") ||
-      formData.embedding_batch_size !== (settings.embedding_batch_size ?? 32) ||
-       formData.reranking_enabled !== (settings.reranking_enabled ?? false) ||
-       formData.reranker_url !== (settings.reranker_url ?? "") ||
-       formData.reranker_model !== (settings.reranker_model ?? "") ||
-       formData.initial_retrieval_top_k !== (settings.initial_retrieval_top_k ?? 20) ||
-       formData.reranker_top_n !== (settings.reranker_top_n ?? 5) ||
-       formData.hybrid_search_enabled !== (settings.hybrid_search_enabled ?? false) ||
-       formData.hybrid_alpha !== (settings.hybrid_alpha ?? 0.5) ||
-       formData.ollama_embedding_url !== (settings.ollama_embedding_url ?? "") ||
-       formData.ollama_chat_url !== (settings.ollama_chat_url ?? "") ||
-       formData.embedding_model !== (settings.embedding_model ?? "") ||
-       formData.chat_model !== (settings.chat_model ?? "")
-    );
+    const { dirtyFields } = get();
+    return dirtyFields().size > 0;
+  },
+
+  dirtyFields: () => {
+    const { formData, loadedFormData } = get();
+    const dirty = new Set<keyof SettingsFormData>();
+    (Object.keys(formData) as Array<keyof SettingsFormData>).forEach((k) => {
+      // Direct equality is fine; all fields are scalar.
+      if (formData[k] !== loadedFormData[k]) {
+        dirty.add(k);
+      }
+    });
+    return dirty;
+  },
+
+  dirtyByTab: () => {
+    const dirty = get().dirtyFields();
+    const out: Record<SettingsTab, number> = {
+      overview: 0,
+      models: 0,
+      documents: 0,
+      retrieval: 0,
+      wiki: 0,
+      maintenance: 0,
+    };
+    dirty.forEach((field) => {
+      const tab = FIELD_TAB[field];
+      if (tab) out[tab] += 1;
+    });
+    return out;
+  },
+
+  discard: () => {
+    set((state) => ({
+      formData: { ...state.loadedFormData },
+      errors: {},
+      saveStatus: "idle",
+    }));
   },
 
   resetState: () => {
     set({
       settings: null,
       formData: { ...defaultFormData },
-      loading: true,
-      saving: false,
-      error: null,
-      errors: {},
-      saveStatus: "idle",
-      reindexRequired: false,
-    });
-  },
-
-  // Alias for resetState to match task requirements
-  reset: () => {
-    set({
-      settings: null,
-      formData: { ...defaultFormData },
+      loadedFormData: { ...defaultFormData },
       loading: true,
       saving: false,
       error: null,

--- a/frontend/src/stores/useUploadStore.test.ts
+++ b/frontend/src/stores/useUploadStore.test.ts
@@ -1,0 +1,300 @@
+/**
+ * PR A: phase-aware upload store regression tests.
+ *
+ * Covers the contract that the user-facing fix depends on:
+ *  - Network upload reaching 100% does NOT flip the chip to "indexed".
+ *  - Adaptive polling resets on phase change and never errors out
+ *    on a long-running indexing job (no 3-minute false timeout).
+ *  - applyStatusSnapshot maps server fields onto the store correctly.
+ *  - retryUpload resets phase + progress + error in addition to status.
+ *  - clearCompleted leaves "processing" rows alone (in-flight files
+ *    must not vanish under the user mid-pipeline).
+ *  - The deprecated `progress` alias keeps mirroring `uploadProgress`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { uploadDocumentMock, getDocumentStatusMock } = vi.hoisted(() => ({
+  uploadDocumentMock: vi.fn(),
+  getDocumentStatusMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  uploadDocument: uploadDocumentMock,
+  getDocumentStatus: getDocumentStatusMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { useUploadStore } from "./useUploadStore";
+
+function makeFile(name: string, bytes = 4): File {
+  return new File([new Uint8Array(bytes)], name, { type: "text/plain" });
+}
+
+function resetStore() {
+  useUploadStore.setState({
+    uploads: [],
+    isProcessing: false,
+    activeVaultId: null,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetStore();
+  uploadDocumentMock.mockReset();
+  getDocumentStatusMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useUploadStore — async-aware contract", () => {
+  it("network 100% does NOT mark indexed; status moves to processing and waits for backend", async () => {
+    let progressCb: (n: number) => void = () => {};
+    uploadDocumentMock.mockImplementation((_file, onProgress) => {
+      progressCb = onProgress;
+      return new Promise((resolve) => {
+        // Resolve after the test pushes upload progress to 100.
+        setTimeout(() => {
+          progressCb(100);
+          resolve({ id: "42", filename: "a.txt", status: "pending" });
+        }, 0);
+      });
+    });
+    // First poll returns processing/parsing; never resolves to indexed in this test.
+    getDocumentStatusMock.mockResolvedValue({
+      id: 42,
+      filename: "a.txt",
+      status: "processing",
+      chunk_count: 0,
+      phase: "parsing",
+      phase_message: "Parsing",
+      progress_percent: null,
+    });
+
+    useUploadStore.getState().addUploads([makeFile("a.txt")], 1);
+
+    // Drain the microtask + the 0ms timeout that resolves uploadDocument.
+    await vi.advanceTimersByTimeAsync(1);
+    // Drive one polling cycle (1500ms first interval).
+    await vi.advanceTimersByTimeAsync(1600);
+
+    const u = useUploadStore.getState().uploads[0];
+    expect(u).toBeDefined();
+    expect(u.uploadProgress).toBe(100);
+    // CONTRACT: status is NOT "indexed".
+    expect(u.status).not.toBe("indexed");
+    // CONTRACT: status is processing-style; phase string drives detail.
+    expect(u.status).toBe("processing");
+    expect(u.phase).toBe("parsing");
+    expect(u.phaseLabel).toBe("Parsing");
+  });
+
+  it("polling does NOT time out at 3 minutes — stays alive past the legacy threshold", async () => {
+    uploadDocumentMock.mockResolvedValue({
+      id: 7,
+      filename: "big.xlsx",
+      status: "pending",
+    });
+    // Always non-terminal.
+    getDocumentStatusMock.mockResolvedValue({
+      id: 7,
+      filename: "big.xlsx",
+      status: "processing",
+      chunk_count: 0,
+      phase: "embedding",
+      phase_message: "Embedding chunks",
+      progress_percent: 12,
+    });
+
+    useUploadStore.getState().addUploads([makeFile("big.xlsx")], 1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Run well past the legacy 3-minute (180_000ms) ceiling.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    const u = useUploadStore.getState().uploads[0];
+    // CONTRACT: no error, no timeout — still processing.
+    expect(u.status).toBe("processing");
+    expect(u.error).toBeUndefined();
+    expect(u.phase).toBe("embedding");
+  });
+
+  it("indexed + wiki=running keeps polling; indexed + wiki=completed stops", async () => {
+    uploadDocumentMock.mockResolvedValue({
+      id: 9,
+      filename: "doc.txt",
+      status: "pending",
+    });
+    let call = 0;
+    getDocumentStatusMock.mockImplementation(async () => {
+      call += 1;
+      if (call < 3) {
+        return {
+          id: 9,
+          filename: "doc.txt",
+          status: "indexed",
+          chunk_count: 5,
+          phase: "indexed",
+          wiki_status: "running",
+        };
+      }
+      return {
+        id: 9,
+        filename: "doc.txt",
+        status: "indexed",
+        chunk_count: 5,
+        phase: "indexed",
+        wiki_status: "completed",
+      };
+    });
+
+    useUploadStore.getState().addUploads([makeFile("doc.txt")], 1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    // First poll: indexed but wiki running -> keep polling.
+    await vi.advanceTimersByTimeAsync(1600);
+    const after1 = useUploadStore.getState().uploads[0];
+    expect(after1.status).toBe("indexed");
+    expect(after1.wikiStatus).toBe("running");
+
+    // Two more polling cycles to pass the wiki-running snapshot.
+    await vi.advanceTimersByTimeAsync(3500);
+    const after2 = useUploadStore.getState().uploads[0];
+    expect(after2.wikiStatus).toBe("completed");
+  });
+
+  it("retryUpload clears phase / progress / error and re-enqueues", async () => {
+    useUploadStore.setState({
+      uploads: [
+        {
+          id: "x",
+          file: makeFile("err.txt"),
+          status: "error",
+          uploadProgress: 50,
+          progress: 50,
+          processingProgress: 30,
+          wikiProgress: null,
+          phase: "parsing",
+          phaseLabel: "Parsing",
+          phaseMessage: "Parsing",
+          processedUnits: 1,
+          totalUnits: 5,
+          unitLabel: "chunks",
+          error: "boom",
+        },
+      ],
+      isProcessing: false,
+      activeVaultId: 1,
+    });
+    // Make the retry upload hang forever so we can inspect post-retry state.
+    uploadDocumentMock.mockImplementation(() => new Promise(() => {}));
+
+    useUploadStore.getState().retryUpload("x");
+    // Let processQueue run one tick.
+    await vi.advanceTimersByTimeAsync(1);
+
+    const u = useUploadStore.getState().uploads[0];
+    expect(u.error).toBeUndefined();
+    expect(u.phase).toBeNull();
+    expect(u.phaseLabel).toBeNull();
+    expect(u.processedUnits).toBeNull();
+    expect(u.totalUnits).toBeNull();
+    // Status moved past pending to uploading (retry triggers processQueue).
+    expect(["pending", "uploading"]).toContain(u.status);
+  });
+
+  it("clearCompleted leaves processing rows alone", () => {
+    useUploadStore.setState({
+      uploads: [
+        {
+          id: "a",
+          file: makeFile("a.txt"),
+          status: "processing",
+          uploadProgress: 100,
+          progress: 100,
+        },
+        {
+          id: "b",
+          file: makeFile("b.txt"),
+          status: "indexed",
+          uploadProgress: 100,
+          progress: 100,
+        },
+      ],
+      isProcessing: false,
+      activeVaultId: 1,
+    });
+    useUploadStore.getState().clearCompleted();
+    const ids = useUploadStore.getState().uploads.map((u) => u.id);
+    expect(ids).toEqual(["a"]);
+  });
+
+  it("`progress` stays as a deprecated alias of uploadProgress", () => {
+    useUploadStore.setState({
+      uploads: [
+        {
+          id: "a",
+          file: makeFile("a.txt"),
+          status: "uploading",
+          uploadProgress: 0,
+          progress: 0,
+        },
+      ],
+      isProcessing: false,
+      activeVaultId: 1,
+    });
+    useUploadStore.getState().updateUploadProgress("a", 73);
+    const u = useUploadStore.getState().uploads[0];
+    expect(u.uploadProgress).toBe(73);
+    expect(u.progress).toBe(73);
+  });
+
+  it("applyStatusSnapshot bumps phaseStartedAt only on phase transition", () => {
+    useUploadStore.setState({
+      uploads: [
+        {
+          id: "a",
+          file: makeFile("a.txt"),
+          status: "processing",
+          uploadProgress: 100,
+          progress: 100,
+          phase: "parsing",
+          phaseStartedAt: 1000,
+        },
+      ],
+      isProcessing: false,
+      activeVaultId: 1,
+    });
+    // Same phase: should not bump.
+    useUploadStore.getState().applyStatusSnapshot("a", {
+      id: 1,
+      filename: "a.txt",
+      status: "processing",
+      chunk_count: 0,
+      phase: "parsing",
+      progress_percent: 50,
+    });
+    expect(useUploadStore.getState().uploads[0].phaseStartedAt).toBe(1000);
+    // Different phase: should bump.
+    useUploadStore.getState().applyStatusSnapshot("a", {
+      id: 1,
+      filename: "a.txt",
+      status: "processing",
+      chunk_count: 0,
+      phase: "embedding",
+      progress_percent: 1,
+    });
+    expect(useUploadStore.getState().uploads[0].phaseStartedAt).not.toBe(1000);
+    expect(useUploadStore.getState().uploads[0].phase).toBe("embedding");
+    expect(useUploadStore.getState().uploads[0].phaseLabel).toBe("Embedding");
+  });
+});

--- a/frontend/src/stores/useUploadStore.ts
+++ b/frontend/src/stores/useUploadStore.ts
@@ -1,33 +1,189 @@
 import { create } from "zustand";
 import { uploadDocument, getDocumentStatus } from "@/lib/api";
+import type { DocumentStatusResponse } from "@/lib/api";
 import { toast } from "sonner";
+
+/**
+ * UploadFile state machine
+ * ------------------------
+ *   pending -> uploading -> processing -> indexed | error | cancelled
+ *
+ * `progress` is preserved as a deprecated alias of `uploadProgress` for one
+ * release so external readers (e.g. legacy tests, untouched components) keep
+ * compiling. New code should read `uploadProgress` / `processingProgress` /
+ * `wikiProgress` directly.
+ *
+ * Backend `phase` (queued / parsing / extracting_text / chunking / embedding
+ * / writing_index / indexed / error) drives the user-facing `phaseLabel`. The
+ * `status` field is intentionally coarse so downstream components can keep
+ * using simple equality checks.
+ */
+export type UploadStatus =
+  | "pending"
+  | "uploading"
+  | "processing"
+  | "indexing"
+  | "indexed"
+  | "error"
+  | "cancelled";
 
 export interface UploadFile {
   id: string;
   file: File;
+  /** Network upload progress, 0..100. */
+  uploadProgress: number;
+  /**
+   * @deprecated Read `uploadProgress` instead. Kept as an alias so callers that
+   * haven't migrated yet still see a sensible number; will be removed in a
+   * future release.
+   */
   progress: number;
-  /** State machine: pending → uploading → indexing → indexed | error | cancelled */
-  status: "pending" | "uploading" | "indexing" | "indexed" | "error" | "cancelled";
+  /** Server-side processing progress, 0..100. Null when phase is indeterminate. */
+  processingProgress?: number | null;
+  /** Wiki compile progress, 0..100. Null when no wiki job is active. */
+  wikiProgress?: number | null;
+  status: UploadStatus;
   error?: string;
-  /** Backend document id, set after successful upload for indexing status polling. */
   documentId?: string;
+  /** Raw backend phase string, e.g. "embedding". */
+  phase?: string | null;
+  /** User-friendly label derived from `phase`. */
+  phaseLabel?: string | null;
+  /** Backend-supplied phase message. */
+  phaseMessage?: string | null;
+  processedUnits?: number | null;
+  totalUnits?: number | null;
+  unitLabel?: string | null;
+  /** epoch ms when this upload was first added to the queue */
+  startedAt?: number;
+  /** epoch ms when the current phase began (best-effort, frontend clock) */
+  phaseStartedAt?: number;
+  /** Server-computed elapsed seconds since processing started. */
+  elapsedSeconds?: number | null;
+  /** Backend wiki status: pending | running | completed | failed | cancelled */
+  wikiStatus?: string | null;
+  /** True once the polling loop has decided to stop trying (manual stop or hard cap). */
+  pollingStopped?: boolean;
+  /** True once the long-running banner should be shown (>= 30 min processing). */
+  longRunning?: boolean;
 }
 
 interface UploadState {
   uploads: UploadFile[];
   isProcessing: boolean;
   activeVaultId: number | null;
-  
+
   // Actions
   addUploads: (files: File[], vaultId?: number) => void;
   cancelUpload: (id: string) => void;
   removeUpload: (id: string) => void;
+  updateUploadProgress: (id: string, progress: number) => void;
+  /** @deprecated alias of updateUploadProgress for legacy callers */
   updateProgress: (id: string, progress: number) => void;
-  setStatus: (id: string, status: UploadFile["status"], error?: string) => void;
+  setStatus: (id: string, status: UploadStatus, error?: string) => void;
+  applyStatusSnapshot: (id: string, snapshot: DocumentStatusResponse) => void;
   setProcessing: (processing: boolean) => void;
   clearCompleted: () => void;
   retryUpload: (id: string) => void;
+  /** Stop polling for this upload without cancelling backend processing. */
+  stopPolling: (id: string) => void;
   processQueue: () => Promise<void>;
+}
+
+// Phase wire-value -> user-facing label map. Keep in sync with
+// backend `services/document_progress.py::ALL_PHASES`.
+const PHASE_LABELS: Record<string, string> = {
+  queued: "Queued",
+  parsing: "Parsing",
+  extracting_text: "Extracting text",
+  chunking: "Chunking",
+  embedding: "Embedding",
+  writing_index: "Writing index",
+  indexed: "Indexed",
+  error: "Error",
+};
+
+export function phaseLabelFor(phase?: string | null): string | null {
+  if (!phase) return null;
+  return PHASE_LABELS[phase] ?? phase;
+}
+
+// Adaptive polling: 1.5s for first 20s, 3s for next 60s, 6s thereafter.
+// Reset back to fast polling when the observed phase changes.
+const MAX_POLL_DURATION_MS = 4 * 60 * 60 * 1000; // 4 hours hard cap
+const LONG_RUNNING_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+
+function pickPollDelay(elapsedMs: number): number {
+  if (elapsedMs < 20_000) return 1500;
+  if (elapsedMs < 80_000) return 3000;
+  return 6000;
+}
+
+/**
+ * Map a backend status snapshot onto our local UploadFile fields. We don't
+ * touch fields the backend didn't supply so existing client state survives
+ * partial responses.
+ */
+function snapshotToPatch(
+  snapshot: DocumentStatusResponse,
+  prevPhase?: string | null,
+): Partial<UploadFile> {
+  const patch: Partial<UploadFile> = {
+    documentId: String(snapshot.id),
+    phase: snapshot.phase ?? null,
+    phaseLabel: phaseLabelFor(snapshot.phase),
+    phaseMessage: snapshot.phase_message ?? null,
+    processedUnits: snapshot.processed_units ?? null,
+    totalUnits: snapshot.total_units ?? null,
+    unitLabel: snapshot.unit_label ?? null,
+    elapsedSeconds: snapshot.elapsed_seconds ?? null,
+    wikiStatus: snapshot.wiki_status ?? null,
+    error: snapshot.error_message ?? undefined,
+  };
+
+  if (snapshot.progress_percent != null) {
+    patch.processingProgress = snapshot.progress_percent;
+  } else if (
+    snapshot.phase &&
+    snapshot.phase !== "indexed" &&
+    snapshot.phase !== "error"
+  ) {
+    // Indeterminate phase: keep null so the UI shows an indeterminate bar.
+    patch.processingProgress = null;
+  }
+
+  if (snapshot.wiki_status === "running") {
+    // Wiki compile doesn't expose granular percent today; render indeterminate.
+    patch.wikiProgress = null;
+  } else if (snapshot.wiki_status === "completed") {
+    patch.wikiProgress = 100;
+  } else {
+    patch.wikiProgress = patch.wikiProgress ?? null;
+  }
+
+  // Refresh the phase-started-at clock when we observe a phase transition.
+  if (snapshot.phase && snapshot.phase !== prevPhase) {
+    patch.phaseStartedAt = Date.now();
+  }
+
+  // Status mapping: keep coarse for downstream eq-checks. The backend's
+  // canonical 4-value `status` enum maps directly here. Phase string
+  // independently drives the detailed UI.
+  switch (snapshot.status) {
+    case "indexed":
+      patch.status = "indexed";
+      break;
+    case "error":
+      patch.status = "error";
+      break;
+    case "processing":
+    case "pending":
+    default:
+      patch.status = "processing";
+      break;
+  }
+
+  return patch;
 }
 
 export const useUploadStore = create<UploadState>((set, get) => ({
@@ -47,11 +203,16 @@ export const useUploadStore = create<UploadState>((set, get) => ({
       return `${f.name}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     };
 
+    const now = Date.now();
     const newUploads: UploadFile[] = files.map((file) => ({
       id: generateId(file),
       file,
+      uploadProgress: 0,
       progress: 0,
+      processingProgress: null,
+      wikiProgress: null,
       status: "pending",
+      startedAt: now,
     }));
 
     set((state) => ({
@@ -59,7 +220,6 @@ export const useUploadStore = create<UploadState>((set, get) => ({
       activeVaultId: vaultId || state.activeVaultId,
     }));
 
-    // Start processing if not already running
     const { isProcessing } = get();
     if (!isProcessing) {
       get().processQueue();
@@ -81,12 +241,17 @@ export const useUploadStore = create<UploadState>((set, get) => ({
     }));
   },
 
-  updateProgress: (id, progress) => {
+  updateUploadProgress: (id, progress) => {
     set((state) => ({
       uploads: state.uploads.map((u) =>
-        u.id === id ? { ...u, progress } : u
+        u.id === id ? { ...u, uploadProgress: progress, progress } : u
       ),
     }));
+  },
+
+  // Deprecated alias preserved so untouched callers still compile.
+  updateProgress: (id, progress) => {
+    get().updateUploadProgress(id, progress);
   },
 
   setStatus: (id, status, error) => {
@@ -97,6 +262,16 @@ export const useUploadStore = create<UploadState>((set, get) => ({
     }));
   },
 
+  applyStatusSnapshot: (id, snapshot) => {
+    set((state) => ({
+      uploads: state.uploads.map((u) => {
+        if (u.id !== id) return u;
+        const patch = snapshotToPatch(snapshot, u.phase);
+        return { ...u, ...patch };
+      }),
+    }));
+  },
+
   setProcessing: (processing) => {
     set({ isProcessing: processing });
   },
@@ -104,7 +279,11 @@ export const useUploadStore = create<UploadState>((set, get) => ({
   clearCompleted: () => {
     set((state) => ({
       uploads: state.uploads.filter(
-        (u) => u.status === "pending" || u.status === "uploading" || u.status === "indexing"
+        (u) =>
+          u.status === "pending" ||
+          u.status === "uploading" ||
+          u.status === "processing" ||
+          u.status === "indexing"
       ),
     }));
   },
@@ -112,21 +291,46 @@ export const useUploadStore = create<UploadState>((set, get) => ({
   retryUpload: (id) => {
     set((state) => ({
       uploads: state.uploads.map((u) =>
-        u.id === id ? { ...u, status: "pending", progress: 0, error: undefined } : u
+        u.id === id
+          ? {
+              ...u,
+              status: "pending",
+              uploadProgress: 0,
+              progress: 0,
+              processingProgress: null,
+              wikiProgress: null,
+              error: undefined,
+              phase: null,
+              phaseLabel: null,
+              phaseMessage: null,
+              processedUnits: null,
+              totalUnits: null,
+              unitLabel: null,
+              elapsedSeconds: null,
+              pollingStopped: false,
+              longRunning: false,
+            }
+          : u
       ),
     }));
-    
-    // Start processing if not already running
+
     const { isProcessing } = get();
     if (!isProcessing) {
       get().processQueue();
     }
   },
 
+  stopPolling: (id) => {
+    set((state) => ({
+      uploads: state.uploads.map((u) =>
+        u.id === id ? { ...u, pollingStopped: true } : u
+      ),
+    }));
+  },
+
   processQueue: async () => {
     let acquired = false;
-    
-    // Atomic check-and-set: only acquire if not already processing
+
     set((state) => {
       if (state.isProcessing) {
         return state;
@@ -136,25 +340,20 @@ export const useUploadStore = create<UploadState>((set, get) => ({
     });
 
     if (!acquired) {
-      // Lock not acquired, another processQueue is running
       return;
     }
 
     try {
       while (true) {
-        // Read fresh state each iteration
         const { uploads, activeVaultId } = get();
         const pendingUpload = uploads.find((u) => u.status === "pending");
 
         if (!pendingUpload) {
-          // No more pending uploads, exit loop
           break;
         }
 
-        // Guard against stale item: check if still pending before processing
         const currentUpload = uploads.find((u) => u.id === pendingUpload.id);
         if (!currentUpload || currentUpload.status !== "pending") {
-          // Item no longer pending, continue to next iteration
           continue;
         }
 
@@ -164,58 +363,121 @@ export const useUploadStore = create<UploadState>((set, get) => ({
           const uploadResult = await uploadDocument(
             pendingUpload.file,
             (progress) => {
-              get().updateProgress(pendingUpload.id, progress);
+              get().updateUploadProgress(pendingUpload.id, progress);
             },
             activeVaultId || undefined
           );
 
-          // Start polling for indexing completion.
+          // Network upload finished. Don't claim "indexed" — the backend
+          // is now the source of truth for processing/wiki state.
           const docId = String(uploadResult.id);
           set((state) => ({
             uploads: state.uploads.map((u) =>
               u.id === pendingUpload.id
-                ? { ...u, status: "indexing", documentId: docId, progress: 100 }
+                ? {
+                    ...u,
+                    status: "processing",
+                    documentId: docId,
+                    uploadProgress: 100,
+                    progress: 100,
+                    phase: "queued",
+                    phaseLabel: phaseLabelFor("queued"),
+                    phaseMessage: "Queued for processing",
+                    phaseStartedAt: Date.now(),
+                  }
                 : u
             ),
           }));
 
-          // Poll until indexed, error, or 3 min timeout (60 × 3 s).
-          let attempts = 0;
-          const maxAttempts = 60;
-          while (attempts < maxAttempts) {
-            await new Promise((r) => setTimeout(r, 3000));
-            attempts++;
+          // Poll. Adaptive interval, no hard timeout (4-hour absolute cap).
+          const startedAt = Date.now();
+          let lastPhase: string | null = "queued";
+          let lastWikiStatus: string | null = null;
+          let phaseChangedAt = startedAt;
+          let pollFailures = 0;
+
+          while (true) {
+            const elapsedMs = Date.now() - startedAt;
+            // Adaptive cadence: ramp 1.5s -> 3s -> 6s based on time spent in
+            // the *current* phase (resets to 1.5s on every observed phase
+            // transition). The earlier expression collapsed to a constant.
+            const delayMs = pickPollDelay(Date.now() - phaseChangedAt);
+            await new Promise((r) => setTimeout(r, delayMs));
+
+            const fresh = get().uploads.find((u) => u.id === pendingUpload.id);
+            if (!fresh) break; // removed
+            if (fresh.pollingStopped) break;
+            if (fresh.status === "cancelled") break;
+            if (elapsedMs > MAX_POLL_DURATION_MS) {
+              // Stop polling; do NOT mark error — backend may still be working.
+              get().stopPolling(pendingUpload.id);
+              break;
+            }
+            if (
+              elapsedMs > LONG_RUNNING_THRESHOLD_MS &&
+              !fresh.longRunning
+            ) {
+              set((state) => ({
+                uploads: state.uploads.map((u) =>
+                  u.id === pendingUpload.id ? { ...u, longRunning: true } : u
+                ),
+              }));
+            }
+
             try {
-              const statusResult = await getDocumentStatus(docId);
-              if (statusResult.status === "indexed") {
-                get().setStatus(pendingUpload.id, "indexed");
-                toast.success(`${pendingUpload.file.name} indexed successfully`);
-                break;
-              } else if (statusResult.status === "error") {
-                get().setStatus(pendingUpload.id, "error", statusResult.error_message ?? "Indexing failed");
-                toast.error(`Failed to index ${pendingUpload.file.name}`);
+              const snapshot = await getDocumentStatus(docId);
+              pollFailures = 0;
+              get().applyStatusSnapshot(pendingUpload.id, snapshot);
+
+              if (snapshot.phase && snapshot.phase !== lastPhase) {
+                lastPhase = snapshot.phase;
+                phaseChangedAt = Date.now();
+              }
+              if (snapshot.wiki_status && snapshot.wiki_status !== lastWikiStatus) {
+                lastWikiStatus = snapshot.wiki_status;
+              }
+
+              if (snapshot.status === "error") {
+                toast.error(`Failed to index ${pendingUpload.file.name}`, {
+                  description: snapshot.error_message ?? undefined,
+                });
                 break;
               }
-              // Still pending/processing — keep polling
+              if (snapshot.status === "indexed") {
+                const wikiTerminal =
+                  snapshot.wiki_status == null ||
+                  snapshot.wiki_status === "completed" ||
+                  snapshot.wiki_status === "failed" ||
+                  snapshot.wiki_status === "cancelled";
+                if (wikiTerminal) {
+                  toast.success(`${pendingUpload.file.name} indexed`);
+                  break;
+                }
+                // Indexed but wiki still working — keep polling for wiki.
+                continue;
+              }
             } catch {
-              // Status poll failed — treat as transient, keep trying
-            }
-            if (attempts >= maxAttempts) {
-              get().setStatus(pendingUpload.id, "error", "Indexing timed out");
-              toast.error(`Indexing timed out for ${pendingUpload.file.name}`);
+              // Transient: keep trying. Bail only after many consecutive failures.
+              pollFailures += 1;
+              if (pollFailures >= 30) {
+                get().setStatus(
+                  pendingUpload.id,
+                  "error",
+                  "Status polling failed repeatedly. Refresh to retry."
+                );
+                break;
+              }
             }
           }
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : "Upload failed";
           get().setStatus(pendingUpload.id, "error", errorMsg);
           toast.error(`Failed to upload ${pendingUpload.file.name}: ${errorMsg}`);
-          // Continue with next pending file on error
         }
       }
     } finally {
       set({ isProcessing: false });
-      
-      // If any pending uploads remain, trigger processQueue once
+
       const { uploads } = get();
       if (uploads.some((u) => u.status === "pending")) {
         get().processQueue();

--- a/specs/merge-blocker-fix/SPEC.md
+++ b/specs/merge-blocker-fix/SPEC.md
@@ -1,0 +1,50 @@
+# Merge-Blocker Fix: Preserve file_id in Async Upload Retry Path
+
+## Problem Statement
+
+The BackgroundProcessor._handle_failure() method was creating retry TaskItems without preserving the `file_id` field. This caused async-uploaded files that failed on the first processing attempt to fall through to `process_file()` (legacy path) on retry, re-running duplicate detection against an already-existing files row, instead of routing to `process_existing_file()` which skips duplicate detection.
+
+Additionally, the admin retry endpoint retry_document() was calling enqueue() without passing file_id, causing the same issue for manually-retried documents.
+
+## Root Cause
+
+Two missing field assignments:
+1. `background_tasks.py:_handle_failure()` — TaskItem constructor missing `file_id=task.file_id`
+2. `documents.py:retry_document()` — enqueue() call missing `file_id=file_id` parameter
+
+## Acceptance Criteria
+
+- [x] _handle_failure() preserves file_id in retry TaskItem
+- [x] Retry tasks with file_id call process_existing_file(), not process_file()
+- [x] Legacy tasks (file_id=None) remain unaffected
+- [x] Admin retry endpoint passes file_id to enqueue()
+- [x] Regression tests cover both code paths
+
+## Technical Design
+
+### Changes
+
+**backend/app/services/background_tasks.py**
+- Line 448: Add `file_id=task.file_id,` to the retry TaskItem constructor in _handle_failure()
+
+**backend/app/api/routes/documents.py**
+- Line 167: Change `enqueue(row["file_path"], vault_id=row["vault_id"])` to `enqueue(row["file_path"], vault_id=row["vault_id"], file_id=file_id)`
+
+**backend/tests/test_document_progress_async.py**
+- Add TestHandleFailurePreservesFileId class with three regression tests
+- Add TestAdminRetryPassesFileId class with source-inspection test
+
+### Test Plan
+
+1. Unit test: _handle_failure preserves file_id in retry task
+2. Unit test: Legacy tasks (file_id=None) are unaffected
+3. Unit test: Retry task with file_id routes to process_existing_file()
+4. Source inspection: retry_document enqueue call includes file_id=file_id
+
+## What "Done" Looks Like
+
+- Code changes committed and pushed to claude/swarm-contract-verification-WhKcH
+- All new regression tests pass
+- PR created, reviewed, and merged
+- CI/CD green
+- No code regressions


### PR DESCRIPTION
## Summary

This PR fixes a merge blocker in the async document upload flow where retry logic was dropping the `file_id` field, plus the three earlier swarm PRs that landed on this branch.

### Merge-blocker fix (commits `574fff6`, `da7e153`)

`BackgroundProcessor._handle_failure()` was creating retry `TaskItem`s without carrying over `task.file_id`, so the first retry of an async-uploaded file fell through to `process_file()` (legacy path) and re-ran duplicate detection against an already-existing `files` row. Similarly, `retry_document()` was calling `enqueue()` without `file_id`.

**Changes:**
- `backend/app/services/background_tasks.py`: add `file_id=task.file_id` to the retry `TaskItem`
- `backend/app/api/routes/documents.py`: add `file_id=file_id` to `background_processor.enqueue()` in `retry_document`
- `backend/tests/test_document_progress_async.py`: 4 regression tests
- `specs/merge-blocker-fix/SPEC.md`: spec document

### Earlier swarm work on this branch

- **`61d5fc2` PR A**: phase-aware async document upload UX (no false 3-min timeout, real progress)
- **`266c4db` PR B**: settings page redesign + backend curator/wiki + SSRF guard
- **`0449fe5` PR C**: optional LLM Wiki Curator (provenance-gated, default-off)

## Test plan

- [x] `test_document_progress_async.py`: 17/17 tests pass (including 4 new regression tests)
  - `test_file_id_preserved_in_retry_task`
  - `test_none_file_id_stays_none_in_retry`
  - `test_retry_task_calls_process_existing_file`
  - `test_retry_document_enqueue_includes_file_id`
- [x] `ruff check` on modified files: clean
- [x] No regressions in adjacent test suites

## Impact

- Fixes retry logic for async uploads — no more re-running dedup on retry
- Fixes admin retry endpoint behavior
- Backwards compatible: legacy `file_id=None` path (scan/email) unchanged

https://claude.ai/code/session_0161d9B98xxXQigXoYFt4FsC

---
_Generated by [Claude Code](https://claude.ai/code/session_0161d9B98xxXQigXoYFt4FsC)_