### PR TITLE
[codex] fix vault document permissions

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -37,6 +37,11 @@ class UserRole(IntEnum):
             return 0
 
 
+VAULT_PERMISSION_LEVELS = {"read": 1, "write": 2, "admin": 3}
+VAULT_PERMISSION_NAMES = {0: None, 1: "read", 2: "write", 3: "admin"}
+VAULT_ACTION_LEVELS = {"read": 1, "write": 2, "delete": 3, "admin": 3}
+
+
 # Lazy imports — services are only loaded when their getter is actually called.
 # This prevents heavy imports (unstructured, aioimaplib, torch, etc.) from
 # blocking every request handler import chain.
@@ -261,6 +266,48 @@ async def get_current_active_user(
     return user
 
 
+def get_effective_vault_permission(
+    db: sqlite3.Connection,
+    principal: dict,
+    vault_id: int | None,
+) -> str | None:
+    """Return the user's strongest effective permission on a vault."""
+    user_id = principal.get("id")
+    user_role = principal.get("role", "")
+
+    if user_id is None or vault_id is None:
+        return None
+
+    if user_role == "superadmin":
+        return "admin"
+
+    effective_level = VAULT_PERMISSION_LEVELS["write"] if user_role == "admin" else 0
+
+    cursor = db.execute(
+        "SELECT permission FROM vault_members WHERE vault_id = ? AND user_id = ?",
+        (vault_id, user_id),
+    )
+    row = cursor.fetchone()
+    if row:
+        effective_level = max(effective_level, VAULT_PERMISSION_LEVELS.get(row[0], 0))
+
+    cursor = db.execute(
+        """SELECT vga.permission FROM vault_group_access vga
+           JOIN group_members gm ON vga.group_id = gm.group_id
+           WHERE vga.vault_id = ? AND gm.user_id = ?""",
+        (vault_id, user_id),
+    )
+    for row in cursor.fetchall():
+        effective_level = max(effective_level, VAULT_PERMISSION_LEVELS.get(row[0], 0))
+
+    cursor = db.execute("SELECT visibility FROM vaults WHERE id = ?", (vault_id,))
+    row = cursor.fetchone()
+    if row and row[0] == "public":
+        effective_level = max(effective_level, VAULT_PERMISSION_LEVELS["read"])
+
+    return VAULT_PERMISSION_NAMES.get(effective_level)
+
+
 async def _evaluate_policy(
     db: sqlite3.Connection,
     principal: dict,
@@ -288,58 +335,10 @@ async def _evaluate_policy(
     if user_role == "superadmin":
         return True
 
-    if user_role == "admin":
-        if action in ("read", "write"):
-            return True
-        return False
-
-    # Use injected db connection instead of creating new pool
-    cursor = db.execute(
-        "SELECT permission FROM vault_members WHERE vault_id = ? AND user_id = ?",
-        (resource_id, user_id),
-    )
-    row = cursor.fetchone()
-
-    if row:
-        permission_levels = {"read": 1, "write": 2, "admin": 3}
-        action_levels = {"read": 1, "write": 2, "delete": 3, "admin": 3}
-
-        required_level = action_levels.get(action, 1)
-        user_level = permission_levels.get(row[0], 0)
-
-        if user_level >= required_level:
-            return True
-
-    # Check vault_group_access for group-based permissions
-    cursor = db.execute(
-        """SELECT vga.permission FROM vault_group_access vga
-           JOIN group_members gm ON vga.group_id = gm.group_id
-           WHERE vga.vault_id = ? AND gm.user_id = ?""",
-        (resource_id, user_id),
-    )
-    group_permissions = cursor.fetchall()
-
-    if group_permissions:
-        permission_levels = {"read": 1, "write": 2, "admin": 3}
-        action_levels = {"read": 1, "write": 2, "delete": 3, "admin": 3}
-
-        highest_level = max(permission_levels.get(p[0], 0) for p in group_permissions)
-        required_level = action_levels.get(action, 1)
-
-        if highest_level >= required_level:
-            return True
-
-    # Check vault visibility for public read access
-    if action == "read":
-        cursor = db.execute(
-            "SELECT visibility FROM vaults WHERE id = ?", (resource_id,)
-        )
-        row = cursor.fetchone()
-
-        if row and row[0] == "public":
-            return True
-
-    return False
+    effective_permission = get_effective_vault_permission(db, principal, resource_id)
+    effective_level = VAULT_PERMISSION_LEVELS.get(effective_permission or "", 0)
+    required_level = VAULT_ACTION_LEVELS.get(action, VAULT_ACTION_LEVELS["read"])
+    return effective_level >= required_level
 
 
 def get_evaluate_policy(
@@ -459,33 +458,18 @@ def get_user_accessible_vault_ids(user: dict, db) -> list:
     - vault_group_access via group membership
     - For superadmin/admin: returns empty list (means "all vaults")
     """
-    user_id = user["id"]
     user_role = user.get("role", "")
 
     # superadmin/admin can access all vaults
     if user_role in ("superadmin", "admin"):
         return []  # Empty list means "all vaults"
 
-    vault_ids = set()
-
-    # Direct vault_members access
-    cursor = db.execute(
-        "SELECT vault_id FROM vault_members WHERE user_id = ?", (user_id,)
-    )
-    for row in cursor.fetchall():
-        vault_ids.add(row[0])
-
-    # Group-based access
-    cursor = db.execute(
-        """SELECT DISTINCT vga.vault_id FROM vault_group_access vga
-           JOIN group_members gm ON vga.group_id = gm.group_id
-           WHERE gm.user_id = ?""",
-        (user_id,),
-    )
-    for row in cursor.fetchall():
-        vault_ids.add(row[0])
-
-    return list(vault_ids)
+    cursor = db.execute("SELECT id FROM vaults")
+    return [
+        row[0]
+        for row in cursor.fetchall()
+        if get_effective_vault_permission(db, user, row[0]) is not None
+    ]
 
 
 class MultipleOrgError(Exception):

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 import sqlite3
 from collections.abc import Callable
@@ -272,40 +273,69 @@ def get_effective_vault_permission(
     vault_id: int | None,
 ) -> str | None:
     """Return the user's strongest effective permission on a vault."""
+    if vault_id is None:
+        return None
+    return get_effective_vault_permissions(db, principal, [vault_id]).get(vault_id)
+
+
+def get_effective_vault_permissions(
+    db: sqlite3.Connection,
+    principal: dict,
+    vault_ids: list[int],
+) -> dict[int, str | None]:
+    """Return each vault's strongest effective permission for the user."""
     user_id = principal.get("id")
     user_role = principal.get("role", "")
+    normalized_ids = list(dict.fromkeys(vault_ids))
 
-    if user_id is None or vault_id is None:
-        return None
+    if user_id is None or not normalized_ids:
+        return {}
 
     if user_role == "superadmin":
-        return "admin"
+        return {vault_id: "admin" for vault_id in normalized_ids}
 
-    effective_level = VAULT_PERMISSION_LEVELS["write"] if user_role == "admin" else 0
+    baseline_level = VAULT_PERMISSION_LEVELS["write"] if user_role == "admin" else 0
+    effective_levels = {vault_id: baseline_level for vault_id in normalized_ids}
+    placeholders = ",".join("?" for _ in normalized_ids)
 
     cursor = db.execute(
-        "SELECT permission FROM vault_members WHERE vault_id = ? AND user_id = ?",
-        (vault_id, user_id),
+        f"""SELECT vault_id, permission FROM vault_members
+            WHERE user_id = ? AND vault_id IN ({placeholders})""",
+        (user_id, *normalized_ids),
     )
-    row = cursor.fetchone()
-    if row:
-        effective_level = max(effective_level, VAULT_PERMISSION_LEVELS.get(row[0], 0))
+    for vault_id, permission in cursor.fetchall():
+        effective_levels[vault_id] = max(
+            effective_levels[vault_id],
+            VAULT_PERMISSION_LEVELS.get(permission, 0),
+        )
 
     cursor = db.execute(
-        """SELECT vga.permission FROM vault_group_access vga
+        f"""SELECT vga.vault_id, vga.permission FROM vault_group_access vga
            JOIN group_members gm ON vga.group_id = gm.group_id
-           WHERE vga.vault_id = ? AND gm.user_id = ?""",
-        (vault_id, user_id),
+           WHERE gm.user_id = ? AND vga.vault_id IN ({placeholders})""",
+        (user_id, *normalized_ids),
     )
-    for row in cursor.fetchall():
-        effective_level = max(effective_level, VAULT_PERMISSION_LEVELS.get(row[0], 0))
+    for vault_id, permission in cursor.fetchall():
+        effective_levels[vault_id] = max(
+            effective_levels[vault_id],
+            VAULT_PERMISSION_LEVELS.get(permission, 0),
+        )
 
-    cursor = db.execute("SELECT visibility FROM vaults WHERE id = ?", (vault_id,))
-    row = cursor.fetchone()
-    if row and row[0] == "public":
-        effective_level = max(effective_level, VAULT_PERMISSION_LEVELS["read"])
+    cursor = db.execute(
+        f"""SELECT id FROM vaults
+            WHERE visibility = 'public' AND id IN ({placeholders})""",
+        tuple(normalized_ids),
+    )
+    for (vault_id,) in cursor.fetchall():
+        effective_levels[vault_id] = max(
+            effective_levels[vault_id],
+            VAULT_PERMISSION_LEVELS["read"],
+        )
 
-    return VAULT_PERMISSION_NAMES.get(effective_level)
+    return {
+        vault_id: VAULT_PERMISSION_NAMES.get(effective_levels[vault_id])
+        for vault_id in normalized_ids
+    }
 
 
 async def _evaluate_policy(
@@ -335,7 +365,9 @@ async def _evaluate_policy(
     if user_role == "superadmin":
         return True
 
-    effective_permission = get_effective_vault_permission(db, principal, resource_id)
+    effective_permission = await asyncio.to_thread(
+        get_effective_vault_permission, db, principal, resource_id
+    )
     effective_level = VAULT_PERMISSION_LEVELS.get(effective_permission or "", 0)
     required_level = VAULT_ACTION_LEVELS.get(action, VAULT_ACTION_LEVELS["read"])
     return effective_level >= required_level
@@ -465,10 +497,12 @@ def get_user_accessible_vault_ids(user: dict, db) -> list:
         return []  # Empty list means "all vaults"
 
     cursor = db.execute("SELECT id FROM vaults")
+    vault_ids = [row[0] for row in cursor.fetchall()]
+    permissions = get_effective_vault_permissions(db, user, vault_ids)
     return [
-        row[0]
-        for row in cursor.fetchall()
-        if get_effective_vault_permission(db, user, row[0]) is not None
+        vault_id
+        for vault_id, permission in permissions.items()
+        if permission is not None
     ]
 
 

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1012,6 +1012,52 @@ async def scan_directories(
     # Note: No finally block to stop processor - it runs continuously
 
 
+async def _delete_file_record(
+    conn: sqlite3.Connection,
+    vector_store: VectorStore,
+    file_id: int,
+    file_name: str,
+    vault_id: int,
+) -> None:
+    """Delete one file and its derived data with consistent cleanup."""
+    try:
+        try:
+            db = vector_store.db
+            if db is not None and "chunks" in await db.table_names():
+                vector_store.table = await db.open_table("chunks")
+                deleted_chunks = await vector_store.delete_by_file(str(file_id))
+                logger.info(
+                    "Deleted %d chunks from vector store for file_id %s",
+                    deleted_chunks,
+                    file_id,
+                )
+            else:
+                logger.debug(
+                    "Chunks table not found, skipping vector store deletion for file_id %s",
+                    file_id,
+                )
+        except Exception as e:
+            logger.warning("Error deleting chunks from vector store: %s", e)
+
+        try:
+            from app.services.wiki_store import WikiStore as _WikiStore
+
+            await asyncio.to_thread(
+                lambda: _WikiStore(conn).mark_claims_stale_by_file(file_id, vault_id)
+            )
+        except Exception as e:
+            logger.warning("mark_claims_stale_by_file(%d) failed: %s", file_id, e)
+
+        await asyncio.to_thread(
+            conn.execute, "DELETE FROM files WHERE id = ?", (file_id,)
+        )
+        await asyncio.to_thread(conn.commit)
+        logger.info("Deleted document '%s' (id: %d)", file_name, file_id)
+    except Exception:
+        await asyncio.to_thread(conn.rollback)
+        raise
+
+
 @router.delete("/{file_id}", response_model=DeleteResponse)
 async def delete_document(
     file_id: int,
@@ -1048,40 +1094,13 @@ async def delete_document(
         raise HTTPException(status_code=403, detail="Insufficient vault permissions")
 
     try:
-        # Delete from vector store first
-        try:
-            db = vector_store.db
-            if db is not None and "chunks" in await db.table_names():
-                vector_store.table = await db.open_table("chunks")
-                deleted_chunks = await vector_store.delete_by_file(str(file_id))
-                logger.info(
-                    "Deleted %d chunks from vector store for file_id %s",
-                    deleted_chunks,
-                    file_id,
-                )
-            else:
-                logger.debug(
-                    "Chunks table not found, skipping vector store deletion for file_id %s",
-                    file_id,
-                )
-        except Exception as e:
-            logger.warning("Error deleting chunks from vector store: %s", e)
-            # Continue with database deletion even if vector store fails
-
-        # Mark wiki claims stale before removing the file record
-        try:
-            from app.services.wiki_store import WikiStore as _WikiStore
-            await asyncio.to_thread(
-                lambda: _WikiStore(conn).mark_claims_stale_by_file(file_id, file_vault_id)
-            )
-        except Exception as _wiki_exc:
-            logger.warning("mark_claims_stale_by_file(%d) failed: %s", file_id, _wiki_exc)
-
-        # Delete from database
-        await asyncio.to_thread(
-            conn.execute, "DELETE FROM files WHERE id = ?", (file_id,)
+        await _delete_file_record(
+            conn,
+            vector_store,
+            file_id,
+            file_name,
+            file_vault_id,
         )
-        await asyncio.to_thread(conn.commit)
 
         return DeleteResponse(
             file_id=file_id,
@@ -1103,8 +1122,9 @@ async def batch_delete_documents(
         ..., embed=True, description="List of file IDs to delete"
     ),
     conn: sqlite3.Connection = Depends(get_db),
-    user: dict = Depends(require_admin_role),
+    user: dict = Depends(get_current_active_user),
     vector_store: VectorStore = Depends(get_vector_store),
+    evaluate: Callable = Depends(get_evaluate_policy),
 ):
     """
     Batch delete documents by IDs.
@@ -1118,9 +1138,17 @@ async def batch_delete_documents(
 
     for file_id in file_ids:
         try:
+            try:
+                normalized_file_id = int(file_id)
+            except (TypeError, ValueError):
+                failed_ids.append(file_id)
+                continue
+
             # Check if file exists
             cursor = await asyncio.to_thread(
-                conn.execute, "SELECT id, file_name FROM files WHERE id = ?", (file_id,)
+                conn.execute,
+                "SELECT id, file_name, vault_id FROM files WHERE id = ?",
+                (normalized_file_id,),
             )
             row = await asyncio.to_thread(cursor.fetchone)
 
@@ -1129,30 +1157,23 @@ async def batch_delete_documents(
                 continue
 
             file_name = row["file_name"]
+            file_vault_id = row["vault_id"]
 
-            # Delete from vector store first
-            try:
-                db = vector_store.db
-                if db is not None and "chunks" in await db.table_names():
-                    vector_store.table = await db.open_table("chunks")
-                    await vector_store.delete_by_file(str(file_id))
-            except Exception as e:
-                logger.warning(
-                    "Error deleting chunks from vector store for file_id %d: %s",
-                    file_id,
-                    e,
-                )
+            if not await evaluate(user, "vault", file_vault_id, "admin"):
+                failed_ids.append(file_id)
+                continue
 
-            # Delete from database
-            await asyncio.to_thread(
-                conn.execute, "DELETE FROM files WHERE id = ?", (file_id,)
+            await _delete_file_record(
+                conn,
+                vector_store,
+                normalized_file_id,
+                file_name,
+                file_vault_id,
             )
-            await asyncio.to_thread(conn.commit)
             deleted_count += 1
-            logger.info("Deleted document '%s' (id: %d)", file_name, file_id)
 
         except Exception:
-            logger.exception("Error deleting document %d", file_id)
+            logger.exception("Error deleting document %s", file_id)
             failed_ids.append(file_id)
 
     return BatchDeleteResponse(
@@ -1177,33 +1198,23 @@ async def delete_all_vault_documents(
     """
     # Get all file IDs in the vault
     cursor = await asyncio.to_thread(
-        conn.execute, "SELECT id FROM files WHERE vault_id = ?", (vault_id,)
+        conn.execute, "SELECT id, file_name FROM files WHERE vault_id = ?", (vault_id,)
     )
     rows = await asyncio.to_thread(cursor.fetchall)
 
-    file_ids = [row["id"] for row in rows]
     deleted_count = 0
 
-    for file_id in file_ids:
+    for row in rows:
+        file_id = row["id"]
+        file_name = row["file_name"]
         try:
-            # Delete from vector store first
-            try:
-                db = vector_store.db
-                if db is not None and "chunks" in await db.table_names():
-                    vector_store.table = await db.open_table("chunks")
-                    await vector_store.delete_by_file(str(file_id))
-            except Exception as e:
-                logger.warning(
-                    "Error deleting chunks from vector store for file_id %d: %s",
-                    file_id,
-                    e,
-                )
-
-            # Delete from database
-            await asyncio.to_thread(
-                conn.execute, "DELETE FROM files WHERE id = ?", (file_id,)
+            await _delete_file_record(
+                conn,
+                vector_store,
+                file_id,
+                file_name,
+                vault_id,
             )
-            await asyncio.to_thread(conn.commit)
             deleted_count += 1
 
         except Exception:

--- a/backend/app/api/routes/vaults.py
+++ b/backend/app/api/routes/vaults.py
@@ -17,8 +17,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from app.api.deps import (
     get_current_active_user,
     get_db,
+    get_effective_vault_permission,
     get_evaluate_policy,
-    get_user_accessible_vault_ids,
     get_vector_store,
     require_vault_permission,
 )
@@ -77,6 +77,7 @@ class VaultResponse(BaseModel):
     org_id: Optional[int] = None
     is_default: bool = False
     """True when this vault is the system default and cannot be renamed or deleted."""
+    current_user_permission: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -87,7 +88,7 @@ class VaultListResponse(BaseModel):
     vaults: List[VaultResponse]
 
 
-def _row_to_vault_response(row) -> VaultResponse:
+def _row_to_vault_response(row, current_user_permission: Optional[str] = None) -> VaultResponse:
     """Map a database row to VaultResponse."""
     vault_id = row[0]
     return VaultResponse(
@@ -101,6 +102,7 @@ def _row_to_vault_response(row) -> VaultResponse:
         session_count=row[7] or 0,
         org_id=row[8],
         is_default=(vault_id == 1),
+        current_user_permission=current_user_permission,
     )
 
 
@@ -118,7 +120,7 @@ _VAULT_WITH_COUNTS_SQL = """
 
 
 async def _fetch_vault_with_counts(
-    conn: sqlite3.Connection, vault_id: int
+    conn: sqlite3.Connection, vault_id: int, user: Optional[dict] = None
 ) -> Optional[VaultResponse]:
     """Fetch a single vault with file/memory/session counts."""
     cursor = await asyncio.to_thread(
@@ -127,17 +129,28 @@ async def _fetch_vault_with_counts(
         (vault_id,),
     )
     row = await asyncio.to_thread(cursor.fetchone)
-    return _row_to_vault_response(row) if row else None
+    if not row:
+        return None
+    permission = get_effective_vault_permission(conn, user, vault_id) if user else None
+    return _row_to_vault_response(row, permission)
 
 
-async def _fetch_all_vaults(conn: sqlite3.Connection) -> List[VaultResponse]:
+async def _fetch_all_vaults(
+    conn: sqlite3.Connection, user: Optional[dict] = None
+) -> List[VaultResponse]:
     """Fetch all vaults with counts, ordered by creation date."""
     cursor = await asyncio.to_thread(
         conn.execute,
         _VAULT_WITH_COUNTS_SQL + " GROUP BY v.id ORDER BY v.created_at ASC",
     )
     rows = await asyncio.to_thread(cursor.fetchall)
-    return [_row_to_vault_response(row) for row in rows]
+    vaults = []
+    for row in rows:
+        permission = (
+            get_effective_vault_permission(conn, user, row[0]) if user else None
+        )
+        vaults.append(_row_to_vault_response(row, permission))
+    return vaults
 
 
 @router.get("/vaults", response_model=VaultListResponse)
@@ -146,14 +159,8 @@ async def list_vaults(
     conn: sqlite3.Connection = Depends(get_db),
 ):
     """List all vaults with document/memory/session counts."""
-    vaults = await _fetch_all_vaults(conn)
-
-    if user.get("role") not in ("superadmin", "admin"):
-        accessible_ids = get_user_accessible_vault_ids(user, conn)
-        if accessible_ids:
-            vaults = [v for v in vaults if v.id in accessible_ids]
-        else:
-            vaults = []
+    vaults = await _fetch_all_vaults(conn, user)
+    vaults = [v for v in vaults if v.current_user_permission is not None]
 
     return VaultListResponse(vaults=vaults)
 
@@ -164,15 +171,10 @@ async def list_accessible_vaults(
     conn: sqlite3.Connection = Depends(get_db),
 ):
     """Return vaults the current user has access to."""
-    if user.get("role") in ("superadmin", "admin"):
-        return VaultListResponse(vaults=await _fetch_all_vaults(conn))
-
-    accessible_ids = get_user_accessible_vault_ids(user, conn)
-    if not accessible_ids:
-        return VaultListResponse(vaults=[])
-
-    vaults = await _fetch_all_vaults(conn)
-    return VaultListResponse(vaults=[v for v in vaults if v.id in accessible_ids])
+    vaults = await _fetch_all_vaults(conn, user)
+    return VaultListResponse(
+        vaults=[v for v in vaults if v.current_user_permission is not None]
+    )
 
 
 @router.get("/vaults/{vault_id}", response_model=VaultResponse)
@@ -183,7 +185,7 @@ async def get_vault(
     evaluate: Callable = Depends(get_evaluate_policy),
 ):
     """Get a single vault with counts."""
-    vault = await _fetch_vault_with_counts(conn, vault_id)
+    vault = await _fetch_vault_with_counts(conn, vault_id, user)
     if vault is None:
         raise HTTPException(
             status_code=404, detail=f"Vault with id {vault_id} not found"
@@ -286,7 +288,7 @@ async def create_vault(
         )
         raise HTTPException(status_code=500, detail="Failed to assign vault membership")
 
-    vault = await _fetch_vault_with_counts(conn, vault_id)
+    vault = await _fetch_vault_with_counts(conn, vault_id, user)
     return vault
 
 
@@ -335,7 +337,7 @@ async def update_vault(
 
     if not update_fields:
         # No fields to update, just fetch and return current record
-        vault = await _fetch_vault_with_counts(conn, vault_id)
+        vault = await _fetch_vault_with_counts(conn, vault_id, user)
         if vault is None:
             raise HTTPException(
                 status_code=404, detail=f"Vault with id {vault_id} not found"
@@ -373,7 +375,7 @@ async def update_vault(
             logging.getLogger(__name__).warning(f"Failed to rename vault folder: {e}")
 
     # Fetch updated record
-    vault = await _fetch_vault_with_counts(conn, vault_id)
+    vault = await _fetch_vault_with_counts(conn, vault_id, user)
 
     # Race condition fix: check if vault is None after fetch
     if vault is None:

--- a/backend/app/api/routes/vaults.py
+++ b/backend/app/api/routes/vaults.py
@@ -18,6 +18,7 @@ from app.api.deps import (
     get_current_active_user,
     get_db,
     get_effective_vault_permission,
+    get_effective_vault_permissions,
     get_evaluate_policy,
     get_vector_store,
     require_vault_permission,
@@ -131,7 +132,11 @@ async def _fetch_vault_with_counts(
     row = await asyncio.to_thread(cursor.fetchone)
     if not row:
         return None
-    permission = get_effective_vault_permission(conn, user, vault_id) if user else None
+    permission = (
+        await asyncio.to_thread(get_effective_vault_permission, conn, user, vault_id)
+        if user
+        else None
+    )
     return _row_to_vault_response(row, permission)
 
 
@@ -144,12 +149,19 @@ async def _fetch_all_vaults(
         _VAULT_WITH_COUNTS_SQL + " GROUP BY v.id ORDER BY v.created_at ASC",
     )
     rows = await asyncio.to_thread(cursor.fetchall)
+    permissions = (
+        await asyncio.to_thread(
+            get_effective_vault_permissions,
+            conn,
+            user,
+            [row[0] for row in rows],
+        )
+        if user
+        else {}
+    )
     vaults = []
     for row in rows:
-        permission = (
-            get_effective_vault_permission(conn, user, row[0]) if user else None
-        )
-        vaults.append(_row_to_vault_response(row, permission))
+        vaults.append(_row_to_vault_response(row, permissions.get(row[0])))
     return vaults
 
 

--- a/backend/tests/test_deps_auth.py
+++ b/backend/tests/test_deps_auth.py
@@ -895,7 +895,7 @@ class TestEvaluatePolicy:
     """Tests for evaluate_policy RBAC engine."""
 
     def _vault_policy_db(self):
-        conn = sqlite3.connect(":memory:")
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
         conn.execute(
             "CREATE TABLE vaults (id INTEGER PRIMARY KEY, visibility TEXT DEFAULT 'private')"
         )
@@ -925,26 +925,6 @@ class TestEvaluatePolicy:
         assert await evaluate_policy(superadmin, "vault", 1, "write") is True
         assert await evaluate_policy(superadmin, "vault", 1, "delete") is True
         assert await evaluate_policy(superadmin, "vault", 1, "admin") is True
-
-    @pytest.mark.asyncio
-    async def _legacy_evaluate_policy_admin_read_write(self):
-        """Admin user → True for read/write, False for delete/admin."""
-        from app.api.deps import evaluate_policy
-
-        admin = {"id": 2, "role": "admin"}
-
-        mock = MagicMock()
-        mock.sqlite_path = "./test.db"
-        pool = MagicMock()
-        pool.get_connection.return_value.__enter__ = MagicMock(return_value=MagicMock())
-        pool.get_connection.return_value.__exit__ = MagicMock(return_value=False)
-
-        with patch("app.api.deps.settings", mock, create=True):
-            with patch("app.api.deps.get_pool", return_value=pool):
-                assert await evaluate_policy(admin, "vault", 1, "read") is True
-                assert await evaluate_policy(admin, "vault", 1, "write") is True
-                assert await evaluate_policy(admin, "vault", 1, "delete") is False
-                assert await evaluate_policy(admin, "vault", 1, "admin") is False
 
     @pytest.mark.asyncio
     async def test_evaluate_policy_admin_read_write(self):
@@ -1002,6 +982,42 @@ class TestEvaluatePolicy:
         assert get_effective_vault_permission(conn, public_only, 3) == "read"
         assert await _evaluate_policy(conn, public_only, "vault", 3, "read") is True
         assert await _evaluate_policy(conn, public_only, "vault", 3, "write") is False
+
+    def test_get_effective_vault_permissions_batches_permission_queries(self):
+        """Multiple vault permissions are resolved with constant-query batching."""
+        from app.api.deps import get_effective_vault_permissions
+
+        member = {"id": 4, "role": "member"}
+        conn = self._vault_policy_db()
+        conn.execute(
+            "INSERT INTO vault_members (vault_id, user_id, permission) VALUES (?, ?, ?)",
+            (1, 4, "read"),
+        )
+        conn.execute(
+            "INSERT INTO group_members (group_id, user_id) VALUES (?, ?)",
+            (10, 4),
+        )
+        conn.execute(
+            "INSERT INTO vault_group_access (vault_id, group_id, permission) VALUES (?, ?, ?)",
+            (2, 10, "admin"),
+        )
+        conn.commit()
+
+        statements = []
+        conn.set_trace_callback(statements.append)
+
+        assert get_effective_vault_permissions(conn, member, [1, 2, 3]) == {
+            1: "read",
+            2: "admin",
+            3: "read",
+        }
+
+        select_count = sum(
+            1
+            for statement in statements
+            if statement.lstrip().upper().startswith("SELECT")
+        )
+        assert select_count == 3
 
     def test_get_user_accessible_vault_ids_includes_public_read(self):
         """Accessible vault enumeration includes effective public read access."""

--- a/backend/tests/test_deps_auth.py
+++ b/backend/tests/test_deps_auth.py
@@ -10,6 +10,7 @@ Tests cover:
 - get_user_accessible_vault_ids: vault access enumeration for regular users
 """
 
+import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -893,6 +894,25 @@ class TestGetCurrentUserJWT:
 class TestEvaluatePolicy:
     """Tests for evaluate_policy RBAC engine."""
 
+    def _vault_policy_db(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE vaults (id INTEGER PRIMARY KEY, visibility TEXT DEFAULT 'private')"
+        )
+        conn.execute(
+            "CREATE TABLE vault_members (vault_id INTEGER, user_id INTEGER, permission TEXT)"
+        )
+        conn.execute("CREATE TABLE group_members (group_id INTEGER, user_id INTEGER)")
+        conn.execute(
+            "CREATE TABLE vault_group_access (vault_id INTEGER, group_id INTEGER, permission TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO vaults (id, visibility) VALUES (?, ?)",
+            [(1, "private"), (2, "private"), (3, "public")],
+        )
+        conn.commit()
+        return conn
+
     @pytest.mark.asyncio
     async def test_evaluate_policy_superadmin_grants_all(self):
         """Superadmin user → True for all actions."""
@@ -907,7 +927,7 @@ class TestEvaluatePolicy:
         assert await evaluate_policy(superadmin, "vault", 1, "admin") is True
 
     @pytest.mark.asyncio
-    async def test_evaluate_policy_admin_read_write(self):
+    async def _legacy_evaluate_policy_admin_read_write(self):
         """Admin user → True for read/write, False for delete/admin."""
         from app.api.deps import evaluate_policy
 
@@ -925,6 +945,72 @@ class TestEvaluatePolicy:
                 assert await evaluate_policy(admin, "vault", 1, "write") is True
                 assert await evaluate_policy(admin, "vault", 1, "delete") is False
                 assert await evaluate_policy(admin, "vault", 1, "admin") is False
+
+    @pytest.mark.asyncio
+    async def test_evaluate_policy_admin_read_write(self):
+        """Admin fallback allows read/write but not delete/admin by itself."""
+        from app.api.deps import _evaluate_policy
+
+        admin = {"id": 2, "role": "admin"}
+        conn = self._vault_policy_db()
+
+        assert await _evaluate_policy(conn, admin, "vault", 1, "read") is True
+        assert await _evaluate_policy(conn, admin, "vault", 1, "write") is True
+        assert await _evaluate_policy(conn, admin, "vault", 1, "delete") is False
+        assert await _evaluate_policy(conn, admin, "vault", 1, "admin") is False
+
+    @pytest.mark.asyncio
+    async def test_evaluate_policy_admin_explicit_vault_admin(self):
+        """Admin with explicit vault admin can perform admin/delete on that vault."""
+        from app.api.deps import _evaluate_policy, get_effective_vault_permission
+
+        admin = {"id": 2, "role": "admin"}
+        conn = self._vault_policy_db()
+        conn.execute(
+            "INSERT INTO vault_members (vault_id, user_id, permission) VALUES (?, ?, ?)",
+            (1, 2, "admin"),
+        )
+
+        assert get_effective_vault_permission(conn, admin, 1) == "admin"
+        assert await _evaluate_policy(conn, admin, "vault", 1, "admin") is True
+        assert await _evaluate_policy(conn, admin, "vault", 1, "delete") is True
+
+    @pytest.mark.asyncio
+    async def test_evaluate_policy_maxes_direct_group_and_public_permissions(self):
+        """Lower direct grants do not hide group admin or public read."""
+        from app.api.deps import _evaluate_policy, get_effective_vault_permission
+
+        member = {"id": 4, "role": "member"}
+        conn = self._vault_policy_db()
+        conn.execute(
+            "INSERT INTO vault_members (vault_id, user_id, permission) VALUES (?, ?, ?)",
+            (1, 4, "read"),
+        )
+        conn.execute(
+            "INSERT INTO group_members (group_id, user_id) VALUES (?, ?)",
+            (10, 4),
+        )
+        conn.execute(
+            "INSERT INTO vault_group_access (vault_id, group_id, permission) VALUES (?, ?, ?)",
+            (1, 10, "admin"),
+        )
+
+        assert get_effective_vault_permission(conn, member, 1) == "admin"
+        assert await _evaluate_policy(conn, member, "vault", 1, "delete") is True
+
+        public_only = {"id": 5, "role": "member"}
+        assert get_effective_vault_permission(conn, public_only, 3) == "read"
+        assert await _evaluate_policy(conn, public_only, "vault", 3, "read") is True
+        assert await _evaluate_policy(conn, public_only, "vault", 3, "write") is False
+
+    def test_get_user_accessible_vault_ids_includes_public_read(self):
+        """Accessible vault enumeration includes effective public read access."""
+        from app.api.deps import get_user_accessible_vault_ids
+
+        conn = self._vault_policy_db()
+        user = {"id": 5, "role": "member"}
+
+        assert get_user_accessible_vault_ids(user, conn) == [3]
 
     @pytest.mark.asyncio
     async def test_evaluate_policy_invalid_principal(self):

--- a/backend/tests/test_vault_document_permissions_regression.py
+++ b/backend/tests/test_vault_document_permissions_regression.py
@@ -1,0 +1,226 @@
+"""Regression tests for vault-scoped document permission behavior."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import tempfile
+import threading
+from pathlib import Path
+from queue import Empty, Queue
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_current_active_user, get_db, get_vector_store
+from app.main import app
+from app.models.database import init_db, run_migrations
+
+
+class SimpleConnectionPool:
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._pool = Queue(maxsize=5)
+        self._closed = False
+        self._lock = threading.Lock()
+
+    def get_connection(self):
+        if self._closed:
+            raise RuntimeError("Pool closed")
+        try:
+            return self._pool.get_nowait()
+        except Empty:
+            return self._create_connection()
+
+    def _create_connection(self):
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def release_connection(self, conn):
+        if self._closed:
+            conn.close()
+            return
+        try:
+            self._pool.put_nowait(conn)
+        except Exception:
+            conn.close()
+
+    def close_all(self):
+        self._closed = True
+        while True:
+            try:
+                self._pool.get_nowait().close()
+            except Empty:
+                break
+
+
+@pytest.fixture()
+def permission_client():
+    temp_dir = tempfile.mkdtemp()
+    db_path = str(Path(temp_dir) / "app.db")
+    init_db(db_path)
+    run_migrations(db_path)
+    pool = SimpleConnectionPool(db_path)
+
+    vector_store = MagicMock()
+    vector_store.db = MagicMock()
+    vector_store.db.table_names = AsyncMock(return_value=["chunks"])
+    vector_store.db.open_table = AsyncMock(return_value=MagicMock())
+    vector_store.delete_by_file = AsyncMock(return_value=1)
+
+    def override_get_db():
+        conn = pool.get_connection()
+        try:
+            yield conn
+        finally:
+            pool.release_connection(conn)
+
+    current_user = {"id": 2, "username": "admin", "role": "admin", "is_active": True}
+
+    async def override_user():
+        return current_user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_active_user] = override_user
+    app.dependency_overrides[get_vector_store] = lambda: vector_store
+
+    conn = pool.get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO users (id, username, hashed_password, role) VALUES (?, ?, ?, ?)",
+            (2, "admin", "fake", "admin"),
+        )
+        conn.execute(
+            "INSERT INTO users (id, username, hashed_password, role) VALUES (?, ?, ?, ?)",
+            (3, "member", "fake", "member"),
+        )
+        conn.execute(
+            "INSERT INTO vaults (id, name, description, visibility) VALUES (?, ?, ?, ?)",
+            (2, "Admin Vault", "", "private"),
+        )
+        conn.execute(
+            "INSERT INTO vaults (id, name, description, visibility) VALUES (?, ?, ?, ?)",
+            (3, "Other Vault", "", "private"),
+        )
+        conn.execute(
+            "INSERT INTO vaults (id, name, description, visibility) VALUES (?, ?, ?, ?)",
+            (4, "Public Vault", "", "public"),
+        )
+        conn.execute(
+            "INSERT INTO vault_members (vault_id, user_id, permission) VALUES (?, ?, ?)",
+            (2, 2, "admin"),
+        )
+        conn.execute(
+            "INSERT INTO vault_members (vault_id, user_id, permission) VALUES (?, ?, ?)",
+            (1, 3, "write"),
+        )
+        conn.execute(
+            "INSERT INTO files (id, file_name, file_path, file_size, status, vault_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (1, "allowed.txt", "/tmp/allowed.txt", 1, "indexed", 2),
+        )
+        conn.execute(
+            "INSERT INTO files (id, file_name, file_path, file_size, status, vault_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (2, "blocked.txt", "/tmp/blocked.txt", 1, "indexed", 3),
+        )
+        conn.execute(
+            "INSERT INTO files (id, file_name, file_path, file_size, status, vault_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (3, "default.txt", "/tmp/default.txt", 1, "indexed", 1),
+        )
+        conn.commit()
+    finally:
+        pool.release_connection(conn)
+
+    client = TestClient(app)
+    yield client, pool, vector_store, current_user
+
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_active_user, None)
+    app.dependency_overrides.pop(get_vector_store, None)
+    pool.close_all()
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _file_exists(pool: SimpleConnectionPool, file_id: int) -> bool:
+    conn = pool.get_connection()
+    try:
+        row = conn.execute("SELECT id FROM files WHERE id = ?", (file_id,)).fetchone()
+        return row is not None
+    finally:
+        pool.release_connection(conn)
+
+
+def test_app_admin_with_vault_admin_can_delete_single_document(permission_client):
+    client, pool, vector_store, _ = permission_client
+
+    with patch("app.services.wiki_store.WikiStore.mark_claims_stale_by_file") as stale:
+        response = client.delete("/api/documents/1")
+
+    assert response.status_code == 200
+    assert not _file_exists(pool, 1)
+    vector_store.delete_by_file.assert_awaited_once_with("1")
+    stale.assert_called_once_with(1, 2)
+
+
+def test_app_admin_without_vault_admin_cannot_delete_single_document(permission_client):
+    client, pool, vector_store, _ = permission_client
+
+    response = client.delete("/api/documents/2")
+
+    assert response.status_code == 403
+    assert _file_exists(pool, 2)
+    vector_store.delete_by_file.assert_not_awaited()
+
+
+def test_batch_delete_is_per_file_vault_admin_scoped(permission_client):
+    client, pool, vector_store, _ = permission_client
+
+    with patch("app.services.wiki_store.WikiStore.mark_claims_stale_by_file") as stale:
+        response = client.post(
+            "/api/documents/batch",
+            json={"file_ids": ["1", "2", "not-an-id"]},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"deleted_count": 1, "failed_ids": ["2", "not-an-id"]}
+    assert not _file_exists(pool, 1)
+    assert _file_exists(pool, 2)
+    vector_store.delete_by_file.assert_awaited_once_with("1")
+    stale.assert_called_once_with(1, 2)
+
+
+def test_write_only_default_vault_user_cannot_delete(permission_client):
+    client, pool, vector_store, current_user = permission_client
+    current_user.update({"id": 3, "username": "member", "role": "member"})
+
+    response = client.delete("/api/documents/3")
+
+    assert response.status_code == 403
+    assert _file_exists(pool, 3)
+    vector_store.delete_by_file.assert_not_awaited()
+
+
+def test_vault_list_includes_effective_permission_and_public_read(permission_client):
+    client, _, _, current_user = permission_client
+    current_user.update({"id": 3, "username": "member", "role": "member"})
+
+    response = client.get("/api/vaults")
+
+    assert response.status_code == 200
+    vaults = {vault["id"]: vault for vault in response.json()["vaults"]}
+    assert vaults[1]["current_user_permission"] == "write"
+    assert vaults[4]["current_user_permission"] == "read"
+    assert 2 not in vaults
+    assert 3 not in vaults
+
+
+def test_vault_create_response_returns_creator_admin_permission(permission_client):
+    client, _, _, current_user = permission_client
+    current_user.update({"id": 3, "username": "member", "role": "member"})
+
+    response = client.post("/api/vaults", json={"name": "Created By Member"})
+
+    assert response.status_code == 201
+    assert response.json()["current_user_permission"] == "admin"

--- a/frontend/src/components/shared/DocumentCard.tsx
+++ b/frontend/src/components/shared/DocumentCard.tsx
@@ -27,6 +27,8 @@ interface DocumentCardProps {
   onDelete: (id: string) => void;
   /** Loading state for delete action */
   isDeleting?: boolean;
+  /** Whether delete actions should be available for this document */
+  canDelete?: boolean;
   /** Selection state for bulk operations */
   isSelected?: boolean;
   /** Callback when selection changes */
@@ -46,6 +48,7 @@ export function DocumentCard({
   document,
   onDelete,
   isDeleting = false,
+  canDelete = true,
   isSelected = false,
   onSelectionChange,
 }: DocumentCardProps) {
@@ -93,31 +96,32 @@ export function DocumentCard({
           </div>
 
           {/* Actions dropdown (≥44×44px touch target) */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-11 w-11 flex-shrink-0"
-                aria-label={`Actions for ${document.filename}`}
-                aria-haspopup="menu"
-              >
-                <MoreVertical className="w-5 h-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem
-                onClick={() => onDelete(document.id)}
-                disabled={isDeleting}
-                className="text-destructive focus:text-destructive"
-                aria-label={`Delete ${document.filename}`}
-              >
-                <Trash2 className="w-4 h-4 mr-2" />
-                Delete
-              </DropdownMenuItem>
-
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {canDelete && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-11 w-11 flex-shrink-0"
+                  aria-label={`Actions for ${document.filename}`}
+                  aria-haspopup="menu"
+                >
+                  <MoreVertical className="w-5 h-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem
+                  onClick={() => onDelete(document.id)}
+                  disabled={isDeleting}
+                  className="text-destructive focus:text-destructive"
+                  aria-label={`Delete ${document.filename}`}
+                >
+                  <Trash2 className="w-4 h-4 mr-2" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
 
         {/* Metadata row: status, size, date, chunks */}
@@ -149,20 +153,22 @@ export function DocumentCard({
         </div>
 
         {/* Standalone delete button (visible on larger mobile screens) */}
-        <div className="mt-4 flex sm:hidden">
-          <Button
-            variant="destructive"
-            size="sm"
-            className="h-11 w-full"
-            onClick={() => onDelete(document.id)}
-            disabled={isDeleting}
-            aria-label={`Delete ${document.filename}`}
-            aria-busy={isDeleting}
-          >
-            <Trash2 className="w-4 h-4 mr-2" />
+        {canDelete && (
+          <div className="mt-4 flex sm:hidden">
+            <Button
+              variant="destructive"
+              size="sm"
+              className="h-11 w-full"
+              onClick={() => onDelete(document.id)}
+              disabled={isDeleting}
+              aria-label={`Delete ${document.filename}`}
+              aria-busy={isDeleting}
+            >
+              <Trash2 className="w-4 h-4 mr-2" />
             {isDeleting ? "Deleting…" : "Delete Document"}
-          </Button>
-        </div>
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -712,6 +712,7 @@ export interface Vault {
   org_id: number | null;
   /** Backend-provided flag: true when vault cannot be renamed or deleted. */
   is_default?: boolean;
+  current_user_permission?: "read" | "write" | "admin" | null;
 }
 
 export interface VaultListResponse {

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -129,6 +129,7 @@ vi.mock('@/lib/formatters', () => ({
 
 // Import component after mocks
 import DocumentsPage from '@/pages/DocumentsPage';
+import { useVaultStore } from '@/stores/useVaultStore';
 
 describe('DocumentsPage - Drag to Resize Filename Column', () => {
   let container: HTMLElement;
@@ -136,6 +137,10 @@ describe('DocumentsPage - Drag to Resize Filename Column', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useVaultStore).mockReturnValue({
+      activeVaultId: null,
+      vaults: [],
+    } as ReturnType<typeof useVaultStore>);
     document.body.style.cursor = '';
   });
 
@@ -172,6 +177,52 @@ describe('DocumentsPage - Drag to Resize Filename Column', () => {
       const headers = Array.from(container.querySelectorAll('th[scope="col"]'));
       const filenameTh = headers.find(th => th.textContent?.includes('Filename'));
       expect(filenameTh).toBeTruthy();
+    });
+  });
+
+  describe('Vault permission gating', () => {
+    it('hides destructive document actions without an active vault', async () => {
+      vi.mocked(useVaultStore).mockReturnValue({
+        activeVaultId: null,
+        vaults: [],
+      } as ReturnType<typeof useVaultStore>);
+
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(findResizeHandle()).toBeTruthy();
+      });
+
+      expect(container.textContent).not.toContain('Delete All in Vault');
+      expect(
+        container.querySelector('input[aria-label="Select all documents"]')
+      ).toBeDisabled();
+    });
+
+    it('enables destructive document actions for vault admins', async () => {
+      vi.mocked(useVaultStore).mockReturnValue({
+        activeVaultId: 2,
+        vaults: [{ id: 2, name: 'Admin Vault', current_user_permission: 'admin' }],
+      } as ReturnType<typeof useVaultStore>);
+
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(findResizeHandle()).toBeTruthy();
+      });
+
+      expect(container.textContent).toContain('Delete All in Vault');
+      expect(
+        container.querySelector('input[aria-label="Select all documents"]')
+      ).not.toBeDisabled();
     });
   });
 

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -100,7 +100,20 @@ export default function DocumentsPage() {
 
   // Global upload store
   const { uploads, addUploads, cancelUpload, removeUpload, clearCompleted, retryUpload } = useUploadStore();
-  const { activeVaultId } = useVaultStore();
+  const { vaults, activeVaultId } = useVaultStore();
+  const activeVault = vaults.find((vault) => vault.id === activeVaultId);
+  const activeVaultPermission = activeVault?.current_user_permission ?? null;
+  const canWriteActiveVault =
+    activeVaultPermission === "write" || activeVaultPermission === "admin";
+  const canAdminActiveVault = activeVaultPermission === "admin";
+  const hasSelectedVault = activeVaultId != null && activeVault != null;
+  const canMutateDocuments = hasSelectedVault && canAdminActiveVault;
+
+  useEffect(() => {
+    if (!canMutateDocuments) {
+      setSelectedIds(new Set());
+    }
+  }, [canMutateDocuments]);
 
   const fetchDocuments = useCallback(async (search?: string) => {
     try {
@@ -241,15 +254,17 @@ export default function DocumentsPage() {
 
   // Bulk selection handlers
   const handleSelectAll = useCallback((checked: boolean | 'indeterminate') => {
+    if (!canMutateDocuments) return;
     if (checked) {
       const allIds = new Set(documents?.map((doc) => String(doc.id)) ?? []);
       setSelectedIds(allIds);
     } else {
       setSelectedIds(new Set());
     }
-  }, [documents]);
+  }, [canMutateDocuments, documents]);
 
   const handleSelectOne = useCallback((docId: string, checked: boolean) => {
+    if (!canMutateDocuments) return;
     setSelectedIds(prev => {
       const newSet = new Set(prev);
       if (checked) {
@@ -259,9 +274,13 @@ export default function DocumentsPage() {
       }
       return newSet;
     });
-  }, []);
+  }, [canMutateDocuments]);
 
   const executeBulkDelete = useCallback(async () => {
+    if (!canMutateDocuments) {
+      toast.error("Select a vault you administer before deleting documents");
+      return;
+    }
     setIsBulkDeleting(true);
     try {
       const result = await deleteDocuments(Array.from(selectedIds));
@@ -279,7 +298,7 @@ export default function DocumentsPage() {
     } finally {
       setIsBulkDeleting(false);
     }
-  }, [selectedIds]);
+  }, [canMutateDocuments, selectedIds]);
 
   const handleBulkDelete = useCallback(() => {
     if (selectedIds.size === 0) return;
@@ -293,7 +312,7 @@ export default function DocumentsPage() {
   }, [selectedIds, executeBulkDelete]);
 
   const executeDeleteAllInVault = useCallback(async () => {
-    if (!activeVaultId) return;
+    if (!activeVaultId || !canMutateDocuments) return;
     setIsBulkDeletingAll(true);
     try {
       const result = await deleteAllDocumentsInVault(activeVaultId);
@@ -307,12 +326,12 @@ export default function DocumentsPage() {
     } finally {
       setIsBulkDeletingAll(false);
     }
-  }, [activeVaultId]);
+  }, [activeVaultId, canMutateDocuments]);
 
   const handleDeleteAllInVault = useCallback(() => {
     if (!documents || documents.length === 0) return;
-    if (!activeVaultId) {
-      toast.error("No vault selected");
+    if (!canMutateDocuments) {
+      toast.error("Select a vault you administer before deleting documents");
       return;
     }
     setConfirmDialog({
@@ -323,15 +342,19 @@ export default function DocumentsPage() {
       variant: "destructive",
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [documents.length, activeVaultId, executeDeleteAllInVault]);
+  }, [documents.length, canMutateDocuments, executeDeleteAllInVault]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     if (acceptedFiles.length === 0) return;
+    if (!hasSelectedVault || !canWriteActiveVault) {
+      toast.error("Select a vault with write access before uploading");
+      return;
+    }
     
     addUploads(acceptedFiles, activeVaultId ?? undefined);
     setRejectedFiles([]);
     toast.success(`Added ${acceptedFiles.length} file(s) to upload queue`);
-  }, [addUploads, activeVaultId]);
+  }, [addUploads, activeVaultId, canWriteActiveVault, hasSelectedVault]);
 
   const onDropRejected = useCallback((rejected: FileRejection[]) => {
     const rejectedNames = rejected.map((r) => `${r.file.name} (${r.errors.map((e) => e.message).join(', ')})`);
@@ -345,9 +368,14 @@ export default function DocumentsPage() {
     onDrop,
     onDropRejected,
     maxSize: MAX_FILE_SIZE,
+    disabled: !hasSelectedVault || !canWriteActiveVault,
   });
 
   const handleScan = async () => {
+    if (!hasSelectedVault || !canWriteActiveVault) {
+      toast.error("Select a vault with write access before scanning");
+      return;
+    }
     setIsScanning(true);
     try {
       const result = await scanDocuments(activeVaultId ?? undefined);
@@ -361,6 +389,10 @@ export default function DocumentsPage() {
   };
 
   const handleDeleteDocument = (docId: string) => {
+    if (!canMutateDocuments) {
+      toast.error("Select a vault you administer before deleting documents");
+      return;
+    }
     setConfirmDialog({
       open: true,
       title: "Delete Document",
@@ -458,7 +490,17 @@ export default function DocumentsPage() {
         </div>
         <div className="flex items-center gap-2">
           <VaultSelector />
-          <Button onClick={handleScan} disabled={isScanning}>
+          <Button
+            onClick={handleScan}
+            disabled={isScanning || !hasSelectedVault || !canWriteActiveVault}
+            title={
+              !hasSelectedVault
+                ? "Select a vault to scan documents"
+                : !canWriteActiveVault
+                  ? "Write access is required to scan this vault"
+                  : "Scan directory"
+            }
+          >
             {isScanning ? (
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />
             ) : (
@@ -466,7 +508,7 @@ export default function DocumentsPage() {
             )}
             Scan Directory
           </Button>
-          {filteredDocuments.length > 0 && (
+          {filteredDocuments.length > 0 && canMutateDocuments && (
             <Button 
               variant="destructive" 
               onClick={handleDeleteAllInVault} 
@@ -516,7 +558,7 @@ export default function DocumentsPage() {
         {...getRootProps()}
         className={`border-2 border-dashed cursor-pointer transition-colors ${
           isDragActive ? "border-primary bg-primary/5" : "border-border"
-        }`}
+        } ${!hasSelectedVault || !canWriteActiveVault ? "opacity-60 cursor-not-allowed" : ""}`}
       >
         <input {...getInputProps()} />
         <CardContent className="py-8">
@@ -527,7 +569,9 @@ export default function DocumentsPage() {
             </Badge>
             <Upload className="w-12 h-12 text-muted-foreground mb-4" />
             <p className="text-lg font-medium">
-              {isDragActive ? "Drop files here..." : "Drag & drop files here, or click to select"}
+              {!hasSelectedVault || !canWriteActiveVault
+                ? "Select a writable vault to upload"
+                : isDragActive ? "Drop files here..." : "Drag & drop files here, or click to select"}
             </p>
             <p className="text-sm text-muted-foreground mt-1">
               Supports PDF, DOCX, TXT, MD files (max 50MB each). Uploads continue in background.
@@ -811,7 +855,7 @@ export default function DocumentsPage() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          {selectedIds.size > 0 && (
+          {selectedIds.size > 0 && canMutateDocuments && (
             <>
               <Badge variant="outline">{selectedIds.size} selected</Badge>
               <Button 
@@ -940,6 +984,7 @@ export default function DocumentsPage() {
                         <Checkbox
                           checked={selectedIds.size > 0 && selectedIds.size === filteredDocuments.length}
                           onCheckedChange={handleSelectAll}
+                          disabled={!canMutateDocuments}
                           aria-label="Select all documents"
                         />
                       </th>
@@ -989,6 +1034,7 @@ export default function DocumentsPage() {
                             <Checkbox
                               checked={isSelected}
                               onCheckedChange={(checked) => handleSelectOne(String(doc.id), !!checked)}
+                              disabled={!canMutateDocuments}
                               aria-label={`Select ${doc.filename}`}
                             />
                           </td>
@@ -1063,6 +1109,7 @@ export default function DocumentsPage() {
                           <td className="p-4 flex-none w-[100px]">{formatFileSize(doc.size)}</td>
                           <td className="p-4 flex-none w-[140px] text-muted-foreground">{formatDate(doc.created_at)}</td>
                           <td className="p-4 flex-none w-[60px] text-right">
+                            {canMutateDocuments && (
                             <Button
                               variant="ghost"
                               size="icon"
@@ -1072,6 +1119,7 @@ export default function DocumentsPage() {
                             >
                               <Trash2 className="w-4 h-4 text-destructive" aria-hidden="true" />
                             </Button>
+                            )}
                           </td>
                         </tr>
                       );
@@ -1104,8 +1152,9 @@ export default function DocumentsPage() {
                      <DocumentCard
                        document={doc}
                        onDelete={(id) => handleDeleteDocument(String(id))}
+                       canDelete={canMutateDocuments}
                        isSelected={selectedIds.has(doc.id)}
-                       onSelectionChange={handleSelectOne}
+                       onSelectionChange={canMutateDocuments ? handleSelectOne : undefined}
                      />
                    </div>
                  );

--- a/frontend/src/pages/DocumentsPage.virtualization.test.tsx
+++ b/frontend/src/pages/DocumentsPage.virtualization.test.tsx
@@ -80,8 +80,8 @@ vi.mock("@/hooks/useDebounce", () => ({
 // Mock useVaultStore
 vi.mock("@/stores/useVaultStore", () => ({
   useVaultStore: vi.fn(() => ({
-    activeVaultId: null,
-    vaults: [],
+    activeVaultId: 1,
+    vaults: [{ id: 1, current_user_permission: "admin" }],
   })),
 }));
 

--- a/frontend/src/pages/VaultsPage.test.tsx
+++ b/frontend/src/pages/VaultsPage.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+vi.mock("@/lib/api", () => ({
+  listOrganizations: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/stores/useVaultStore", () => ({
+  useVaultStore: vi.fn(() => ({
+    vaults: [
+      {
+        id: 1,
+        name: "Default",
+        description: "",
+        file_count: 0,
+        memory_count: 0,
+        session_count: 0,
+        is_default: true,
+        current_user_permission: "admin",
+      },
+      {
+        id: 2,
+        name: "Admin Vault",
+        description: "",
+        file_count: 0,
+        memory_count: 0,
+        session_count: 0,
+        current_user_permission: "admin",
+      },
+      {
+        id: 3,
+        name: "Write Vault",
+        description: "",
+        file_count: 0,
+        memory_count: 0,
+        session_count: 0,
+        current_user_permission: "write",
+      },
+    ],
+    loading: false,
+    fetchVaults: vi.fn(),
+    addVault: vi.fn(),
+    editVault: vi.fn(),
+    removeVault: vi.fn(),
+    activeVaultId: 2,
+    setActiveVault: vi.fn(),
+  })),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    disabled,
+    title,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    title?: string;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} title={title} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => <div />,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h3>{children}</h3>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}));
+
+vi.mock("lucide-react", () => ({
+  Brain: () => <span />,
+  Database: () => <span />,
+  FileText: () => <span />,
+  Loader2: () => <span />,
+  MessageSquare: () => <span />,
+  Pencil: () => <span>Edit icon</span>,
+  Plus: () => <span />,
+  Shield: () => <span />,
+  Trash2: () => <span>Delete icon</span>,
+}));
+
+import VaultsPage from "@/pages/VaultsPage";
+
+describe("VaultsPage permission gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses each vault permission and default status for edit/delete controls", async () => {
+    render(<VaultsPage />);
+
+    expect(await screen.findByText("Admin Vault")).toBeInTheDocument();
+
+    expect(screen.getByTitle("Edit vault")).not.toBeDisabled();
+    expect(screen.getByTitle("Delete vault")).not.toBeDisabled();
+
+    for (const button of screen.getAllByTitle("Default vault cannot be modified")) {
+      expect(button).toBeDisabled();
+    }
+    for (const button of screen.getAllByTitle("Vault admin permission is required")) {
+      expect(button).toBeDisabled();
+    }
+  });
+});

--- a/frontend/src/pages/VaultsPage.tsx
+++ b/frontend/src/pages/VaultsPage.tsx
@@ -151,6 +151,7 @@ export default function VaultsPage() {
   }
 
   const isDefaultVault = (vault: Vault) => vault.is_default === true;
+  const canAdminVault = (vault: Vault) => vault.current_user_permission === "admin";
 
   return (
     <div className="space-y-6">
@@ -174,7 +175,13 @@ export default function VaultsPage() {
         </div>
       )}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {vaults.map(vault => (
+        {vaults.map(vault => {
+          const canEditVault = canAdminVault(vault) && !isDefaultVault(vault);
+          const unavailableReason = isDefaultVault(vault)
+            ? "Default vault cannot be modified"
+            : "Vault admin permission is required";
+
+          return (
           <Card key={vault.id}>
             <CardHeader>
               <div className="flex items-start justify-between">
@@ -232,8 +239,8 @@ export default function VaultsPage() {
                     variant="ghost"
                     size="sm"
                     onClick={() => openEditDialog(vault)}
-                    disabled={isDefaultVault(vault)}
-                    title={isDefaultVault(vault) ? "Default vault cannot be modified" : "Edit vault"}
+                    disabled={!canEditVault}
+                    title={canEditVault ? "Edit vault" : unavailableReason}
                   >
                     <Pencil className="h-4 w-4" />
                   </Button>
@@ -241,8 +248,8 @@ export default function VaultsPage() {
                     variant="ghost"
                     size="sm"
                     onClick={() => openDeleteDialog(vault)}
-                    disabled={isDefaultVault(vault)}
-                    title={isDefaultVault(vault) ? "Default vault cannot be deleted" : "Delete vault"}
+                    disabled={!canEditVault}
+                    title={canEditVault ? "Delete vault" : unavailableReason}
                     className="text-destructive hover:text-destructive"
                   >
                     <Trash2 className="h-4 w-4" />
@@ -251,7 +258,8 @@ export default function VaultsPage() {
               </div>
             </CardContent>
           </Card>
-        ))}
+          );
+        })}
       </div>
 
       {/* Create Dialog */}


### PR DESCRIPTION
## Summary

This PR fixes vault/document permission behavior end to end after the reported document management issue. It centralizes effective vault permission calculation, returns the current user's effective permission on vault API responses, makes document deletion consistently vault-admin scoped, and gates destructive UI controls before users hit backend 403s.

## What changed

- Added effective vault permission calculation across superadmin, direct vault membership, group vault access, public-read visibility, and app-admin fallback.
- Preserved app-admin read/write fallback while requiring explicit or group vault admin permission for admin/delete actions.
- Added `current_user_permission` to vault response paths and filtered vault list endpoints to read-accessible vaults.
- Batched multi-vault permission computation so vault list/accessibility paths avoid per-vault permission query loops.
- Reused one per-file delete helper for single delete, batch delete, and delete-all cleanup, including vector cleanup, wiki stale marking, DB deletion, logging, commit, and rollback behavior.
- Changed batch delete from global-admin-only to per-file vault-admin authorization while preserving the existing response shape.
- Gated DocumentsPage upload/scan/delete actions by the selected vault permission and blocked destructive actions in all-vault/no-active-vault mode.
- Gated VaultsPage edit/delete controls by each rendered vault's own permission while keeping default vault modification blocked.

## Review follow-up

- Fixed the N+1 permission lookup called out in review by adding a batched permission helper and using it from `_fetch_all_vaults` and `get_user_accessible_vault_ids`.
- Wrapped route permission computation in `asyncio.to_thread` where it is called from async vault fetch helpers.
- Updated `DocumentsPage.virtualization.test.tsx` with an admin active vault mock so checkbox selection tests exercise the new gating correctly.
- Removed the dead `_legacy_evaluate_policy_admin_read_write` test.

## Validation

- `python -m pytest tests\test_deps_auth.py::TestEvaluatePolicy::test_evaluate_policy_admin_read_write tests\test_deps_auth.py::TestEvaluatePolicy::test_evaluate_policy_admin_explicit_vault_admin tests\test_deps_auth.py::TestEvaluatePolicy::test_evaluate_policy_maxes_direct_group_and_public_permissions tests\test_deps_auth.py::TestEvaluatePolicy::test_get_effective_vault_permissions_batches_permission_queries tests\test_deps_auth.py::TestEvaluatePolicy::test_get_user_accessible_vault_ids_includes_public_read tests\test_vault_document_permissions_regression.py -q`
- `python -m ruff check app\api\deps.py app\api\routes\vaults.py tests\test_deps_auth.py`
- `python -m ruff check app\api\deps.py app\api\routes\vaults.py app\api\routes\documents.py tests\test_deps_auth.py tests\test_vault_document_permissions_regression.py`
- `npm test -- --run src\pages\DocumentsPage.virtualization.test.tsx src\pages\DocumentsPage.test.tsx src\pages\VaultsPage.test.tsx`
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `git diff --check`

## Notes

The frontend test suite still emits existing uncontrolled-input warnings from the test Checkbox mocks, but the targeted tests pass.