### PR TITLE
[codex] fix feedback policy and logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,8 +474,11 @@ curl http://localhost:9090/api/health?deep=true | jq .vector_store
 | GET | `/api/chat/sessions/{id}` | Get session with messages |
 | POST | `/api/chat/sessions` | Create new session |
 | POST | `/api/chat/sessions/{id}/messages` | Add message to session |
+| PATCH | `/api/chat/sessions/{id}/messages/{message_id}/feedback` | Set or clear message feedback (`"up"`, `"down"`, or `null`) |
 | PUT | `/api/chat/sessions/{id}` | Update session title |
 | DELETE | `/api/chat/sessions/{id}` | Delete session (CASCADE deletes messages) |
+
+Feedback is stored as the current user's signal on owned chat sessions. Non-admin users need vault write access and may only change feedback for sessions they own; admins and superadmins may moderate feedback on any session they can write. Legacy ownerless sessions keep the vault-write policy.
 
 ### Documents
 

--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -725,9 +725,9 @@ async def create_session(
     if not await evaluate_policy(user, "vault", request.vault_id, "write"):
         raise HTTPException(status_code=403, detail="No write access to this vault")
 
-    query = "INSERT INTO chat_sessions (vault_id, title, created_at, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+    query = "INSERT INTO chat_sessions (vault_id, user_id, title, created_at, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     cursor = await asyncio.to_thread(
-        conn.execute, query, (request.vault_id, request.title)
+        conn.execute, query, (request.vault_id, user["id"], request.title)
     )
     await asyncio.to_thread(conn.commit)
 
@@ -819,8 +819,8 @@ async def fork_session(
     fork_title = f"Branch of {session_row[2] or 'conversation'}"
     cursor = await asyncio.to_thread(
         conn.execute,
-        "INSERT INTO chat_sessions (vault_id, title, forked_from_session_id, fork_message_index, created_at, updated_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-        (vault_id, fork_title, session_id, request.message_index),
+        "INSERT INTO chat_sessions (vault_id, user_id, title, forked_from_session_id, fork_message_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        (vault_id, user["id"], fork_title, session_id, request.message_index),
     )
     await asyncio.to_thread(conn.commit)
     new_session_id = cursor.lastrowid
@@ -1218,10 +1218,12 @@ async def set_message_feedback(
             detail="rating must be 'up', 'down', or null",
         )
 
-    # Verify session exists and get vault_id for authorization
+    # Verify session exists and get vault_id/owner for authorization.
+    # Feedback is treated as a per-user signal on owned sessions; admin roles can
+    # moderate any session, while legacy ownerless sessions keep vault-write access.
     session_result = await asyncio.to_thread(
         conn.execute,
-        "SELECT id, vault_id FROM chat_sessions WHERE id = ?",
+        "SELECT id, vault_id, user_id FROM chat_sessions WHERE id = ?",
         (session_id,),
     )
     session_row = await asyncio.to_thread(session_result.fetchone)
@@ -1230,6 +1232,14 @@ async def set_message_feedback(
 
     if not await evaluate_policy(user, "vault", session_row[1], "write"):
         raise HTTPException(status_code=403, detail="No write access to this vault")
+
+    session_owner_id = session_row[2]
+    if (
+        session_owner_id is not None
+        and session_owner_id != user["id"]
+        and user.get("role") not in ("superadmin", "admin")
+    ):
+        raise HTTPException(status_code=403, detail="Cannot update feedback for another user's session")
 
     # Verify message belongs to session
     check_result = await asyncio.to_thread(

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -508,6 +508,7 @@ def init_db(sqlite_path: str) -> None:
         conn.execute("PRAGMA journal_mode=WAL;")
         conn.execute("PRAGMA busy_timeout=30000;")
         conn.execute("PRAGMA foreign_keys = ON;")
+        migrate_add_user_id_to_chat_sessions(sqlite_path, conn=conn)
         conn.executescript(SCHEMA)
         # Ensure default vault exists
         conn.execute(
@@ -582,6 +583,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_vault_permission_columns(sqlite_path)
     migrate_vault_paths(sqlite_path)
     migrate_add_org_slug_column(sqlite_path)
+    migrate_add_user_id_to_chat_sessions(sqlite_path)
     migrate_add_fork_columns(sqlite_path)
     migrate_add_feedback_column(sqlite_path)
     migrate_add_chat_memories_column(sqlite_path)
@@ -906,6 +908,36 @@ def migrate_vault_paths(sqlite_path: str) -> None:
                 # Continue with other vaults, don't raise
     finally:
         conn.close()
+
+
+def migrate_add_user_id_to_chat_sessions(
+    sqlite_path: str,
+    conn: sqlite3.Connection | None = None,
+) -> None:
+    """Migration: Add owner user_id to chat_sessions for per-user policy checks."""
+    owns_connection = conn is None
+    conn = conn or sqlite3.connect(sqlite_path)
+    try:
+        table_cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='chat_sessions'"
+        )
+        if table_cursor.fetchone() is None:
+            return
+
+        columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(chat_sessions)").fetchall()
+        }
+        if "user_id" not in columns:
+            conn.execute("ALTER TABLE chat_sessions ADD COLUMN user_id INTEGER")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_chat_sessions_user_id "
+            "ON chat_sessions(user_id)"
+        )
+        conn.commit()
+    finally:
+        if owns_connection:
+            conn.close()
 
 
 def migrate_add_fork_columns(sqlite_path: str) -> None:

--- a/backend/tests/test_chat_auth.py
+++ b/backend/tests/test_chat_auth.py
@@ -72,7 +72,7 @@ from fastapi.testclient import TestClient
 from app.api.deps import get_db, get_rag_engine, get_vector_store
 from app.config import settings
 from app.main import app
-from app.services.auth_service import create_access_token, hash_password
+from app.services.auth_service import create_access_token
 
 
 class SimpleConnectionPool:
@@ -183,7 +183,9 @@ class TestChatAuthBase(unittest.TestCase):
             conn.execute("DELETE FROM chat_sessions")
             conn.execute("DELETE FROM users WHERE id != 0")  # Keep admin user if exists
 
-            pw = hash_password("testpass")
+            # These tests authenticate with generated JWTs, so the password hash
+            # only needs to satisfy the users table shape.
+            pw = "unused-test-password-hash"
 
             # User 1: superadmin
             conn.execute(
@@ -324,6 +326,13 @@ class TestChatAuthentication(TestChatAuthBase):
         response = self.client.delete("/api/chat/sessions/1")
         self.assertEqual(response.status_code, 401)
 
+    def test_patch_message_feedback_unauthenticated(self):
+        """PATCH message feedback without auth returns 401."""
+        response = self.client.patch(
+            "/api/chat/sessions/1/messages/1/feedback", json={"rating": "up"}
+        )
+        self.assertEqual(response.status_code, 401)
+
 
 class TestChatAuthorization(TestChatAuthBase):
     """Tests for chat endpoint authorization."""
@@ -350,6 +359,139 @@ class TestChatAuthorization(TestChatAuthBase):
         )
         # Should succeed since we mocked rag_engine
         self.assertEqual(response.status_code, 200)
+
+
+class TestMessageFeedbackRoute(TestChatAuthBase):
+    """Tests for message feedback persistence, validation, and ownership policy."""
+
+    def _seed_feedback_message(self, vault_id=3, owner_id=3, role="assistant"):
+        conn = self._get_db_conn()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO chat_sessions (vault_id, user_id, title, created_at, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                (vault_id, owner_id, "Feedback Session"),
+            )
+            session_id = cursor.lastrowid
+            cursor = conn.execute(
+                "INSERT INTO chat_messages (session_id, role, content, sources, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                (session_id, role, "Feedback target", "[]"),
+            )
+            message_id = cursor.lastrowid
+            conn.commit()
+            return session_id, message_id
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def _grant_member2_write_to_vault3(self):
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+                (3, 4, "write", 1),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def test_set_update_and_clear_feedback(self):
+        """Owner with vault write can set, change, and clear feedback."""
+        session_id, message_id = self._seed_feedback_message()
+
+        for rating in ("up", "down", None):
+            response = self.client.patch(
+                f"/api/chat/sessions/{session_id}/messages/{message_id}/feedback",
+                json={"rating": rating},
+                headers=self._auth_headers(self._member_token()),
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["feedback"], rating)
+
+    def test_invalid_rating_returns_422(self):
+        """Only up, down, and null are accepted as feedback ratings."""
+        session_id, message_id = self._seed_feedback_message()
+
+        response = self.client.patch(
+            f"/api/chat/sessions/{session_id}/messages/{message_id}/feedback",
+            json={"rating": "sideways"},
+            headers=self._auth_headers(self._member_token()),
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertIn("rating must be", response.json()["detail"])
+
+    def test_user_without_vault_write_gets_403(self):
+        """Feedback mutation requires vault write access before ownership checks."""
+        session_id, message_id = self._seed_feedback_message()
+
+        response = self.client.patch(
+            f"/api/chat/sessions/{session_id}/messages/{message_id}/feedback",
+            json={"rating": "up"},
+            headers=self._auth_headers(self._member_no_access_token()),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("No write access", response.json()["detail"])
+
+    def test_non_owner_with_vault_write_cannot_update_feedback(self):
+        """Non-admin users cannot overwrite another user's owned feedback signal."""
+        self._grant_member2_write_to_vault3()
+        session_id, message_id = self._seed_feedback_message(owner_id=3)
+
+        response = self.client.patch(
+            f"/api/chat/sessions/{session_id}/messages/{message_id}/feedback",
+            json={"rating": "down"},
+            headers=self._auth_headers(self._member_no_access_token()),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("another user's session", response.json()["detail"])
+
+    def test_legacy_ownerless_session_allows_any_vault_writer(self):
+        """Legacy sessions with NULL owner keep the vault-write feedback policy."""
+        self._grant_member2_write_to_vault3()
+        session_id, message_id = self._seed_feedback_message(owner_id=None)
+
+        response = self.client.patch(
+            f"/api/chat/sessions/{session_id}/messages/{message_id}/feedback",
+            json={"rating": "up"},
+            headers=self._auth_headers(self._member_no_access_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["feedback"], "up")
+
+    def test_admin_can_update_owned_session_feedback(self):
+        """Admins can moderate feedback across owned sessions."""
+        session_id, message_id = self._seed_feedback_message(owner_id=3)
+
+        response = self.client.patch(
+            f"/api/chat/sessions/{session_id}/messages/{message_id}/feedback",
+            json={"rating": "down"},
+            headers=self._auth_headers(self._admin_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["feedback"], "down")
+
+    def test_missing_session_or_message_returns_404(self):
+        """Missing sessions and messages return distinct 404 responses."""
+        session_id, message_id = self._seed_feedback_message()
+
+        missing_session = self.client.patch(
+            f"/api/chat/sessions/99999/messages/{message_id}/feedback",
+            json={"rating": "up"},
+            headers=self._auth_headers(self._member_token()),
+        )
+        self.assertEqual(missing_session.status_code, 404)
+        self.assertIn("Session not found", missing_session.json()["detail"])
+
+        missing_message = self.client.patch(
+            f"/api/chat/sessions/{session_id}/messages/99999/feedback",
+            json={"rating": "up"},
+            headers=self._auth_headers(self._member_token()),
+        )
+        self.assertEqual(missing_message.status_code, 404)
+        self.assertIn("Message not found", missing_message.json()["detail"])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_schema_unification.py
+++ b/backend/tests/test_schema_unification.py
@@ -209,6 +209,47 @@ class TestDatabaseCreation:
         finally:
             conn.close()
 
+    def test_run_migrations_adds_user_id_to_legacy_chat_sessions(self, tmp_path):
+        """Older databases missing chat_sessions.user_id must migrate before schema indexes run."""
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("""
+                CREATE TABLE chat_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vault_id INTEGER NOT NULL DEFAULT 1,
+                    title TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.execute(
+                "INSERT INTO chat_sessions (vault_id, title) VALUES (?, ?)",
+                (1, "legacy"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        run_migrations(str(db_path))
+
+        conn = sqlite3.connect(db_path)
+        try:
+            cursor = conn.execute("PRAGMA table_info(chat_sessions)")
+            columns = {row[1] for row in cursor.fetchall()}
+            assert "user_id" in columns
+
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            )
+            indexes = {row[0] for row in cursor.fetchall()}
+            assert "idx_chat_sessions_user_id" in indexes
+
+            cursor = conn.execute("SELECT user_id FROM chat_sessions WHERE title = ?", ("legacy",))
+            assert cursor.fetchone()[0] is None
+        finally:
+            conn.close()
+
     def test_init_db_creates_users_table_with_security_columns(self):
         """Fresh database users table must have security columns."""
         conn = sqlite3.connect(":memory:")

--- a/frontend/src/components/chat/MessageActions.test.tsx
+++ b/frontend/src/components/chat/MessageActions.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { updateMessageFeedback } from "@/lib/api";
+import { AssistantMessageActions } from "./MessageActions";
+
+vi.mock("@/lib/api", () => ({
+  updateMessageFeedback: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+describe("AssistantMessageActions feedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(localStorage.getItem).mockReturnValue(null);
+    vi.mocked(updateMessageFeedback).mockResolvedValue({} as Awaited<ReturnType<typeof updateMessageFeedback>>);
+  });
+
+  it("sends the selected feedback rating to the API", () => {
+    render(<AssistantMessageActions content="Answer" sessionId="7" messageId="42" />);
+
+    fireEvent.click(screen.getByLabelText("Good response"));
+
+    expect(updateMessageFeedback).toHaveBeenCalledWith(7, 42, "up");
+  });
+
+  it("cycles feedback between up, down, and cleared", () => {
+    render(<AssistantMessageActions content="Answer" sessionId="7" messageId="42" />);
+
+    const good = screen.getByLabelText("Good response");
+    const bad = screen.getByLabelText("Bad response");
+
+    fireEvent.click(good);
+    expect(good).toHaveAttribute("aria-pressed", "true");
+    expect(updateMessageFeedback).toHaveBeenLastCalledWith(7, 42, "up");
+
+    fireEvent.click(bad);
+    expect(bad).toHaveAttribute("aria-pressed", "true");
+    expect(updateMessageFeedback).toHaveBeenLastCalledWith(7, 42, "down");
+
+    fireEvent.click(bad);
+    expect(bad).toHaveAttribute("aria-pressed", "false");
+    expect(updateMessageFeedback).toHaveBeenLastCalledWith(7, 42, null);
+  });
+
+  it("rolls back to resolved external feedback when save fails", async () => {
+    vi.mocked(updateMessageFeedback).mockRejectedValueOnce(new Error("offline"));
+    const onFeedback = vi.fn();
+
+    render(
+      <AssistantMessageActions
+        content="Answer"
+        sessionId="7"
+        messageId="42"
+        externalFeedback="up"
+        onFeedback={onFeedback}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Bad response"));
+
+    expect(onFeedback).toHaveBeenCalledWith("down");
+    await waitFor(() => expect(onFeedback).toHaveBeenLastCalledWith("up"));
+    expect(localStorage.setItem).toHaveBeenLastCalledWith("chat_feedback_42", "up");
+    expect(toast.error).toHaveBeenCalledWith("Couldn't save feedback");
+  });
+
+  it("uses localStorage only when the server has no feedback value", () => {
+    vi.mocked(localStorage.getItem).mockReturnValue("up");
+
+    const { rerender } = render(
+      <AssistantMessageActions content="Answer" sessionId="7" messageId="42" />
+    );
+
+    expect(screen.getByLabelText("Good response")).toHaveAttribute("aria-pressed", "true");
+
+    rerender(
+      <AssistantMessageActions content="Answer" sessionId="7" messageId="42" serverFeedback={null} />
+    );
+
+    expect(screen.getByLabelText("Good response")).toHaveAttribute("aria-pressed", "false");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("chat_feedback_42");
+  });
+});

--- a/frontend/src/components/chat/MessageActions.tsx
+++ b/frontend/src/components/chat/MessageActions.tsx
@@ -106,14 +106,23 @@ function FeedbackActions({
   const [internalFeedback, setInternalFeedback] = useState<"up" | "down" | null>(null);
 
   useEffect(() => {
-    if (serverFeedback != null) {
+    if (serverFeedback !== undefined) {
       setInternalFeedback(serverFeedback);
+      if (serverFeedback === null && messageId) {
+        try {
+          localStorage.removeItem(`chat_feedback_${messageId}`);
+        } catch { /* ignore */ }
+      }
       return;
     }
-    if (!messageId) return;
+    if (!messageId) {
+      setInternalFeedback(null);
+      return;
+    }
     try {
       const stored = localStorage.getItem(`chat_feedback_${messageId}`);
       if (stored === "up" || stored === "down") setInternalFeedback(stored);
+      else setInternalFeedback(null);
     } catch { /* ignore */ }
   }, [messageId, serverFeedback]);
 
@@ -121,7 +130,7 @@ function FeedbackActions({
 
   const handleFeedback = useCallback(
     (type: "up" | "down") => {
-      const prev = internalFeedback;
+      const prev = current;
       const next: "up" | "down" | null = current === type ? null : type;
 
       if (externalFeedback === undefined) setInternalFeedback(next);
@@ -152,7 +161,7 @@ function FeedbackActions({
         });
       }
     },
-    [current, internalFeedback, externalFeedback, messageId, sessionId, onFeedback]
+    [current, externalFeedback, messageId, sessionId, onFeedback]
   );
 
   return (

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -406,7 +406,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
         sources: m.sources ?? undefined,
         memoriesUsed: m.memories ?? undefined,
         created_at: m.created_at,
-        feedback: m.feedback ?? undefined,
+        feedback: m.feedback ?? null,
       }));
       loadChat(String(forked.id), forkMessages);
       await refreshHistory();

--- a/frontend/src/components/layout/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { MobileBottomNav } from "./MobileBottomNav";
+
+const mockLogout = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/useAuthStore", () => ({
+  useAuthStore: vi.fn((selector: (s: { user: { role: string } | null; logout: () => Promise<void> }) => unknown) =>
+    selector({ user: { role: "admin" }, logout: mockLogout })
+  ),
+}));
+
+describe("MobileBottomNav", () => {
+  beforeEach(() => {
+    mockLogout.mockResolvedValue(undefined);
+    mockLogout.mockClear();
+  });
+
+  it("exposes logout in the more sheet", async () => {
+    render(
+      <MemoryRouter>
+        <MobileBottomNav activeItem="chat" onItemSelect={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByLabelText("More navigation options"));
+    fireEvent.click(screen.getByLabelText("Log out"));
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { MessageSquare, FileText, Brain, MoreHorizontal, Database, Settings, Users, X, User, Building2, UserCog, BookOpen } from "lucide-react";
+import { MessageSquare, FileText, Brain, MoreHorizontal, Database, Settings, Users, X, User, Building2, UserCog, BookOpen, LogOut } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { useNavigate } from "react-router-dom";
 import type { NavItemId } from "./navigationTypes";
 
 interface MobileBottomNavProps {
@@ -37,8 +38,16 @@ const moreNavItems: { id: NavItemId; label: string; icon: React.ComponentType<{ 
 
 export function MobileBottomNav({ activeItem, onItemSelect }: MobileBottomNavProps) {
   const [moreOpen, setMoreOpen] = useState(false);
+  const navigate = useNavigate();
   const userRole = useAuthStore((state) => state.user?.role);
+  const logout = useAuthStore((state) => state.logout);
   const isAdmin = userRole === "admin" || userRole === "superadmin";
+
+  const handleLogout = async () => {
+    setMoreOpen(false);
+    await logout();
+    navigate("/login", { replace: true });
+  };
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-card border-t border-border z-50 md:hidden" aria-label="Mobile navigation">
@@ -158,6 +167,18 @@ export function MobileBottomNav({ activeItem, onItemSelect }: MobileBottomNavPro
                   </button>
                 );
               })}
+              <button
+                type="button"
+                onClick={handleLogout}
+                className={cn(
+                  "flex flex-col items-center gap-3 p-4 rounded-xl border border-border transition-all duration-200",
+                  "hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                )}
+                aria-label="Log out"
+              >
+                <LogOut className="w-6 h-6 text-muted-foreground" />
+                <span className="text-sm font-medium text-foreground">Log out</span>
+              </button>
             </div>
           </SheetContent>
         </Sheet>

--- a/frontend/src/components/layout/NavigationRail.test.tsx
+++ b/frontend/src/components/layout/NavigationRail.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, BrowserRouter } from "react-router-dom";
 import { NavigationRail } from "./NavigationRail";
 import type { NavItemId } from "./navigationTypes";
+
+const mockLogout = vi.hoisted(() => vi.fn());
 
 // Mock useThemeStore before importing NavigationRail (NavigationRail imports useThemeStore)
 vi.mock("@/stores/useThemeStore", () => ({
@@ -15,8 +17,8 @@ vi.mock("@/stores/useThemeStore", () => ({
 
 // Mock useAuthStore — default to admin so all nav items are visible
 vi.mock("@/stores/useAuthStore", () => ({
-  useAuthStore: vi.fn((selector: (s: { user: { role: string } | null }) => unknown) =>
-    selector({ user: { role: "admin" } })
+  useAuthStore: vi.fn((selector: (s: { user: { role: string } | null; logout: () => Promise<void> }) => unknown) =>
+    selector({ user: { role: "admin" }, logout: mockLogout })
   ),
 }));
 
@@ -29,6 +31,11 @@ const mockHealthStatus = {
 };
 
 describe("NavigationRail", () => {
+  beforeEach(() => {
+    mockLogout.mockResolvedValue(undefined);
+    mockLogout.mockClear();
+  });
+
   describe("Navigation Items", () => {
     it("renders all navigation items", () => {
       render(
@@ -120,6 +127,20 @@ describe("NavigationRail", () => {
 
       const usersButton = screen.getByLabelText("Users");
       expect(usersButton).toHaveAttribute("href", "/admin/users");
+    });
+
+    it("logs out from the rail action", async () => {
+      render(
+        <MemoryRouter>
+          <NavigationRail
+            healthStatus={mockHealthStatus}
+          />
+        </MemoryRouter>
+      );
+
+      fireEvent.click(screen.getByLabelText("Log out"));
+
+      await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/frontend/src/components/layout/NavigationRail.tsx
+++ b/frontend/src/components/layout/NavigationRail.tsx
@@ -1,8 +1,8 @@
-import { MessageSquare, FileText, Brain, Settings, Database, Users, UserCog, Building2, UserCircle, Sun, Moon, BookOpen } from "lucide-react";
+import { MessageSquare, FileText, Brain, Settings, Database, Users, UserCog, Building2, UserCircle, Sun, Moon, BookOpen, LogOut } from "lucide-react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { cn } from "@/lib/utils";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import type { NavItemId, NavigationProps } from "./navigationTypes";
 
 // Re-export types for backward compatibility
@@ -52,9 +52,11 @@ interface NavigationRailProps {
 
 export function NavigationRail({ healthStatus }: NavigationRailProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const pathname = location.pathname;
   const { theme, setTheme } = useThemeStore();
   const userRole = useAuthStore((state) => state.user?.role);
+  const logout = useAuthStore((state) => state.logout);
   const isAdmin = userRole === "admin" || userRole === "superadmin";
 
   // Determine active item based on current pathname
@@ -75,6 +77,10 @@ export function NavigationRail({ healthStatus }: NavigationRailProps) {
   };
 
   const activeItem = getActiveItem();
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login", { replace: true });
+  };
 
   return (
     <nav className="w-20 min-h-screen bg-card border-r border-border flex flex-col items-center py-6 gap-2" aria-label="Main navigation">
@@ -134,6 +140,16 @@ export function NavigationRail({ healthStatus }: NavigationRailProps) {
 
       {/* Bottom Spacer */}
       <div className="mt-auto" />
+
+      {/* Logout */}
+      <button
+        type="button"
+        onClick={handleLogout}
+        className="p-2 rounded-lg hover:bg-secondary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Log out"
+      >
+        <LogOut className="w-4 h-4 text-muted-foreground" />
+      </button>
 
       {/* Theme Toggle (H-30) */}
       <button

--- a/frontend/src/hooks/useChatHistory.ts
+++ b/frontend/src/hooks/useChatHistory.ts
@@ -65,7 +65,7 @@ export function useChatHistory(activeVaultId: number | null): UseChatHistoryRetu
         sources: m.sources ?? undefined,
         memoriesUsed: m.memories ?? undefined,
         created_at: m.created_at,
-        feedback: m.feedback ?? undefined,
+        feedback: m.feedback ?? null,
       }));
       useChatStore.getState().loadChat(session.id.toString(), loadedMessages);
     } catch (err) {

--- a/frontend/src/pages/ChatShell.tsx
+++ b/frontend/src/pages/ChatShell.tsx
@@ -159,7 +159,7 @@ export default function ChatShell() {
           memoriesUsed: m.memories ?? undefined,
           wikiRefs: m.wiki_refs ?? undefined,
           created_at: m.created_at,
-          feedback: m.feedback ?? undefined,
+          feedback: m.feedback ?? null,
         }));
         useChatStore.getState().loadChat(sessionId, loadedMessages);
       } catch (err) {

--- a/frontend/src/stores/useAuthStore.ts
+++ b/frontend/src/stores/useAuthStore.ts
@@ -240,6 +240,7 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: false,
           });
           setJwtAccessToken(null);
+          resetCsrfToken();
           get()._setLoading(false);
           // Reset init guard so re-login works after logout
           _initAttempted = false;


### PR DESCRIPTION
## Summary
- fix feedback optimistic rollback so failed saves restore the resolved current rating
- make backend feedback policy explicit: non-admin users can update feedback only on owned sessions, while admins can moderate and legacy ownerless sessions keep vault-write behavior
- add desktop and mobile logout actions that use the existing auth store cleanup
- add backend route coverage plus frontend feedback and logout action tests

## Root Cause
Issue #49 came from rollback capturing internal feedback state even when the displayed value came from parent-provided external feedback. Issue #50 was unresolved because the backend only used vault write access and never considered `chat_sessions.user_id`. Issue #51 tracked the missing backend and frontend coverage around those paths.

## Validation
- `python -m pytest backend\tests\test_chat_auth.py`
- `python -m ruff check app\api\routes\chat.py tests\test_chat_auth.py`
- `npm test -- MessageActions.test.tsx NavigationRail.test.tsx MobileBottomNav.test.tsx`
- `npm run typecheck`
- `npm run lint`

Closes #49
Closes #50
Closes #51