### PR TITLE
feat: Instant/Thinking dual-mode chat with hot rebind, health gating, persistence

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -23,9 +23,9 @@ from app.api.deps import (
     get_user_accessible_vault_ids,
 )
 from app.config import settings
+from app.models.chat_mode import ChatMode
 from app.models.database import get_pool
 from app.services.citation_validator import repair_against_sources_and_memories
-from app.models.chat_mode import ChatMode
 from app.services.rag_engine import RAGEngine, RAGEngineError
 from app.services.wiki_citation_helpers import (
     build_per_claim_sources as _build_per_claim_sources_impl,

--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -25,6 +25,7 @@ from app.api.deps import (
 from app.config import settings
 from app.models.database import get_pool
 from app.services.citation_validator import repair_against_sources_and_memories
+from app.models.chat_mode import ChatMode
 from app.services.rag_engine import RAGEngine, RAGEngineError
 from app.services.wiki_citation_helpers import (
     build_per_claim_sources as _build_per_claim_sources_impl,
@@ -48,6 +49,7 @@ class ChatRequest(BaseModel):
     history: List[Dict[str, Any]] = Field(default_factory=list)
     stream: bool = False
     vault_id: Optional[int] = None
+    mode: Optional[Literal["instant", "thinking"]] = None
 
 
 class UsedMemory(BaseModel):
@@ -93,6 +95,7 @@ class ChatMessage(BaseModel):
 class ChatStreamRequest(BaseModel):
     messages: List[ChatMessage]
     vault_id: Optional[int] = None
+    mode: Optional[Literal["instant", "thinking"]] = None
 
 
 class CreateSessionRequest(BaseModel):
@@ -200,6 +203,7 @@ def stream_chat_response(
     history: List[Dict[str, Any]],
     rag_engine: Optional[RAGEngine],
     vault_id: Optional[int] = None,
+    mode: Optional[ChatMode] = None,
 ) -> StreamingResponse:
     """
     Generate a streaming chat response using SSE format.
@@ -230,7 +234,7 @@ def stream_chat_response(
 
         try:
             async for chunk in rag_engine.query(
-                message, history, stream=True, vault_id=vault_id
+                message, history, stream=True, vault_id=vault_id, mode=mode
             ):
                 chunk_type = chunk.get("type")
 
@@ -321,6 +325,7 @@ async def non_stream_chat_response(
     history: List[Dict[str, Any]],
     rag_engine: Optional[RAGEngine],
     vault_id: Optional[int] = None,
+    mode: Optional[ChatMode] = None,
 ) -> ChatResponse:
     """
     Generate a non-streaming chat response.
@@ -344,7 +349,7 @@ async def non_stream_chat_response(
 
     try:
         async for chunk in rag_engine.query(
-            message, history, stream=False, vault_id=vault_id
+            message, history, stream=False, vault_id=vault_id, mode=mode
         ):
             chunk_type = chunk.get("type")
             logger.debug(
@@ -454,9 +459,14 @@ async def chat(
                 status_code=403,
                 detail="Searching all vaults requires admin access. Please select a specific vault.",
             )
+    effective_mode = ChatMode(request.mode) if request.mode else None
     try:
         return await non_stream_chat_response(
-            request.message, request.history, rag_engine, vault_id=request.vault_id
+            request.message,
+            request.history,
+            rag_engine,
+            vault_id=request.vault_id,
+            mode=effective_mode,
         )
     except Exception:
         logger.exception("[chat] UNHANDLED EXCEPTION during chat processing")
@@ -492,8 +502,13 @@ async def chat_stream(
             )
 
     history = [msg.model_dump(exclude_none=True) for msg in request.messages[:-1]]
+    effective_mode = ChatMode(request.mode) if request.mode else None
     return stream_chat_response(
-        last_message.content, history, rag_engine, vault_id=request.vault_id
+        last_message.content,
+        history,
+        rag_engine,
+        vault_id=request.vault_id,
+        mode=effective_mode,
     )
 
 

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -42,6 +42,11 @@ async def health_check(
 
     if deep:
         llm_status = await llm_checker.check_all()
+        try:
+            llm_mode_status = await llm_checker.check_chat_modes()
+        except Exception as exc:
+            logger.debug("check_chat_modes unavailable: %s", exc)
+            llm_mode_status = {"thinking": False, "instant": False}
         models_status = await model_checker.check_models()
 
         # Probe vector store connectivity and embedding dimension consistency
@@ -85,6 +90,7 @@ async def health_check(
             vector_status = {"ok": False, "error": str(e)}
 
         result["llm"] = llm_status
+        result["llm_modes"] = llm_mode_status
         result["models"] = models_status
         result["vector_store"] = vector_status
         result["services"] = {
@@ -95,6 +101,18 @@ async def health_check(
         }
 
     return result
+
+
+@router.get("/llm-health/modes")
+async def llm_mode_health(
+    llm_checker: LLMHealthChecker = Depends(get_llm_health_checker),
+):
+    """Probe both Thinking and Instant LLM endpoints.
+
+    Returns ``{"thinking": bool, "instant": bool}``. Used by the chat
+    composer to enable/disable the per-message mode toggle.
+    """
+    return await llm_checker.check_chat_modes()
 
 
 @router.get("/healthz")

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -213,7 +213,7 @@ class SettingsUpdate(BaseModel):
             raise ValueError("hybrid_alpha must be between 0 and 1")
         return v
 
-    @field_validator("ollama_embedding_url", "ollama_chat_url", mode="before")
+    @field_validator("ollama_embedding_url", "ollama_chat_url", "instant_chat_url", mode="before")
     @classmethod
     def validate_ollama_url(cls, v):
         if v is None:
@@ -227,7 +227,7 @@ class SettingsUpdate(BaseModel):
             raise ValueError("URL must not contain credentials (@)")
         return v
 
-    @field_validator("embedding_model", "chat_model", mode="before")
+    @field_validator("embedding_model", "chat_model", "instant_chat_model", mode="before")
     @classmethod
     def validate_model_name(cls, v):
         if v is None:

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -3,7 +3,7 @@ import sqlite3
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, field_validator, model_validator
 
 from app.api.deps import get_csrf_manager, get_current_active_user, get_db, require_role
@@ -48,6 +48,17 @@ class SettingsUpdate(BaseModel):
     ollama_chat_url: Optional[str] = None
     embedding_model: Optional[str] = None
     chat_model: Optional[str] = None
+
+    # Instant mode (LM Studio on local GPU)
+    instant_chat_url: Optional[str] = None
+    instant_chat_model: Optional[str] = None
+    default_chat_mode: Optional[str] = None
+
+    # Per-mode retrieval overrides
+    instant_initial_retrieval_top_k: Optional[int] = None
+    instant_reranker_top_n: Optional[int] = None
+    instant_memory_context_top_k: Optional[int] = None
+    instant_max_tokens: Optional[int] = None
 
     # Feature flags (still supported)
     auto_scan_enabled: Optional[bool] = None
@@ -111,6 +122,25 @@ class SettingsUpdate(BaseModel):
     def validate_vector_top_k(cls, v):
         if v is not None and v <= 0:
             raise ValueError("vector_top_k must be a positive integer")
+        return v
+
+    @field_validator("default_chat_mode")
+    @classmethod
+    def validate_default_chat_mode(cls, v):
+        if v is not None and v not in ("instant", "thinking"):
+            raise ValueError("default_chat_mode must be 'instant' or 'thinking'")
+        return v
+
+    @field_validator(
+        "instant_initial_retrieval_top_k",
+        "instant_reranker_top_n",
+        "instant_memory_context_top_k",
+        "instant_max_tokens",
+    )
+    @classmethod
+    def validate_instant_positive_ints(cls, v):
+        if v is not None and v <= 0:
+            raise ValueError("must be a positive integer")
         return v
 
     @field_validator("chunk_size_chars")
@@ -330,6 +360,14 @@ ALLOWED_FIELDS = [
     "ollama_chat_url",
     "embedding_model",
     "chat_model",
+    # Instant mode (LM Studio)
+    "instant_chat_url",
+    "instant_chat_model",
+    "default_chat_mode",
+    "instant_initial_retrieval_top_k",
+    "instant_reranker_top_n",
+    "instant_memory_context_top_k",
+    "instant_max_tokens",
     # Wiki / Knowledge Compiler
     "wiki_enabled",
     "wiki_compile_on_ingest",
@@ -422,6 +460,15 @@ class SettingsResponse(BaseModel):
     # Model config
     embedding_model: str
     chat_model: str
+
+    # Instant mode (LM Studio)
+    instant_chat_url: str = "http://host.docker.internal:1234"
+    instant_chat_model: str = "nvidia/nemotron-3-nano-4b"
+    default_chat_mode: str = "thinking"
+    instant_initial_retrieval_top_k: int = 10
+    instant_reranker_top_n: int = 4
+    instant_memory_context_top_k: int = 2
+    instant_max_tokens: int = 4096
 
     # Document processing (user-configurable)
     chunk_size: Optional[int] = None  # Legacy, deprecated
@@ -519,6 +566,14 @@ def _build_settings_dict() -> dict:
         "ollama_chat_url": settings.ollama_chat_url,
         "embedding_model": settings.embedding_model,
         "chat_model": settings.chat_model,
+        # Instant mode (LM Studio)
+        "instant_chat_url": settings.instant_chat_url,
+        "instant_chat_model": settings.instant_chat_model,
+        "default_chat_mode": settings.default_chat_mode,
+        "instant_initial_retrieval_top_k": settings.instant_initial_retrieval_top_k,
+        "instant_reranker_top_n": settings.instant_reranker_top_n,
+        "instant_memory_context_top_k": settings.instant_memory_context_top_k,
+        "instant_max_tokens": settings.instant_max_tokens,
         "chunk_size": settings.chunk_size,
         "chunk_overlap": settings.chunk_overlap,
         "max_context_chunks": settings.max_context_chunks,
@@ -617,6 +672,34 @@ def _compute_effective_sources(conn: Optional[sqlite3.Connection]) -> dict[str, 
     return out
 
 
+def _hot_rebind_llm_clients(app, update: SettingsUpdate) -> None:
+    """Apply live URL/model updates to the running LLMClient instances.
+
+    The ``settings`` singleton has already been mutated by
+    ``_apply_settings_update`` before this is called, so we read the new
+    values from settings directly. We do NOT recreate the httpx pools —
+    ``LLMClient.reconfigure`` mutates ``base_url``/``model`` in place,
+    preserving every external reference (LLMHealthChecker,
+    background_processor, keepalive task, RAGEngine).
+    """
+    thinking_client = getattr(app.state, "thinking_llm_client", None)
+    instant_client = getattr(app.state, "instant_llm_client", None)
+    if thinking_client is not None and (
+        update.ollama_chat_url is not None or update.chat_model is not None
+    ):
+        thinking_client.reconfigure(
+            base_url=settings.ollama_chat_url,
+            model=settings.chat_model,
+        )
+    if instant_client is not None and (
+        update.instant_chat_url is not None or update.instant_chat_model is not None
+    ):
+        instant_client.reconfigure(
+            base_url=settings.instant_chat_url,
+            model=settings.instant_chat_model,
+        )
+
+
 def _apply_settings_update(update: SettingsUpdate) -> SettingsResponse:
     """Shared logic to apply settings update and return updated settings."""
     updated = False
@@ -646,6 +729,7 @@ def get_settings(
 @router.post("/settings")
 def post_settings(
     update: SettingsUpdate,
+    request: Request,
     conn: sqlite3.Connection = Depends(get_db),
     _role: dict = Depends(require_role("admin")),
 ):
@@ -653,6 +737,7 @@ def post_settings(
     _enforce_curator_required_when_enabled(update)
     result = _apply_settings_update(update)
     _persist_settings(conn, update)
+    _hot_rebind_llm_clients(request.app, update)
     # Re-derive effective_sources now that we've persisted.
     result = SettingsResponse.model_validate(
         {**_build_settings_dict(), "effective_sources": _compute_effective_sources(conn)}
@@ -663,6 +748,7 @@ def post_settings(
 @router.put("/settings")
 def put_settings(
     update: SettingsUpdate,
+    request: Request,
     conn: sqlite3.Connection = Depends(get_db),
     _role: dict = Depends(require_role("admin")),
 ):
@@ -670,6 +756,7 @@ def put_settings(
     _enforce_curator_required_when_enabled(update)
     result = _apply_settings_update(update)
     _persist_settings(conn, update)
+    _hot_rebind_llm_clients(request.app, update)
     result = SettingsResponse.model_validate(
         {**_build_settings_dict(), "effective_sources": _compute_effective_sources(conn)}
     )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,17 @@ class Settings(BaseSettings):
     embedding_model: str = "microsoft/harrier-oss-v1-0.6b"
     chat_model: str = "gemma-4-26b-a4b-it-apex"
 
+    # Instant mode (LM Studio on local GPU)
+    instant_chat_url: str = "http://host.docker.internal:1234"
+    instant_chat_model: str = "nvidia/nemotron-3-nano-4b"
+    default_chat_mode: str = "thinking"  # "instant" | "thinking"
+
+    # Per-mode retrieval overrides (Instant uses smaller budget)
+    instant_initial_retrieval_top_k: int = 10
+    instant_reranker_top_n: int = 4
+    instant_memory_context_top_k: int = 2
+    instant_max_tokens: int = 4096
+
     # Embedding dimension (auto-detected from model, but can be overridden)
     embedding_dim: int = 1024
 

--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -16,7 +16,11 @@ from app.services.background_tasks import get_background_processor
 from app.services.email_service import EmailIngestionService
 from app.services.embeddings import EmbeddingService
 from app.services.file_watcher import FileWatcher
-from app.services.llm_client import LLMClient
+from app.services.llm_client import (
+    LLMClient,
+    create_instant_client,
+    create_thinking_client,
+)
 from app.services.llm_health import LLMHealthChecker
 from app.services.maintenance import MaintenanceService
 from app.services.memory_store import MemoryStore
@@ -199,8 +203,24 @@ async def lifespan(app: FastAPI):
         logger.warning(f"Upload migration failed (continuing anyway): {e}")
 
     app.state.db_pool = get_pool(str(settings.sqlite_path), max_size=10)
-    app.state.llm_client = LLMClient()
-    await _safe_await(app.state.llm_client.start(), "LLM client start", timeout=10)
+
+    # Dual LLM clients: Thinking (gpt-oss-120b on DGX Spark via ollama_chat_url)
+    # and Instant (Nemotron 3 Nano 4B on LM Studio via instant_chat_url).
+    app.state.thinking_llm_client = create_thinking_client()
+    await _safe_await(
+        app.state.thinking_llm_client.start(),
+        "Thinking LLM client start",
+        timeout=10,
+    )
+    app.state.instant_llm_client = create_instant_client()
+    await _safe_await(
+        app.state.instant_llm_client.start(),
+        "Instant LLM client start",
+        timeout=10,
+    )
+    # Back-compat alias — every existing consumer (LLMHealthChecker,
+    # background_processor, keepalive, RAGEngine) reads ``llm_client``.
+    app.state.llm_client = app.state.thinking_llm_client
     app.state.embedding_service = EmbeddingService()
 
     # Validate that live TEI model matches EMBEDDING_MODEL config
@@ -358,6 +378,8 @@ async def lifespan(app: FastAPI):
     app.state.llm_health_checker = LLMHealthChecker(
         embedding_service=app.state.embedding_service,
         llm_client=app.state.llm_client,
+        thinking_client=app.state.thinking_llm_client,
+        instant_client=app.state.instant_llm_client,
     )
     app.state.model_checker = ModelChecker()
     app.state.model_validation = (
@@ -438,6 +460,8 @@ async def lifespan(app: FastAPI):
         llm_client=app.state.llm_client,
         reranking_service=app.state.reranking_service,
         wiki_retrieval=app.state.wiki_retrieval,
+        thinking_client=app.state.thinking_llm_client,
+        instant_client=app.state.instant_llm_client,
     )
     logger.info("RAGEngine singleton initialized with wiki retrieval")
 
@@ -454,12 +478,21 @@ async def lifespan(app: FastAPI):
 
     asyncio.create_task(_run_memory_backfill())
 
-    # Start LLM keep-alive task to prevent LM Studio from unloading model
-    keepalive_task = None
+    # Start LLM keep-alive tasks for both backends to prevent unload on idle.
+    keepalive_task_thinking = None
+    keepalive_task_instant = None
     try:
-        keepalive_task = asyncio.create_task(_llm_keepalive_task(app.state.llm_client))
+        keepalive_task_thinking = asyncio.create_task(
+            _llm_keepalive_task(app.state.thinking_llm_client)
+        )
     except Exception as e:
-        logger.warning(f"LLM keepalive task failed (continuing): {e}")
+        logger.warning(f"Thinking LLM keepalive task failed (continuing): {e}")
+    try:
+        keepalive_task_instant = asyncio.create_task(
+            _llm_keepalive_task(app.state.instant_llm_client)
+        )
+    except Exception as e:
+        logger.warning(f"Instant LLM keepalive task failed (continuing): {e}")
 
     yield
 
@@ -467,20 +500,28 @@ async def lifespan(app: FastAPI):
     # Stop email ingestion service
     if app.state.email_service:
         app.state.email_service.stop_polling()
-    if keepalive_task:
-        keepalive_task.cancel()
-        try:
-            await keepalive_task
-        except asyncio.CancelledError:
-            pass
+    for kt in (keepalive_task_thinking, keepalive_task_instant):
+        if kt:
+            kt.cancel()
+            try:
+                await kt
+            except asyncio.CancelledError:
+                pass
     if app.state.file_watcher:
         await app.state.file_watcher.stop()
     if app.state.background_processor:
         await app.state.background_processor.stop()
     if getattr(app.state, "wiki_compile_processor", None):
         await app.state.wiki_compile_processor.stop()
+    # Close both underlying LLM clients. The ``llm_client`` attr is an
+    # alias of ``thinking_llm_client`` so closing it separately is
+    # unnecessary; ``LLMClient.close()`` is also idempotent.
     try:
-        await app.state.llm_client.close()
+        await app.state.thinking_llm_client.close()
+    except Exception:
+        pass
+    try:
+        await app.state.instant_llm_client.close()
     except Exception:
         pass
     try:

--- a/backend/app/models/chat_mode.py
+++ b/backend/app/models/chat_mode.py
@@ -1,0 +1,7 @@
+"""Chat mode enumeration for Instant/Thinking dispatch."""
+from enum import Enum
+
+
+class ChatMode(str, Enum):
+    INSTANT = "instant"
+    THINKING = "thinking"

--- a/backend/app/services/circuit_breaker.py
+++ b/backend/app/services/circuit_breaker.py
@@ -246,6 +246,17 @@ llm_cb = AsyncCircuitBreaker(
     name="llm",
 )
 
+
+def create_llm_circuit_breaker(name: str = "llm") -> AsyncCircuitBreaker:
+    """Return a fresh per-instance LLM circuit breaker.
+
+    Each LLMClient instance owns its own breaker so failures on one
+    backend (e.g. Instant) cannot trip the breaker for another
+    (e.g. Thinking).
+    """
+    return AsyncCircuitBreaker(fail_max=5, reset_timeout=60, name=name)
+
+
 reranking_cb = AsyncCircuitBreaker(
     fail_max=3,
     reset_timeout=30,

--- a/backend/app/services/circuit_breaker.py
+++ b/backend/app/services/circuit_breaker.py
@@ -125,6 +125,19 @@ class AsyncCircuitBreaker:
             self.name,
         )
 
+    def reset(self) -> None:
+        """Force the circuit breaker back to a clean CLOSED state.
+
+        Intended for use when the underlying endpoint or model is reconfigured
+        so a previously opened breaker does not block requests to the new target.
+        Caller is responsible for ensuring no concurrent requests are in flight.
+        """
+        self._state = CircuitBreakerState.CLOSED
+        self._fail_counter = 0
+        self._success_counter = 0
+        self._last_failure_time = None
+        logger.info("Circuit breaker '%s' reset to CLOSED", self.name)
+
     def _check_timeout(self) -> None:
         """Check if the reset timeout has expired and transition to half-open."""
         if self._state == CircuitBreakerState.OPEN:

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -73,11 +73,22 @@ class LLMClient:
         in-place updates take effect immediately without recreating the
         httpx pool or invalidating any stored references held by callers
         (LLMHealthChecker, background_processor, keepalive tasks, RAGEngine).
+
+        Resets the circuit breaker on any change so a previously opened
+        breaker from a now-unreachable endpoint does not block requests to
+        the newly configured target.
         """
+        changed = False
         if base_url is not None:
-            self.base_url = base_url.rstrip("/")
-        if model is not None:
+            new_base_url = base_url.rstrip("/")
+            if new_base_url != self.base_url:
+                self.base_url = new_base_url
+                changed = True
+        if model is not None and model != self.model:
             self.model = model
+            changed = True
+        if changed:
+            self._circuit_breaker.reset()
 
     async def start(self):
         """Start the HTTP client. Must be called before using the client."""

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -13,7 +13,7 @@ from app.config import settings
 from app.services.circuit_breaker import (
     CircuitBreakerError,
     CircuitBreakerState,
-    llm_cb,
+    create_llm_circuit_breaker,
 )
 from app.utils.assistant_sanitizer import sanitize_assistant_content
 
@@ -40,17 +40,44 @@ class LLMError(Exception):
 class LLMClient:
     """OpenAI-compatible LLM chat client."""
 
-    def __init__(self, timeout: float = 300.0):
+    def __init__(
+        self,
+        timeout: float = 300.0,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+        cb_name: str = "llm",
+    ):
         """
         Initialize the LLM client.
 
         Args:
             timeout: Request timeout in seconds (default: 300.0 for model loading)
+            base_url: Override for the chat endpoint. Defaults to settings.ollama_chat_url.
+            model: Override for the model name. Defaults to settings.chat_model.
+            cb_name: Circuit breaker name (for logging / metrics distinction).
         """
-        self.base_url = settings.ollama_chat_url.rstrip("/")
-        self.model = settings.chat_model
+        self.base_url = (base_url or settings.ollama_chat_url).rstrip("/")
+        self.model = model or settings.chat_model
         self.timeout = timeout
+        self._circuit_breaker = create_llm_circuit_breaker(name=cb_name)
         self._client: Optional[httpx.AsyncClient] = None
+
+    def reconfigure(
+        self,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        """Hot-update base_url and/or model in place.
+
+        Per-request URLs are computed from ``self.base_url`` at call time, so
+        in-place updates take effect immediately without recreating the
+        httpx pool or invalidating any stored references held by callers
+        (LLMHealthChecker, background_processor, keepalive tasks, RAGEngine).
+        """
+        if base_url is not None:
+            self.base_url = base_url.rstrip("/")
+        if model is not None:
+            self.model = model
 
     async def start(self):
         """Start the HTTP client. Must be called before using the client."""
@@ -151,7 +178,7 @@ class LLMClient:
         }
 
         try:
-            response = await llm_cb(client.post)(url, json=payload)
+            response = await self._circuit_breaker(client.post)(url, json=payload)
             response.raise_for_status()
             data = response.json()
 
@@ -214,10 +241,10 @@ class LLMClient:
 
         # Check circuit breaker state before attempting stream connection.
         # Use the lock to avoid race conditions with concurrent requests.
-        async with llm_cb._lock:
-            if llm_cb.current_state == CircuitBreakerState.OPEN:
-                llm_cb._check_timeout()
-                if llm_cb.current_state == CircuitBreakerState.OPEN:
+        async with self._circuit_breaker._lock:
+            if self._circuit_breaker.current_state == CircuitBreakerState.OPEN:
+                self._circuit_breaker._check_timeout()
+                if self._circuit_breaker.current_state == CircuitBreakerState.OPEN:
                     raise LLMError(
                         "LLM service is currently unavailable (circuit breaker open)"
                     )
@@ -396,12 +423,12 @@ class LLMClient:
             # not a service-unavailability signal.
             raise
         except httpx.TimeoutException as e:
-            async with llm_cb._lock:
-                llm_cb.record_failure()
+            async with self._circuit_breaker._lock:
+                self._circuit_breaker.record_failure()
             raise LLMError(f"Streaming request timed out after {self.timeout}s") from e
         except httpx.HTTPStatusError as e:
-            async with llm_cb._lock:
-                llm_cb.record_failure()
+            async with self._circuit_breaker._lock:
+                self._circuit_breaker.record_failure()
             # Read response content first to avoid ResponseNotRead error in streaming context
             try:
                 response_text = (await e.response.aread()).decode(
@@ -413,19 +440,39 @@ class LLMClient:
                 f"HTTP error {e.response.status_code}: {response_text}"
             ) from e
         except httpx.RequestError as e:
-            async with llm_cb._lock:
-                llm_cb.record_failure()
+            async with self._circuit_breaker._lock:
+                self._circuit_breaker.record_failure()
             raise LLMError(f"Streaming request failed: {str(e)}") from e
         finally:
             if stream_succeeded:
-                async with llm_cb._lock:
-                    llm_cb.record_success()
+                async with self._circuit_breaker._lock:
+                    self._circuit_breaker.record_success()
 
         # Log connection pool metrics after streaming completes
         self._log_pool_stats()
 
     async def close(self):
-        """Close the HTTP client."""
+        """Close the HTTP client (idempotent — safe to call multiple times)."""
         if self._client is not None:
             await self._client.aclose()
             self._client = None
+
+
+def create_thinking_client(timeout: float = 300.0) -> "LLMClient":
+    """Create an LLMClient configured for the Thinking backend (gpt-oss-120b / DGX Spark)."""
+    return LLMClient(
+        timeout=timeout,
+        base_url=settings.ollama_chat_url,
+        model=settings.chat_model,
+        cb_name="llm_thinking",
+    )
+
+
+def create_instant_client(timeout: float = 120.0) -> "LLMClient":
+    """Create an LLMClient configured for the Instant backend (LM Studio / Nemotron 4B)."""
+    return LLMClient(
+        timeout=timeout,
+        base_url=settings.instant_chat_url,
+        model=settings.instant_chat_model,
+        cb_name="llm_instant",
+    )

--- a/backend/app/services/llm_health.py
+++ b/backend/app/services/llm_health.py
@@ -24,7 +24,9 @@ class LLMHealthChecker:
         self,
         timeout: float = 5.0,
         embedding_service: Optional[EmbeddingService] = None,
-        llm_client: Optional[LLMClient] = None
+        llm_client: Optional[LLMClient] = None,
+        thinking_client: Optional[LLMClient] = None,
+        instant_client: Optional[LLMClient] = None,
     ):
         """
         Initialize the health checker.
@@ -32,11 +34,16 @@ class LLMHealthChecker:
         Args:
             timeout: Request timeout in seconds for health checks (default: 5.0)
             embedding_service: Optional injected EmbeddingService instance
-            llm_client: Optional injected LLMClient instance
+            llm_client: Optional injected LLMClient instance (legacy single-client API)
+            thinking_client: Optional injected Thinking-mode LLMClient instance
+            instant_client: Optional injected Instant-mode LLMClient instance
         """
         self.timeout = timeout
         self._embedding_service = embedding_service
+        # Preserve legacy single-client API: `llm_client` alone targets Thinking.
         self._llm_client = llm_client
+        self._thinking_client = thinking_client or llm_client
+        self._instant_client = instant_client
 
     async def check_embeddings(self) -> Dict[str, Any]:
         """
@@ -110,6 +117,36 @@ class LLMHealthChecker:
             # Ensure locally created client is closed
             if created_locally and client is not None:
                 await client.close()
+
+    async def _probe_client(self, client: LLMClient) -> bool:
+        """Send a minimal ping through ``client`` and return True iff successful."""
+        try:
+            await client.chat_completion(
+                [{"role": "user", "content": "ping"}],
+                max_tokens=1,
+            )
+            return True
+        except Exception:
+            return False
+
+    async def check_chat_modes(self) -> Dict[str, bool]:
+        """Probe both the Thinking and Instant endpoints independently.
+
+        Returns:
+            ``{"thinking": bool, "instant": bool}``. A missing client is
+            reported as ``False`` so the frontend fails closed.
+        """
+        thinking_ok = (
+            await self._probe_client(self._thinking_client)
+            if self._thinking_client is not None
+            else False
+        )
+        instant_ok = (
+            await self._probe_client(self._instant_client)
+            if self._instant_client is not None
+            else False
+        )
+        return {"thinking": thinking_ok, "instant": instant_ok}
 
     async def check_all(self) -> Dict[str, Any]:
         """

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -110,11 +110,19 @@ class RAGEngine:
         document_retrieval_service: Optional[DocumentRetrievalService] = None,
         prompt_builder_service: Optional[PromptBuilderService] = None,
         wiki_retrieval: Optional[Any] = None,
+        thinking_client: Optional[LLMClient] = None,
+        instant_client: Optional[LLMClient] = None,
     ) -> None:
         self.embedding_service = embedding_service or EmbeddingService()
         self.vector_store = vector_store or None
         self.memory_store = memory_store or MemoryStore()
         self.llm_client = llm_client or LLMClient()
+        # Per-mode client overrides. When None, the ``thinking_client`` /
+        # ``instant_client`` properties fall back to ``self.llm_client`` so
+        # tests that mutate ``engine.llm_client`` post-construction continue
+        # to flow through both modes.
+        self._thinking_client_override = thinking_client
+        self._instant_client_override = instant_client
         self.reranking_service = reranking_service
 
         # Log warnings for missing dependencies (indicates non-DI usage)
@@ -195,12 +203,23 @@ class RAGEngine:
         # Wiki retrieval service (optional — injected at startup)
         self._wiki_retrieval = wiki_retrieval
 
+    @property
+    def thinking_client(self) -> LLMClient:
+        """LLM client for Thinking mode. Falls back to ``self.llm_client`` when no explicit override was passed at construction."""
+        return self._thinking_client_override or self.llm_client
+
+    @property
+    def instant_client(self) -> LLMClient:
+        """LLM client for Instant mode. Falls back to ``self.llm_client`` when no explicit override was passed at construction."""
+        return self._instant_client_override or self.llm_client
+
     async def query(
         self,
         user_input: str,
         chat_history: List[Dict[str, Any]],
         stream: bool = False,
         vault_id: Optional[int] = None,
+        mode: Optional["ChatMode"] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """Execute a RAG query: embed, search, build prompt, call LLM."""
         logger.info(
@@ -208,6 +227,33 @@ class RAGEngine:
             len(user_input),
             vault_id,
             stream,
+        )
+
+        # Resolve effective mode and per-mode retrieval budget.
+        from app.models.chat_mode import ChatMode  # local to avoid cycles
+        if mode is None:
+            try:
+                mode = ChatMode(settings.default_chat_mode)
+            except ValueError:
+                mode = ChatMode.THINKING
+
+        if mode == ChatMode.INSTANT:
+            effective_initial_top_k = settings.instant_initial_retrieval_top_k
+            effective_reranker_top_n = settings.instant_reranker_top_n
+            effective_memory_top_k = settings.instant_memory_context_top_k
+            effective_max_tokens = settings.instant_max_tokens
+            active_client = self.instant_client
+        else:
+            effective_initial_top_k = self.initial_retrieval_top_k
+            effective_reranker_top_n = self.reranker_top_n
+            effective_memory_top_k = settings.memory_context_top_k
+            effective_max_tokens = 32768
+            active_client = self.thinking_client
+
+        logger.debug(
+            "RAGEngine.query mode=%s client=%s",
+            mode.value,
+            getattr(active_client, "base_url", "<unknown>"),
         )
         # Per-query observability accumulator. Always built; emitted into
         # the done message only when ``rag_trace_in_response`` is on.
@@ -229,13 +275,14 @@ class RAGEngine:
         except Exception as exc:
             logger.error("Memory intent detection/add failed (%s): %s", type(exc).__name__, exc)
 
-        # Query transformation for broader retrieval (if enabled)
+        # Query transformation for broader retrieval (if enabled).
+        # Use the active (mode-selected) client so Instant mode doesn't
+        # pay Thinking latency on query rewrites.
         transformed_queries: List[Tuple[str, str]] = [('original', user_input)]
-        if settings.query_transformation_enabled and self.llm_client is not None:
+        if settings.query_transformation_enabled and active_client is not None:
             try:
-                if self._query_transformer is None:
-                    self._query_transformer = QueryTransformer(self.llm_client)
-                transformed_queries = await self._query_transformer.transform(
+                query_transformer = QueryTransformer(active_client)
+                transformed_queries = await query_transformer.transform(
                     user_input
                 )
                 # transformed_queries is now List[Tuple[str, str]] like [('original', '...'), ('step_back', '...'), ('hyde', '...')]
@@ -369,6 +416,8 @@ class RAGEngine:
                     vault_id,
                     effective_alpha=effective_alpha,
                     variants_dropped=variants_dropped,
+                    override_initial_top_k=effective_initial_top_k,
+                    override_reranker_top_n=effective_reranker_top_n,
                 )
                 logger.info(
                     "[query] _execute_retrieval returned: result_count=%d, first_3_distances=%s",
@@ -433,7 +482,7 @@ class RAGEngine:
             try:
                 distiller = ContextDistiller(
                     self.embedding_service,
-                    self.llm_client if settings.context_distillation_synthesis_enabled else None,
+                    active_client if settings.context_distillation_synthesis_enabled else None,
                 )
                 trace.distillation_before = len(relevant_chunks)
                 relevant_chunks = await distiller.distill(
@@ -496,7 +545,7 @@ class RAGEngine:
                 )
                 # Apply context_top_k cap after relevance filtering so prompt context
                 # stays bounded even when top_k is large.
-                memories = candidates[: settings.memory_context_top_k]
+                memories = candidates[:effective_memory_top_k]
                 logger.info(
                     "[query] Memory: %d candidates → %d after context_top_k cap",
                     len(candidates),
@@ -516,14 +565,18 @@ class RAGEngine:
         # content so citation labels can be parsed for the trace.
         assembled_response: List[str] = []
         if stream:
-            async for chunk in self._stream_llm_response(messages):
+            async for chunk in self._stream_llm_response(
+                messages, client=active_client, max_tokens=effective_max_tokens
+            ):
                 chunk_type = chunk.get("type", "unknown")
                 logger.debug("[query] Yielding '%s' chunk (stream)", chunk_type)
                 if chunk_type == "content":
                     assembled_response.append(chunk.get("content", ""))
                 yield chunk
         else:
-            async for chunk in self._get_llm_response(messages):
+            async for chunk in self._get_llm_response(
+                messages, client=active_client, max_tokens=effective_max_tokens
+            ):
                 chunk_type = chunk.get("type", "unknown")
                 logger.debug("[query] Yielding '%s' chunk (non-stream)", chunk_type)
                 if chunk_type == "content":
@@ -610,6 +663,8 @@ class RAGEngine:
         vault_id: Optional[int],
         effective_alpha: float = 0.6,
         variants_dropped: List[str] = None,
+        override_initial_top_k: Optional[int] = None,
+        override_reranker_top_n: Optional[int] = None,
     ) -> tuple[List[Dict[str, Any]], Optional[str], str, Optional[bool], str, str, int, str, List[str], bool, Dict[str, int]]:
         """Execute vector search and retrieval evaluation.
 
@@ -642,8 +697,13 @@ class RAGEngine:
         # Phase 1: Search phase - original query failures propagate immediately
         vector_results = []
         try:
+            effective_initial = (
+                override_initial_top_k
+                if override_initial_top_k is not None
+                else self.initial_retrieval_top_k
+            )
             fetch_k = (
-                self.initial_retrieval_top_k
+                effective_initial
                 if self.reranking_enabled
                 else self.retrieval_top_k
             )
@@ -811,7 +871,11 @@ class RAGEngine:
                     reranked_chunks, rerank_success = await self.reranking_service.rerank(
                         query=user_input,
                         chunks=vector_results,
-                        top_n=self.reranker_top_n,
+                        top_n=(
+                            override_reranker_top_n
+                            if override_reranker_top_n is not None
+                            else self.reranker_top_n
+                        ),
                     )
                     if reranked_chunks:
                         vector_results = reranked_chunks
@@ -995,17 +1059,22 @@ class RAGEngine:
     async def _stream_llm_response(
         self,
         messages: List[Dict[str, str]],
+        client: Optional[LLMClient] = None,
+        max_tokens: int = 32768,
     ) -> AsyncIterator[Dict[str, Any]]:
         """Stream LLM response chunks.
 
         Args:
             messages: List of message dictionaries
+            client: Override LLM client (defaults to self.llm_client for back-compat).
+            max_tokens: Max output tokens for the model.
 
         Yields:
             Response chunks as dictionaries
         """
+        target = client or self.llm_client
         try:
-            async for chunk in self.llm_client.chat_completion_stream(messages):
+            async for chunk in target.chat_completion_stream(messages, max_tokens=max_tokens):
                 yield {"type": "content", "content": chunk}
         except LLMError as exc:
             logger.error("[_stream_llm_response] LLMError: %s", exc)
@@ -1014,11 +1083,15 @@ class RAGEngine:
     async def _get_llm_response(
         self,
         messages: List[Dict[str, str]],
+        client: Optional[LLMClient] = None,
+        max_tokens: int = 32768,
     ) -> AsyncIterator[Dict[str, Any]]:
         """Get non-streaming LLM response.
 
         Args:
             messages: List of message dictionaries
+            client: Override LLM client (defaults to self.llm_client for back-compat).
+            max_tokens: Max output tokens for the model.
 
         Yields:
             Response content dictionary
@@ -1026,8 +1099,9 @@ class RAGEngine:
         Raises:
             RAGEngineError: If LLM call fails
         """
+        target = client or self.llm_client
         try:
-            content = await self.llm_client.chat_completion(messages)
+            content = await target.chat_completion(messages, max_tokens=max_tokens)
             yield {"type": "content", "content": content}
         except LLMError as exc:
             raise RAGEngineError(f"LLM chat failed: {exc}") from exc

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 
 from app.config import settings
+from app.models.chat_mode import ChatMode
 from app.services.citation_validator import (
     parse_citations,
     parse_wiki_citations,
@@ -219,7 +220,7 @@ class RAGEngine:
         chat_history: List[Dict[str, Any]],
         stream: bool = False,
         vault_id: Optional[int] = None,
-        mode: Optional["ChatMode"] = None,
+        mode: Optional[ChatMode] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """Execute a RAG query: embed, search, build prompt, call LLM."""
         logger.info(

--- a/backend/tests/test_adversarial_security.py
+++ b/backend/tests/test_adversarial_security.py
@@ -193,29 +193,92 @@ class TestEmbeddingsAdversarial:
             mock.embedding_batch_min_sub_size = 1
             yield mock
 
+    def _apply_mock_settings(self, mock_settings):
+        """Apply mock settings to the embeddings module, handling reimports.
+
+        After admin tests delete and reimport app.main, the embeddings module might
+        be reimported, which rebinds the settings reference. This helper ensures the
+        mocked settings are applied to the current module state.
+
+        Returns a tuple of (emb_mod, original_settings) so the caller can restore later.
+        """
+        from app.services import embeddings as emb_mod
+        original_settings = emb_mod.settings
+        emb_mod.settings = mock_settings
+        return emb_mod, original_settings
+
     def test_init_with_empty_url(self, mock_settings):
         """Attack: Empty URL should raise error."""
         mock_settings.ollama_embedding_url = ""
-        with pytest.raises(EmbeddingError, match="not configured"):
-            EmbeddingService()
+
+        # Handle module reimports: If the embeddings module was reimported (e.g., by
+        # admin tests that delete app.main), the EmbeddingService class imported at the
+        # top of this file might be from an old module reference. Reimport it to get
+        # the fresh class that uses the current module's settings.
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        from app.services import embeddings as emb_mod
+
+        original_settings = emb_mod.settings
+        emb_mod.settings = mock_settings
+
+        try:
+            try:
+                EmbeddingService_Fresh()
+                # If we get here, no exception was raised, which is the error condition
+                pytest.fail(f"EmbeddingService() did not raise EmbeddingError")
+            except EmbeddingError as e:
+                # Verify the error message matches the expected pattern
+                if "not configured" not in str(e):
+                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'not configured'")
+                # If we got here, the test passed
+        finally:
+            # Restore original settings
+            emb_mod.settings = original_settings
 
     def test_init_with_invalid_url_scheme(self, mock_settings):
         """Attack: Invalid URL scheme (ftp://, file://)."""
         mock_settings.ollama_embedding_url = "ftp://localhost:11434"
-        with pytest.raises(EmbeddingError, match="Invalid embedding URL"):
-            EmbeddingService()
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        emb_mod, original_settings = self._apply_mock_settings(mock_settings)
+        try:
+            try:
+                EmbeddingService_Fresh()
+                pytest.fail("EmbeddingService() did not raise EmbeddingError")
+            except EmbeddingError as e:
+                if "Invalid embedding URL" not in str(e):
+                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'Invalid embedding URL'")
+        finally:
+            emb_mod.settings = original_settings
 
     def test_init_with_javascript_url(self, mock_settings):
         """Attack: JavaScript URL (XSS attempt)."""
         mock_settings.ollama_embedding_url = "javascript:alert('xss')"
-        with pytest.raises(EmbeddingError, match="Invalid embedding URL"):
-            EmbeddingService()
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        emb_mod, original_settings = self._apply_mock_settings(mock_settings)
+        try:
+            try:
+                EmbeddingService_Fresh()
+                pytest.fail("EmbeddingService() did not raise EmbeddingError")
+            except EmbeddingError as e:
+                if "Invalid embedding URL" not in str(e):
+                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'Invalid embedding URL'")
+        finally:
+            emb_mod.settings = original_settings
 
     def test_init_with_data_url(self, mock_settings):
         """Attack: Data URL (potential injection)."""
         mock_settings.ollama_embedding_url = "data:text/html,<script>alert('xss')</script>"
-        with pytest.raises(EmbeddingError, match="Invalid embedding URL"):
-            EmbeddingService()
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        emb_mod, original_settings = self._apply_mock_settings(mock_settings)
+        try:
+            try:
+                EmbeddingService_Fresh()
+                pytest.fail("EmbeddingService() did not raise EmbeddingError")
+            except EmbeddingError as e:
+                if "Invalid embedding URL" not in str(e):
+                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'Invalid embedding URL'")
+        finally:
+            emb_mod.settings = original_settings
 
     def test_init_with_path_traversal_url(self, mock_settings):
         """Attack: Path traversal in URL."""

--- a/backend/tests/test_adversarial_security.py
+++ b/backend/tests/test_adversarial_security.py
@@ -211,72 +211,73 @@ class TestEmbeddingsAdversarial:
         """Attack: Empty URL should raise error."""
         mock_settings.ollama_embedding_url = ""
 
-        # Handle module reimports: If the embeddings module was reimported (e.g., by
-        # admin tests that delete app.main), the EmbeddingService class imported at the
-        # top of this file might be from an old module reference. Reimport it to get
-        # the fresh class that uses the current module's settings.
-        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
-        from app.services import embeddings as emb_mod
-
-        original_settings = emb_mod.settings
-        emb_mod.settings = mock_settings
-
-        try:
-            try:
-                EmbeddingService_Fresh()
-                # If we get here, no exception was raised, which is the error condition
-                pytest.fail(f"EmbeddingService() did not raise EmbeddingError")
-            except EmbeddingError as e:
-                # Verify the error message matches the expected pattern
-                if "not configured" not in str(e):
-                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'not configured'")
-                # If we got here, the test passed
-        finally:
-            # Restore original settings
-            emb_mod.settings = original_settings
-
-    def test_init_with_invalid_url_scheme(self, mock_settings):
-        """Attack: Invalid URL scheme (ftp://, file://)."""
-        mock_settings.ollama_embedding_url = "ftp://localhost:11434"
         from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
         emb_mod, original_settings = self._apply_mock_settings(mock_settings)
+
         try:
             try:
                 EmbeddingService_Fresh()
                 pytest.fail("EmbeddingService() did not raise EmbeddingError")
             except EmbeddingError as e:
-                if "Invalid embedding URL" not in str(e):
-                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'Invalid embedding URL'")
+                if "not configured" not in str(e):
+                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'not configured'")
+        finally:
+            emb_mod.settings = original_settings
+
+    def _assert_embedding_error(
+        self, exception_fn, expected_message_substring
+    ):
+        """Helper to assert EmbeddingError is raised with expected message."""
+        from app.services.embeddings import EmbeddingError
+
+        try:
+            exception_fn()
+            pytest.fail("EmbeddingService() did not raise EmbeddingError")
+        except EmbeddingError as e:
+            if expected_message_substring not in str(e):
+                pytest.fail(
+                    f"EmbeddingError message '{e}' does not contain "
+                    f"'{expected_message_substring}'"
+                )
+
+    def test_init_with_invalid_url_scheme(self, mock_settings):
+        """Attack: Invalid URL scheme (ftp://, file://)."""
+        mock_settings.ollama_embedding_url = "ftp://localhost:11434"
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh
+
+        emb_mod, original_settings = self._apply_mock_settings(mock_settings)
+        try:
+            self._assert_embedding_error(
+                EmbeddingService_Fresh, "Invalid embedding URL"
+            )
         finally:
             emb_mod.settings = original_settings
 
     def test_init_with_javascript_url(self, mock_settings):
         """Attack: JavaScript URL (XSS attempt)."""
         mock_settings.ollama_embedding_url = "javascript:alert('xss')"
-        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh
+
         emb_mod, original_settings = self._apply_mock_settings(mock_settings)
         try:
-            try:
-                EmbeddingService_Fresh()
-                pytest.fail("EmbeddingService() did not raise EmbeddingError")
-            except EmbeddingError as e:
-                if "Invalid embedding URL" not in str(e):
-                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'Invalid embedding URL'")
+            self._assert_embedding_error(
+                EmbeddingService_Fresh, "Invalid embedding URL"
+            )
         finally:
             emb_mod.settings = original_settings
 
     def test_init_with_data_url(self, mock_settings):
         """Attack: Data URL (potential injection)."""
-        mock_settings.ollama_embedding_url = "data:text/html,<script>alert('xss')</script>"
-        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        mock_settings.ollama_embedding_url = (
+            "data:text/html,<script>alert('xss')</script>"
+        )
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh
+
         emb_mod, original_settings = self._apply_mock_settings(mock_settings)
         try:
-            try:
-                EmbeddingService_Fresh()
-                pytest.fail("EmbeddingService() did not raise EmbeddingError")
-            except EmbeddingError as e:
-                if "Invalid embedding URL" not in str(e):
-                    pytest.fail(f"EmbeddingError message '{e}' does not contain 'Invalid embedding URL'")
+            self._assert_embedding_error(
+                EmbeddingService_Fresh, "Invalid embedding URL"
+            )
         finally:
             emb_mod.settings = original_settings
 

--- a/backend/tests/test_adversarial_security.py
+++ b/backend/tests/test_adversarial_security.py
@@ -211,7 +211,8 @@ class TestEmbeddingsAdversarial:
         """Attack: Empty URL should raise error."""
         mock_settings.ollama_embedding_url = ""
 
-        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh, EmbeddingError
+        from app.services.embeddings import EmbeddingError
+        from app.services.embeddings import EmbeddingService as EmbeddingService_Fresh
         emb_mod, original_settings = self._apply_mock_settings(mock_settings)
 
         try:

--- a/backend/tests/test_adversarial_security.py
+++ b/backend/tests/test_adversarial_security.py
@@ -306,8 +306,10 @@ class TestEmbeddingsAdversarial:
         sql_injection_text = "'; DROP TABLE users; --"
         # Should not execute SQL, should treat as plain text
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"embedding": [0.1, 0.2, 0.3]}
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"embedding": [0.1, 0.2, 0.3]}
+            mock_post.return_value = mock_response
 
             try:
                 await service.embed_single(sql_injection_text)
@@ -327,8 +329,10 @@ class TestEmbeddingsAdversarial:
 
         xss_text = "<script>alert('xss')</script>"
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"embedding": [0.1, 0.2, 0.3]}
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"embedding": [0.1, 0.2, 0.3]}
+            mock_post.return_value = mock_response
 
             await service.embed_single(xss_text)
             # XSS should be preserved as text, not executed
@@ -361,15 +365,26 @@ class TestEmbeddingsAdversarial:
         # Create batch larger than MAX_BATCH_SIZE
         texts = ["test"] * (service.MAX_BATCH_SIZE + 100)
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {
-                "data": [{"embedding": [0.1, 0.2]}] * len(texts)
-            }
+            # Mock should return different responses for each batch call
+            # First call: 512 embeddings, second call: 100 embeddings
+            def create_response(batch_size):
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = {
+                    "embeddings": [[0.1, 0.2]] * batch_size
+                }
+                return mock_response
+
+            # Use side_effect to return different responses for each call
+            mock_post.side_effect = [
+                create_response(512),  # First batch
+                create_response(100),  # Second batch
+            ]
 
             # Should process in chunks, not fail
             await service.embed_batch(texts)
             # Verify multiple calls were made due to batch size limit
-            assert mock_post.call_count > 1
+            assert mock_post.call_count == 2
 
     @pytest.mark.asyncio
     async def test_embed_batch_with_negative_batch_size(self, mock_settings):
@@ -377,12 +392,21 @@ class TestEmbeddingsAdversarial:
         service = EmbeddingService()
 
         texts = ["test1", "test2"]
-        # Negative batch_size should be clamped to valid range
+        # Negative batch_size should be clamped to valid range (1)
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {
-                "data": [{"embedding": [0.1, 0.2]}, {"embedding": [0.3, 0.4]}]
-            }
+            # With batch_size=1 and 2 texts, expect 2 calls with 1 embedding each
+            def create_response(batch_size):
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = {
+                    "embeddings": [[0.1, 0.2]] * batch_size
+                }
+                return mock_response
+
+            mock_post.side_effect = [
+                create_response(1),  # First batch
+                create_response(1),  # Second batch
+            ]
 
             result = await service.embed_batch(texts, batch_size=-10)
             # Should handle gracefully (clamped to 1)
@@ -394,12 +418,21 @@ class TestEmbeddingsAdversarial:
         service = EmbeddingService()
 
         texts = ["test1", "test2"]
-        # Zero batch_size should be clamped to valid range
+        # Zero batch_size should be clamped to valid range (1)
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {
-                "data": [{"embedding": [0.1, 0.2]}, {"embedding": [0.3, 0.4]}]
-            }
+            # With batch_size=1 and 2 texts, expect 2 calls with 1 embedding each
+            def create_response(batch_size):
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = {
+                    "embeddings": [[0.1, 0.2]] * batch_size
+                }
+                return mock_response
+
+            mock_post.side_effect = [
+                create_response(1),  # First batch
+                create_response(1),  # Second batch
+            ]
 
             result = await service.embed_batch(texts, batch_size=0)
             # Should handle gracefully (clamped to 1)
@@ -412,8 +445,10 @@ class TestEmbeddingsAdversarial:
 
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
             # Response with missing embedding field
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"data": [{"invalid": "response"}]}
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"data": [{"invalid": "response"}]}
+            mock_post.return_value = mock_response
 
             with pytest.raises(EmbeddingError):
                 await service.embed_single("test")
@@ -424,9 +459,11 @@ class TestEmbeddingsAdversarial:
         service = EmbeddingService()
 
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.side_effect = json.JSONDecodeError("test", "", 0)
-            mock_post.return_value.text = "<html><body>Access Denied</body></html>"
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.side_effect = json.JSONDecodeError("test", "", 0)
+            mock_response.text = "<html><body>Access Denied</body></html>"
+            mock_post.return_value = mock_response
 
             with pytest.raises(EmbeddingError, match="Invalid response"):
                 await service.embed_single("test")
@@ -437,12 +474,14 @@ class TestEmbeddingsAdversarial:
         service = EmbeddingService()
 
         with patch.object(service._client, 'post', new_callable=AsyncMock) as mock_post:
-            mock_post.return_value.status_code = 200
+            mock_response = MagicMock()
+            mock_response.status_code = 200
             # Create a deeply nested structure
             nested = {"embedding": [0.1]}
             for _ in range(1000):
                 nested = {"embedding": nested}
-            mock_post.return_value.json.return_value = {"data": [nested]}
+            mock_response.json.return_value = {"data": [nested]}
+            mock_post.return_value = mock_response
 
             with pytest.raises(EmbeddingError):
                 await service.embed_single("test")

--- a/backend/tests/test_chat_mode.py
+++ b/backend/tests/test_chat_mode.py
@@ -1,0 +1,33 @@
+"""Smoke tests for ChatMode enum and instant-mode settings defaults."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from app.config import settings
+from app.models.chat_mode import ChatMode
+
+
+def test_chat_mode_enum_values():
+    assert ChatMode("instant") == ChatMode.INSTANT
+    assert ChatMode("thinking") == ChatMode.THINKING
+    assert ChatMode.INSTANT.value == "instant"
+    assert ChatMode.THINKING.value == "thinking"
+    # str-Enum: members compare equal to their string value
+    assert ChatMode.INSTANT == "instant"
+
+
+def test_chat_mode_enum_rejects_unknown():
+    import pytest
+    with pytest.raises(ValueError):
+        ChatMode("nonsense")
+
+
+def test_instant_mode_settings_defaults_present():
+    assert settings.instant_chat_url == "http://host.docker.internal:1234"
+    assert settings.instant_chat_model == "nvidia/nemotron-3-nano-4b"
+    assert settings.default_chat_mode in ("instant", "thinking")
+    assert isinstance(settings.instant_initial_retrieval_top_k, int)
+    assert isinstance(settings.instant_reranker_top_n, int)
+    assert isinstance(settings.instant_memory_context_top_k, int)
+    assert isinstance(settings.instant_max_tokens, int)

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -118,7 +118,9 @@ class FakeLLMClient:
         self.raise_error = raise_error
         self.call_count = 0
 
-    async def chat_completion(self, messages: List[Dict[str, str]]) -> str:
+    async def chat_completion(
+        self, messages: List[Dict[str, str]], **kwargs
+    ) -> str:
         self.call_count += 1
         if self.raise_error:
             from app.services.llm_client import LLMError
@@ -126,7 +128,9 @@ class FakeLLMClient:
             raise LLMError("LLM service unavailable")
         return self.response
 
-    async def chat_completion_stream(self, messages: List[Dict[str, str]]):
+    async def chat_completion_stream(
+        self, messages: List[Dict[str, str]], **kwargs
+    ):
         self.call_count += 1
         if self.raise_error:
             from app.services.llm_client import LLMError

--- a/backend/tests/test_llm_client_per_instance_breaker.py
+++ b/backend/tests/test_llm_client_per_instance_breaker.py
@@ -66,3 +66,53 @@ def test_reconfigure_updates_base_url_and_model_in_place():
     assert c.model == "new-model"
     # Breaker reference is preserved — no recreation.
     assert c._circuit_breaker is breaker_ref
+
+
+def test_reconfigure_resets_open_breaker_when_endpoint_changes():
+    """Reconfiguring to a new endpoint must reset a previously opened breaker."""
+    c = LLMClient(base_url="http://old.example:1234", model="old-model")
+
+    async def trip():
+        async with c._circuit_breaker._lock:
+            for _ in range(5):
+                c._circuit_breaker.record_failure()
+
+    asyncio.run(trip())
+    assert c._circuit_breaker.current_state == CircuitBreakerState.OPEN
+
+    c.reconfigure(base_url="http://new.example:5678")
+    assert c._circuit_breaker.current_state == CircuitBreakerState.CLOSED
+    assert c._circuit_breaker.fail_counter == 0
+
+
+def test_reconfigure_resets_open_breaker_when_model_changes():
+    """Reconfiguring to a new model must reset a previously opened breaker."""
+    c = LLMClient(base_url="http://old.example:1234", model="old-model")
+
+    async def trip():
+        async with c._circuit_breaker._lock:
+            for _ in range(5):
+                c._circuit_breaker.record_failure()
+
+    asyncio.run(trip())
+    assert c._circuit_breaker.current_state == CircuitBreakerState.OPEN
+
+    c.reconfigure(model="new-model")
+    assert c._circuit_breaker.current_state == CircuitBreakerState.CLOSED
+
+
+def test_reconfigure_noop_preserves_breaker_state():
+    """Reconfiguring with the same values must not reset an opened breaker."""
+    c = LLMClient(base_url="http://old.example:1234", model="old-model")
+
+    async def trip():
+        async with c._circuit_breaker._lock:
+            for _ in range(5):
+                c._circuit_breaker.record_failure()
+
+    asyncio.run(trip())
+    assert c._circuit_breaker.current_state == CircuitBreakerState.OPEN
+
+    # Same values — should be a no-op.
+    c.reconfigure(base_url="http://old.example:1234", model="old-model")
+    assert c._circuit_breaker.current_state == CircuitBreakerState.OPEN

--- a/backend/tests/test_llm_client_per_instance_breaker.py
+++ b/backend/tests/test_llm_client_per_instance_breaker.py
@@ -15,7 +15,11 @@ import asyncio
 import pytest
 
 from app.services.circuit_breaker import AsyncCircuitBreaker, CircuitBreakerState
-from app.services.llm_client import LLMClient, create_instant_client, create_thinking_client
+from app.services.llm_client import (
+    LLMClient,
+    create_instant_client,
+    create_thinking_client,
+)
 
 
 def test_per_instance_circuit_breaker_distinct_objects():

--- a/backend/tests/test_llm_client_per_instance_breaker.py
+++ b/backend/tests/test_llm_client_per_instance_breaker.py
@@ -1,0 +1,64 @@
+"""Verify each LLMClient owns its own circuit breaker.
+
+After the dual-mode (Instant/Thinking) refactor, the LLMClient no longer
+uses the module-level ``llm_cb`` singleton inside its methods. Each
+instance constructs its own ``AsyncCircuitBreaker`` so that failures on
+one backend cannot trip the breaker for another.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import asyncio
+
+import pytest
+
+from app.services.circuit_breaker import AsyncCircuitBreaker, CircuitBreakerState
+from app.services.llm_client import LLMClient, create_instant_client, create_thinking_client
+
+
+def test_per_instance_circuit_breaker_distinct_objects():
+    """Two LLMClient instances must hold distinct circuit breaker instances."""
+    a = LLMClient()
+    b = LLMClient()
+    assert isinstance(a._circuit_breaker, AsyncCircuitBreaker)
+    assert isinstance(b._circuit_breaker, AsyncCircuitBreaker)
+    assert a._circuit_breaker is not b._circuit_breaker
+
+
+def test_thinking_and_instant_factories_have_distinct_breakers():
+    """Factory-created Thinking and Instant clients must have isolated breakers and distinct names."""
+    thinking = create_thinking_client()
+    instant = create_instant_client()
+    assert thinking._circuit_breaker is not instant._circuit_breaker
+    assert thinking._circuit_breaker.name == "llm_thinking"
+    assert instant._circuit_breaker.name == "llm_instant"
+
+
+def test_breaker_failure_on_one_does_not_trip_other():
+    """Recording failures on instance A's breaker must NOT affect instance B's state."""
+    a = LLMClient()
+    b = LLMClient()
+
+    async def trip_a():
+        # fail_max=5 — record 5 failures to trip A.
+        async with a._circuit_breaker._lock:
+            for _ in range(5):
+                a._circuit_breaker.record_failure()
+
+    asyncio.run(trip_a())
+
+    assert a._circuit_breaker.current_state == CircuitBreakerState.OPEN
+    assert b._circuit_breaker.current_state == CircuitBreakerState.CLOSED
+
+
+def test_reconfigure_updates_base_url_and_model_in_place():
+    """LLMClient.reconfigure must hot-swap base_url and model without recreating the client."""
+    c = LLMClient(base_url="http://old.example:1234", model="old-model")
+    breaker_ref = c._circuit_breaker
+    c.reconfigure(base_url="http://new.example:5678", model="new-model")
+    assert c.base_url == "http://new.example:5678"
+    assert c.model == "new-model"
+    # Breaker reference is preserved — no recreation.
+    assert c._circuit_breaker is breaker_ref

--- a/backend/tests/test_llm_health_dual.py
+++ b/backend/tests/test_llm_health_dual.py
@@ -1,0 +1,52 @@
+"""Verify LLMHealthChecker.check_chat_modes() probes both Thinking and Instant.
+
+Uses a stub client that records calls and returns success or failure on
+demand. We do NOT spin up real LLM endpoints.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from app.services.llm_health import LLMHealthChecker
+
+
+def _stub_client(ok: bool):
+    """Return an object with an async ``chat_completion`` matching LLMClient's signature."""
+    stub = AsyncMock()
+    if ok:
+        stub.chat_completion = AsyncMock(return_value="pong")
+    else:
+        stub.chat_completion = AsyncMock(side_effect=RuntimeError("backend down"))
+    return stub
+
+
+def test_check_chat_modes_returns_both_keys():
+    thinking = _stub_client(ok=True)
+    instant = _stub_client(ok=True)
+    checker = LLMHealthChecker(
+        thinking_client=thinking,
+        instant_client=instant,
+    )
+    result = asyncio.run(checker.check_chat_modes())
+    assert result == {"thinking": True, "instant": True}
+
+
+def test_check_chat_modes_failing_instant_reported_false():
+    thinking = _stub_client(ok=True)
+    instant = _stub_client(ok=False)
+    checker = LLMHealthChecker(
+        thinking_client=thinking,
+        instant_client=instant,
+    )
+    result = asyncio.run(checker.check_chat_modes())
+    assert result == {"thinking": True, "instant": False}
+
+
+def test_check_chat_modes_missing_clients_fails_closed():
+    checker = LLMHealthChecker()  # no clients
+    result = asyncio.run(checker.check_chat_modes())
+    assert result == {"thinking": False, "instant": False}

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -24,6 +24,9 @@ import { Progress } from "@/components/ui/progress";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/useChatStore";
+import { useChatModeStore } from "@/stores/useChatModeStore";
+import { useLlmHealthStore } from "@/stores/useLlmHealthStore";
+import { useSettingsStore } from "@/stores/useSettingsStore";
 import { useVaultStore } from "@/stores/useVaultStore";
 import { uploadDocument, getDocumentStatus } from "@/lib/api";
 import { MAX_INPUT_LENGTH } from "@/hooks/useSendMessage";
@@ -103,6 +106,23 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
   const textareaRef = (inputRef ?? internalRef) as React.RefObject<HTMLTextAreaElement>;
 
   const { input, setInput, inputError, activeChatId } = useChatStore();
+  const storedChatMode = useChatModeStore((s) => s.chatMode);
+  const setStoredChatMode = useChatModeStore((s) => s.setChatMode);
+  const defaultChatMode = useSettingsStore((s) => s.formData.default_chat_mode);
+  const thinkingHealthy = useLlmHealthStore((s) => s.thinking);
+  const instantHealthy = useLlmHealthStore((s) => s.instant);
+  const refreshLlmHealth = useLlmHealthStore((s) => s.refresh);
+  const effectiveChatMode: "instant" | "thinking" =
+    storedChatMode ?? defaultChatMode ?? "thinking";
+
+  // Poll backend LLM health on mount and every 30s so the Instant toggle
+  // can disable when LM Studio is unreachable.
+  useEffect(() => {
+    refreshLlmHealth();
+    const handle = setInterval(refreshLlmHealth, 30000);
+    return () => clearInterval(handle);
+  }, [refreshLlmHealth]);
+
   const { getActiveVault } = useVaultStore();
   const activeVault = getActiveVault();
   const activeVaultId = useVaultStore((s) => s.activeVaultId);
@@ -669,6 +689,56 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
                 Generating…
               </span>
             )}
+
+            {/* Mode toggle (Instant / Thinking) */}
+            <div
+              role="radiogroup"
+              aria-label="Chat mode"
+              className="flex h-8 items-center rounded-md border border-input text-xs overflow-hidden"
+            >
+              <button
+                type="button"
+                role="radio"
+                aria-checked={effectiveChatMode === "instant"}
+                disabled={!instantHealthy || isStreaming}
+                onClick={() => setStoredChatMode("instant")}
+                title={
+                  instantHealthy
+                    ? "Instant — fast, lightweight model"
+                    : "Instant mode unavailable (LM Studio unreachable)"
+                }
+                className={cn(
+                  "h-full px-3 transition-colors",
+                  effectiveChatMode === "instant"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                  (!instantHealthy || isStreaming) && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                Instant
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={effectiveChatMode === "thinking"}
+                disabled={!thinkingHealthy || isStreaming}
+                onClick={() => setStoredChatMode("thinking")}
+                title={
+                  thinkingHealthy
+                    ? "Thinking — full-quality model"
+                    : "Thinking mode unavailable (backend unreachable)"
+                }
+                className={cn(
+                  "h-full px-3 border-l border-input transition-colors",
+                  effectiveChatMode === "thinking"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                  (!thinkingHealthy || isStreaming) && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                Thinking
+              </button>
+            </div>
 
             {/* Send / Stop */}
             {isStreaming ? (

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -29,6 +29,7 @@ import { useLlmHealthStore } from "@/stores/useLlmHealthStore";
 import { useSettingsStore } from "@/stores/useSettingsStore";
 import { useVaultStore } from "@/stores/useVaultStore";
 import { uploadDocument, getDocumentStatus } from "@/lib/api";
+import { computeEffectiveChatMode } from "@/lib/chatMode";
 import { MAX_INPUT_LENGTH } from "@/hooks/useSendMessage";
 import { toast } from "sonner";
 
@@ -112,8 +113,17 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
   const thinkingHealthy = useLlmHealthStore((s) => s.thinking);
   const instantHealthy = useLlmHealthStore((s) => s.instant);
   const refreshLlmHealth = useLlmHealthStore((s) => s.refresh);
-  const effectiveChatMode: "instant" | "thinking" =
+  // Reflects the mode that will actually be sent, including health fallback,
+  // so the toggle highlight cannot disagree with the request payload.
+  const effectiveChatMode = computeEffectiveChatMode({
+    stored: storedChatMode,
+    defaultMode: defaultChatMode,
+    thinkingHealthy,
+    instantHealthy,
+  });
+  const desiredChatMode: "instant" | "thinking" =
     storedChatMode ?? defaultChatMode ?? "thinking";
+  const isFallenBack = effectiveChatMode !== desiredChatMode;
 
   // Poll backend LLM health on mount and every 30s so the Instant toggle
   // can disable when LM Studio is unreachable.
@@ -691,53 +701,68 @@ export function Composer({ onSend, onStop, isStreaming, className, inputRef }: C
             )}
 
             {/* Mode toggle (Instant / Thinking) */}
-            <div
-              role="radiogroup"
-              aria-label="Chat mode"
-              className="flex h-8 items-center rounded-md border border-input text-xs overflow-hidden"
-            >
-              <button
-                type="button"
-                role="radio"
-                aria-checked={effectiveChatMode === "instant"}
-                disabled={!instantHealthy || isStreaming}
-                onClick={() => setStoredChatMode("instant")}
-                title={
-                  instantHealthy
-                    ? "Instant — fast, lightweight model"
-                    : "Instant mode unavailable (LM Studio unreachable)"
-                }
-                className={cn(
-                  "h-full px-3 transition-colors",
-                  effectiveChatMode === "instant"
-                    ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
-                  (!instantHealthy || isStreaming) && "opacity-50 cursor-not-allowed",
-                )}
+            <div className="flex flex-col items-end gap-0.5">
+              <div
+                role="radiogroup"
+                aria-label="Chat mode"
+                className="flex h-8 items-center rounded-md border border-input text-xs overflow-hidden"
               >
-                Instant
-              </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={effectiveChatMode === "thinking"}
-                disabled={!thinkingHealthy || isStreaming}
-                onClick={() => setStoredChatMode("thinking")}
-                title={
-                  thinkingHealthy
-                    ? "Thinking — full-quality model"
-                    : "Thinking mode unavailable (backend unreachable)"
-                }
-                className={cn(
-                  "h-full px-3 border-l border-input transition-colors",
-                  effectiveChatMode === "thinking"
-                    ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
-                  (!thinkingHealthy || isStreaming) && "opacity-50 cursor-not-allowed",
-                )}
-              >
-                Thinking
-              </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={effectiveChatMode === "instant"}
+                  disabled={!instantHealthy || isStreaming}
+                  onClick={() => setStoredChatMode("instant")}
+                  title={
+                    !instantHealthy
+                      ? "Instant mode unavailable (LM Studio unreachable)"
+                      : isFallenBack && desiredChatMode === "thinking"
+                        ? "Instant — auto-selected because Thinking is unavailable"
+                        : "Instant — fast, lightweight model"
+                  }
+                  className={cn(
+                    "h-full px-3 transition-colors",
+                    effectiveChatMode === "instant"
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                    (!instantHealthy || isStreaming) && "opacity-50 cursor-not-allowed",
+                  )}
+                >
+                  Instant
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={effectiveChatMode === "thinking"}
+                  disabled={!thinkingHealthy || isStreaming}
+                  onClick={() => setStoredChatMode("thinking")}
+                  title={
+                    !thinkingHealthy
+                      ? "Thinking mode unavailable (backend unreachable)"
+                      : isFallenBack && desiredChatMode === "instant"
+                        ? "Thinking — auto-selected because Instant is unavailable"
+                        : "Thinking — full-quality model"
+                  }
+                  className={cn(
+                    "h-full px-3 border-l border-input transition-colors",
+                    effectiveChatMode === "thinking"
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                    (!thinkingHealthy || isStreaming) && "opacity-50 cursor-not-allowed",
+                  )}
+                >
+                  Thinking
+                </button>
+              </div>
+              {isFallenBack && (
+                <span
+                  role="status"
+                  aria-live="polite"
+                  className="text-[10px] text-amber-700 dark:text-amber-300"
+                >
+                  Using {effectiveChatMode} — {desiredChatMode} unavailable
+                </span>
+              )}
             </div>
 
             {/* Send / Stop */}

--- a/frontend/src/components/settings/ModelConnectionSettings.tsx
+++ b/frontend/src/components/settings/ModelConnectionSettings.tsx
@@ -76,6 +76,31 @@ export function ModelConnectionSettings({
           </div>
 
           <div className="space-y-2">
+            <Label htmlFor="instant_chat_url" className="text-sm font-medium">
+              Instant LLM Service URL
+            </Label>
+            <Input
+              id="instant_chat_url"
+              type="url"
+              placeholder="http://host.docker.internal:1234"
+              value={formData.instant_chat_url || ""}
+              onChange={(e) => onChange("instant_chat_url", e.target.value)}
+              aria-describedby="instant_chat_url-desc"
+              aria-invalid={!!errors.instant_chat_url}
+              className={errors.instant_chat_url ? "border-destructive" : ""}
+            />
+            {errors.instant_chat_url && (
+              <p className="text-xs text-destructive" role="alert">
+                {errors.instant_chat_url}
+              </p>
+            )}
+            <p id="instant_chat_url-desc" className="text-xs text-muted-foreground">
+              URL for the Instant chat backend (e.g., LM Studio on the host machine
+              listening on port 1234). Changes apply immediately.
+            </p>
+          </div>
+
+          <div className="space-y-2">
             <Label htmlFor="reranker_url" className="text-sm font-medium">
               Reranker Service URL
             </Label>
@@ -164,6 +189,76 @@ export function ModelConnectionSettings({
             )}
             <p id="chat_model-desc" className="text-xs text-muted-foreground">
               Model used for chat responses. Examples: llama3, mistral, openai/gpt-oss-20b
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="instant_chat_model" className="text-sm font-medium">
+              Instant Chat Model
+            </Label>
+            <Input
+              id="instant_chat_model"
+              type="text"
+              placeholder="nvidia/nemotron-3-nano-4b"
+              value={formData.instant_chat_model || ""}
+              onChange={(e) => onChange("instant_chat_model", e.target.value)}
+              aria-describedby="instant_chat_model-desc"
+              aria-invalid={!!errors.instant_chat_model}
+              className={errors.instant_chat_model ? "border-destructive" : ""}
+            />
+            {errors.instant_chat_model && (
+              <p className="text-xs text-destructive" role="alert">
+                {errors.instant_chat_model}
+              </p>
+            )}
+            <p id="instant_chat_model-desc" className="text-xs text-muted-foreground">
+              Small/fast model loaded in LM Studio for Instant mode. Changes apply
+              immediately.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="default_chat_mode" className="text-sm font-medium">
+              Default Chat Mode
+            </Label>
+            <div
+              id="default_chat_mode"
+              role="radiogroup"
+              aria-describedby="default_chat_mode-desc"
+              className="flex gap-2"
+            >
+              <button
+                type="button"
+                role="radio"
+                aria-checked={formData.default_chat_mode === "instant"}
+                onClick={() => onChange("default_chat_mode", "instant")}
+                className={
+                  "rounded-md border px-3 py-1.5 text-sm transition-colors " +
+                  (formData.default_chat_mode === "instant"
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-input bg-background text-foreground hover:bg-accent")
+                }
+              >
+                Instant
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={formData.default_chat_mode === "thinking"}
+                onClick={() => onChange("default_chat_mode", "thinking")}
+                className={
+                  "rounded-md border px-3 py-1.5 text-sm transition-colors " +
+                  (formData.default_chat_mode === "thinking"
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-input bg-background text-foreground hover:bg-accent")
+                }
+              >
+                Thinking
+              </button>
+            </div>
+            <p id="default_chat_mode-desc" className="text-xs text-muted-foreground">
+              Default mode for new chats. Users can still override per message
+              via the composer toggle.
             </p>
           </div>
 

--- a/frontend/src/hooks/useSendMessage.ts
+++ b/frontend/src/hooks/useSendMessage.ts
@@ -11,6 +11,7 @@ import { useChatStore, type Message } from "@/stores/useChatStore";
 import { useChatModeStore } from "@/stores/useChatModeStore";
 import { useLlmHealthStore } from "@/stores/useLlmHealthStore";
 import { useSettingsStore } from "@/stores/useSettingsStore";
+import { computeEffectiveChatMode } from "@/lib/chatMode";
 import type { UsedMemory } from "@/lib/api";
 
 export const MAX_INPUT_LENGTH = 2000;
@@ -107,20 +108,17 @@ export function useSendMessage(
       // Accumulate wiki refs from the SSE stream so they can be persisted with the message.
       let streamedWikiRefs: WikiReference[] = [];
 
-      // Resolve effective chat mode:
-      //   stored override (if any) → settings default → "thinking".
-      // If the selected mode's backend is unhealthy, fall back to the other.
-      const storedMode = useChatModeStore.getState().chatMode;
-      const defaultMode =
-        useSettingsStore.getState().formData.default_chat_mode ?? "thinking";
-      const desiredMode = storedMode ?? defaultMode;
+      // Resolve effective chat mode using the same logic as the Composer
+      // toggle so the highlighted mode and the sent payload never diverge.
+      // Read .getState() (not hook subscriptions) to capture values at send
+      // time and avoid stale closures.
       const health = useLlmHealthStore.getState();
-      let effectiveMode: "instant" | "thinking" = desiredMode;
-      if (desiredMode === "instant" && !health.instant && health.thinking) {
-        effectiveMode = "thinking";
-      } else if (desiredMode === "thinking" && !health.thinking && health.instant) {
-        effectiveMode = "instant";
-      }
+      const effectiveMode = computeEffectiveChatMode({
+        stored: useChatModeStore.getState().chatMode,
+        defaultMode: useSettingsStore.getState().formData.default_chat_mode,
+        thinkingHealthy: health.thinking,
+        instantHealthy: health.instant,
+      });
 
       const abort = chatStream(
         chatMessages,

--- a/frontend/src/hooks/useSendMessage.ts
+++ b/frontend/src/hooks/useSendMessage.ts
@@ -8,6 +8,9 @@ import {
   type WikiReference,
 } from "@/lib/api";
 import { useChatStore, type Message } from "@/stores/useChatStore";
+import { useChatModeStore } from "@/stores/useChatModeStore";
+import { useLlmHealthStore } from "@/stores/useLlmHealthStore";
+import { useSettingsStore } from "@/stores/useSettingsStore";
 import type { UsedMemory } from "@/lib/api";
 
 export const MAX_INPUT_LENGTH = 2000;
@@ -104,6 +107,21 @@ export function useSendMessage(
       // Accumulate wiki refs from the SSE stream so they can be persisted with the message.
       let streamedWikiRefs: WikiReference[] = [];
 
+      // Resolve effective chat mode:
+      //   stored override (if any) → settings default → "thinking".
+      // If the selected mode's backend is unhealthy, fall back to the other.
+      const storedMode = useChatModeStore.getState().chatMode;
+      const defaultMode =
+        useSettingsStore.getState().formData.default_chat_mode ?? "thinking";
+      const desiredMode = storedMode ?? defaultMode;
+      const health = useLlmHealthStore.getState();
+      let effectiveMode: "instant" | "thinking" = desiredMode;
+      if (desiredMode === "instant" && !health.instant && health.thinking) {
+        effectiveMode = "thinking";
+      } else if (desiredMode === "thinking" && !health.thinking && health.instant) {
+        effectiveMode = "instant";
+      }
+
       const abort = chatStream(
         chatMessages,
         {
@@ -193,7 +211,8 @@ export function useSendMessage(
             }
           },
         },
-        activeVaultId ?? undefined
+        activeVaultId ?? undefined,
+        effectiveMode,
       );
 
       setAbortFn(abort);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -314,6 +314,15 @@ export interface SettingsResponse {
   embedding_model: string;
   chat_model: string;
 
+  // Instant mode (LM Studio)
+  instant_chat_url?: string;
+  instant_chat_model?: string;
+  default_chat_mode?: 'instant' | 'thinking';
+  instant_initial_retrieval_top_k?: number;
+  instant_reranker_top_n?: number;
+  instant_memory_context_top_k?: number;
+  instant_max_tokens?: number;
+
   // Document processing (character-based)
   chunk_size_chars: number;
   chunk_overlap_chars: number;
@@ -410,6 +419,14 @@ export interface UpdateSettingsRequest {
   ollama_chat_url?: string;
   embedding_model?: string;
   chat_model?: string;
+  // Instant mode (LM Studio)
+  instant_chat_url?: string;
+  instant_chat_model?: string;
+  default_chat_mode?: 'instant' | 'thinking';
+  instant_initial_retrieval_top_k?: number;
+  instant_reranker_top_n?: number;
+  instant_memory_context_top_k?: number;
+  instant_max_tokens?: number;
   // Wiki / Knowledge Compiler config
   wiki_enabled?: boolean;
   wiki_compile_on_ingest?: boolean;
@@ -714,6 +731,16 @@ export interface VaultUpdateRequest {
 
 export async function getHealth(): Promise<HealthResponse> {
   const response = await apiClient.get<HealthResponse>("/health");
+  return response.data;
+}
+
+export interface LlmModeHealth {
+  thinking: boolean;
+  instant: boolean;
+}
+
+export async function getLlmModeHealth(): Promise<LlmModeHealth> {
+  const response = await apiClient.get<LlmModeHealth>("/llm-health/modes");
   return response.data;
 }
 
@@ -1027,9 +1054,17 @@ export async function parseSSEStream(
 export function chatStream(
   messages: ChatMessage[],
   callbacks: ChatStreamCallbacks,
-  vaultId?: number
+  vaultId?: number,
+  mode?: 'instant' | 'thinking',
 ): () => void {
   const abortController = new AbortController();
+  // Build the request body once and reuse for both the initial POST and
+  // the 401 token-refresh retry path. Keeps payload shape consistent.
+  const requestBody = JSON.stringify({
+    messages,
+    ...(vaultId != null && { vault_id: vaultId }),
+    ...(mode != null && { mode }),
+  });
 
   const startStream = async () => {
     try {
@@ -1063,7 +1098,7 @@ export function chatStream(
       const response = await fetch(`${API_BASE_URL}/chat/stream`, {
         method: "POST",
         headers,
-        body: JSON.stringify({ messages, ...(vaultId != null && { vault_id: vaultId }) }),
+        body: requestBody,
         signal: abortController.signal,
       });
 
@@ -1088,7 +1123,7 @@ export function chatStream(
                 const retryResponse = await fetch(`${API_BASE_URL}/chat/stream`, {
                   method: "POST",
                   headers,
-                  body: JSON.stringify({ messages, ...(vaultId != null && { vault_id: vaultId }) }),
+                  body: requestBody,
                   signal: abortController.signal,
                 });
                 if (!retryResponse.ok) {

--- a/frontend/src/lib/chatMode.test.ts
+++ b/frontend/src/lib/chatMode.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { computeEffectiveChatMode } from "./chatMode";
+
+describe("computeEffectiveChatMode", () => {
+  it("returns stored mode when its backend is healthy", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: "instant",
+        defaultMode: "thinking",
+        thinkingHealthy: true,
+        instantHealthy: true,
+      })
+    ).toBe("instant");
+
+    expect(
+      computeEffectiveChatMode({
+        stored: "thinking",
+        defaultMode: "instant",
+        thinkingHealthy: true,
+        instantHealthy: true,
+      })
+    ).toBe("thinking");
+  });
+
+  it("falls back from instant to thinking when instant is unhealthy", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: "instant",
+        defaultMode: "instant",
+        thinkingHealthy: true,
+        instantHealthy: false,
+      })
+    ).toBe("thinking");
+  });
+
+  it("falls back from thinking to instant when thinking is unhealthy", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: "thinking",
+        defaultMode: "thinking",
+        thinkingHealthy: false,
+        instantHealthy: true,
+      })
+    ).toBe("instant");
+  });
+
+  it("returns desired mode when both backends are unhealthy (caller handles failure)", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: "instant",
+        defaultMode: "thinking",
+        thinkingHealthy: false,
+        instantHealthy: false,
+      })
+    ).toBe("instant");
+
+    expect(
+      computeEffectiveChatMode({
+        stored: "thinking",
+        defaultMode: "instant",
+        thinkingHealthy: false,
+        instantHealthy: false,
+      })
+    ).toBe("thinking");
+  });
+
+  it("falls back to default mode when no stored preference exists", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: null,
+        defaultMode: "instant",
+        thinkingHealthy: true,
+        instantHealthy: true,
+      })
+    ).toBe("instant");
+
+    expect(
+      computeEffectiveChatMode({
+        stored: undefined,
+        defaultMode: "thinking",
+        thinkingHealthy: true,
+        instantHealthy: true,
+      })
+    ).toBe("thinking");
+  });
+
+  it("falls back to 'thinking' when neither stored nor default is set", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: null,
+        defaultMode: null,
+        thinkingHealthy: true,
+        instantHealthy: true,
+      })
+    ).toBe("thinking");
+  });
+
+  it("applies health fallback to default mode when stored is unset", () => {
+    expect(
+      computeEffectiveChatMode({
+        stored: null,
+        defaultMode: "instant",
+        thinkingHealthy: true,
+        instantHealthy: false,
+      })
+    ).toBe("thinking");
+  });
+});

--- a/frontend/src/lib/chatMode.ts
+++ b/frontend/src/lib/chatMode.ts
@@ -1,0 +1,28 @@
+export type ChatMode = "instant" | "thinking";
+
+export interface ChatModeInputs {
+  /** Persisted user preference. ``null`` / ``undefined`` means "follow default". */
+  stored: ChatMode | null | undefined;
+  /** Backend-configured default mode. */
+  defaultMode: ChatMode | null | undefined;
+  thinkingHealthy: boolean;
+  instantHealthy: boolean;
+}
+
+/**
+ * Resolve which chat mode will actually run, applying health-based fallback.
+ *
+ * Must be the single source of truth for both the Composer's displayed
+ * highlight and the request payload sent by useSendMessage so the user
+ * never sees one mode while another is silently used.
+ */
+export function computeEffectiveChatMode(inputs: ChatModeInputs): ChatMode {
+  const desired: ChatMode = inputs.stored ?? inputs.defaultMode ?? "thinking";
+  if (desired === "instant" && !inputs.instantHealthy && inputs.thinkingHealthy) {
+    return "thinking";
+  }
+  if (desired === "thinking" && !inputs.thinkingHealthy && inputs.instantHealthy) {
+    return "instant";
+  }
+  return desired;
+}

--- a/frontend/src/stores/useChatModeStore.ts
+++ b/frontend/src/stores/useChatModeStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ChatMode = "instant" | "thinking";
+
+interface ChatModeState {
+  /** User-pinned mode. `null` means "use the settings default". */
+  chatMode: ChatMode | null;
+  setChatMode: (mode: ChatMode) => void;
+  clearChatMode: () => void;
+}
+
+export const useChatModeStore = create<ChatModeState>()(
+  persist(
+    (set) => ({
+      chatMode: null,
+      setChatMode: (chatMode) => set({ chatMode }),
+      clearChatMode: () => set({ chatMode: null }),
+    }),
+    { name: "ragapp_chat_mode" }
+  )
+);

--- a/frontend/src/stores/useLlmHealthStore.ts
+++ b/frontend/src/stores/useLlmHealthStore.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+import { getLlmModeHealth } from "@/lib/api";
+
+interface LlmHealthState {
+  thinking: boolean;
+  instant: boolean;
+  lastCheckedAt: number | null;
+  refreshing: boolean;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Tracks live availability of both LLM backends. The composer reads this to
+ * gate the Instant mode toggle. Fails closed: any error sets both backends to
+ * ``false`` so the UI shows them as unavailable rather than silently routing
+ * to a dead endpoint.
+ */
+export const useLlmHealthStore = create<LlmHealthState>((set, get) => ({
+  thinking: false,
+  instant: false,
+  lastCheckedAt: null,
+  refreshing: false,
+  refresh: async () => {
+    if (get().refreshing) return;
+    set({ refreshing: true });
+    try {
+      const status = await getLlmModeHealth();
+      set({
+        thinking: !!status.thinking,
+        instant: !!status.instant,
+        lastCheckedAt: Date.now(),
+        refreshing: false,
+      });
+    } catch {
+      // Fail closed: mark both backends down so the toggle disables.
+      set({
+        thinking: false,
+        instant: false,
+        lastCheckedAt: Date.now(),
+        refreshing: false,
+      });
+    }
+  },
+}));

--- a/frontend/src/stores/useSettingsStore.ts
+++ b/frontend/src/stores/useSettingsStore.ts
@@ -48,6 +48,14 @@ export interface SettingsFormData {
   ollama_chat_url: string;
   embedding_model: string;
   chat_model: string;
+  // Instant mode (LM Studio on local GPU)
+  instant_chat_url: string;
+  instant_chat_model: string;
+  default_chat_mode: 'instant' | 'thinking';
+  instant_initial_retrieval_top_k: number;
+  instant_reranker_top_n: number;
+  instant_memory_context_top_k: number;
+  instant_max_tokens: number;
   // Wiki & curator (PR B + PR C)
   wiki_enabled: boolean;
   wiki_compile_on_ingest: boolean;
@@ -99,6 +107,13 @@ export const FIELD_TAB: Record<keyof SettingsFormData, SettingsTab> = {
   ollama_chat_url: "models",
   embedding_model: "models",
   chat_model: "models",
+  instant_chat_url: "models",
+  instant_chat_model: "models",
+  default_chat_mode: "models",
+  instant_initial_retrieval_top_k: "retrieval",
+  instant_reranker_top_n: "retrieval",
+  instant_memory_context_top_k: "retrieval",
+  instant_max_tokens: "retrieval",
   wiki_enabled: "wiki",
   wiki_compile_on_ingest: "wiki",
   wiki_compile_on_query: "wiki",
@@ -198,6 +213,13 @@ const defaultFormData: SettingsFormData = {
   ollama_chat_url: "",
   embedding_model: "",
   chat_model: "",
+  instant_chat_url: "",
+  instant_chat_model: "",
+  default_chat_mode: "thinking",
+  instant_initial_retrieval_top_k: 10,
+  instant_reranker_top_n: 4,
+  instant_memory_context_top_k: 2,
+  instant_max_tokens: 4096,
   wiki_enabled: true,
   wiki_compile_on_ingest: true,
   wiki_compile_on_query: true,
@@ -261,6 +283,15 @@ function fromSettings(settings: SettingsResponse): SettingsFormData {
     ollama_chat_url: decodeStr(settings.ollama_chat_url, ""),
     embedding_model: decodeStr(settings.embedding_model, ""),
     chat_model: decodeStr(settings.chat_model, ""),
+    instant_chat_url: decodeStr(settings.instant_chat_url ?? "", ""),
+    instant_chat_model: decodeStr(settings.instant_chat_model ?? "", ""),
+    default_chat_mode:
+      settings.default_chat_mode === "instant" ? "instant" : "thinking",
+    instant_initial_retrieval_top_k:
+      settings.instant_initial_retrieval_top_k ?? 10,
+    instant_reranker_top_n: settings.instant_reranker_top_n ?? 4,
+    instant_memory_context_top_k: settings.instant_memory_context_top_k ?? 2,
+    instant_max_tokens: settings.instant_max_tokens ?? 4096,
     wiki_enabled: settings.wiki_enabled ?? true,
     wiki_compile_on_ingest: settings.wiki_compile_on_ingest ?? true,
     wiki_compile_on_query: settings.wiki_compile_on_query ?? true,


### PR DESCRIPTION
## Summary

Adds a second LLM backend (LM Studio / Nemotron 3 Nano 4B) alongside the existing Thinking backend (gpt-oss-120b on DGX Spark). Users pick per message in the composer; a settings default applies otherwise.

## Backend

- New settings: `instant_chat_url`, `instant_chat_model`, `default_chat_mode`, plus per-mode retrieval overrides (`instant_initial_retrieval_top_k`, `instant_reranker_top_n`, `instant_memory_context_top_k`, `instant_max_tokens`).
- `LLMClient`: optional `base_url` / `model` / `cb_name` args, per-instance `AsyncCircuitBreaker` (failures on Instant cannot trip Thinking), and `reconfigure()` for live URL/model swaps in place — no httpx pool recreation, no stale references.
- `create_thinking_client()` / `create_instant_client()` factories with distinct breaker names (`llm_thinking`, `llm_instant`).
- `ChatMode` enum (`app/models/chat_mode.py`).
- `RAGEngine`: `thinking_client` / `instant_client` kwargs + properties that fall back to `self.llm_client` (back-compat for tests that mutate it post-construction). `query()` takes optional `mode`, resolves effective retrieval budget + active client. **QueryTransformer and ContextDistiller route through the active client** so Instant doesn't pay Thinking latency on rewrites/distillation. `_execute_retrieval` accepts `override_initial_top_k` / `override_reranker_top_n`; LLM helpers accept `(client, max_tokens)`.
- Chat routes: `ChatRequest` / `ChatStreamRequest` take an `Optional[Literal["instant","thinking"]]` `mode` (fails closed at 422 on bad values).
- Settings route: `SettingsUpdate` / `ALLOWED_FIELDS` / `SettingsResponse` / `_build_settings_dict()` all extended in lockstep. PUT/POST handlers **hot-rebind** the live thinking/instant clients via `LLMClient.reconfigure()` so endpoint/model edits apply immediately without a restart.
- Lifespan: starts both clients, runs a keepalive task for **each**, injects both into `LLMHealthChecker`, passes both to `RAGEngine`, closes both on shutdown. `app.state.llm_client` remains an alias of the thinking client for back-compat with `LLMHealthChecker`, `background_processor`, and the keepalive task.
- `LLMHealthChecker.check_chat_modes()` probes each backend independently and fails closed on missing clients.
- Health endpoint adds `GET /llm-health/modes` returning `{thinking, instant}` for the composer's gating poll, and surfaces `llm_modes` in the deep `/health` response (defensive try/except so older mocks that only stub `check_all` keep passing).

## Frontend

- `SettingsResponse` + `UpdateSettingsRequest` + `useSettingsStore` extended with the 7 new instant-mode fields; `FIELD_TAB` updated.
- `ModelConnectionSettings.tsx` adds Instant LLM URL, Instant Chat Model, and a Default Chat Mode radio group.
- `chatStream(messages, callbacks, vaultId?, mode?)` — shared `requestBody` so primary fetch and 401-refresh retry stay consistent.
- New persisted `useChatModeStore` (localStorage, survives reloads).
- New `useLlmHealthStore` polling `/llm-health/modes`; fails closed on error.
- `useSendMessage` resolves effective mode from stored override → settings default, then auto-falls-back to the other backend if the desired one is reported unhealthy.
- `Composer` adds a two-button mode toggle in the toolbar. Each button disables when its backend is unhealthy or while streaming.

## Tests

- `test_chat_mode.py` — enum smoke + settings defaults sanity.
- `test_llm_client_per_instance_breaker.py` — distinct breakers per instance, factory naming, isolation under failure, `reconfigure()`.
- `test_llm_health_dual.py` — `check_chat_modes` returns both keys, fails closed when clients are missing.
- `test_integration.py` `FakeLLMClient` now accepts `**kwargs` so the new `max_tokens` plumbing through `_stream_llm_response` / `_get_llm_response` works in existing fakes.

## Verification

| Check | Result |
|---|---|
| Config defaults import | ✅ `http://host.docker.internal:1234 nvidia/nemotron-3-nano-4b thinking` |
| `ChatMode` enum import | ✅ `[ChatMode.INSTANT, ChatMode.THINKING]` |
| `grep llm_cb backend/app/services/llm_client.py` (must be zero inside class methods) | ✅ Zero matches |
| Frontend `tsc --noEmit` | ✅ Zero errors |
| New tests (10 cases across 3 files) | ✅ All passing |
| Focused regression suite (133 tests: circuit_breaker / llm / rag / integration / chat) | ✅ Zero net-new failures — 19 failures match baseline exactly |

## Test plan

- [ ] Boot stack with LM Studio running on `host.docker.internal:1234` serving Nemotron 3 Nano 4B; confirm `/llm-health/modes` returns `{thinking: true, instant: true}`.
- [ ] Boot stack with LM Studio **stopped**; confirm `/llm-health/modes` returns `instant: false` and the Composer Instant toggle disables with a tooltip.
- [ ] Send a chat with Instant selected — verify `RAGEngine.query mode=instant` in debug logs, smaller retrieval budget honored, response from the 4B model.
- [ ] Send a chat with Thinking selected — verify routing to `ollama_chat_url` with full retrieval budget.
- [ ] Edit `instant_chat_url` or `instant_chat_model` via Settings; verify the very next Instant request hits the new endpoint **without a backend restart**.
- [ ] Refresh the chat page; verify the previously selected mode persists (localStorage).
- [ ] Stop LM Studio mid-session while Instant is selected; verify `useSendMessage` falls back to Thinking automatically.
- [ ] Trip the Instant circuit breaker (e.g., 5 consecutive LM Studio failures); confirm the Thinking breaker remains closed and Thinking requests still succeed.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcNgG5MdbUbq1xY9baywyy)_