### PR TITLE
fix(wiki): materialize page on ingest + SSE completion events

### DIFF
--- a/backend/app/api/routes/wiki.py
+++ b/backend/app/api/routes/wiki.py
@@ -4,6 +4,7 @@ Wiki / Knowledge Compiler API routes.
 All endpoints are vault-scoped. Access follows vault access permissions.
 """
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -11,10 +12,12 @@ from dataclasses import asdict
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from app.api.deps import evaluate_policy, get_current_active_user, get_db
 from app.services.wiki_compiler import WikiCompiler
+from app.services.wiki_events import get_wiki_event_bus
 from app.services.wiki_linter import WikiLinter
 from app.services.wiki_store import WikiStore
 
@@ -466,6 +469,46 @@ async def list_wiki_jobs(
     store = WikiStore(db)
     jobs = store.list_jobs(vault_id, status=status)
     return {"jobs": [_as_dict(j) for j in jobs]}
+
+
+@router.get("/wiki/events")
+async def wiki_events_stream(
+    vault_id: int = Query(...),
+    user: dict = Depends(get_current_active_user),
+):
+    """SSE stream of terminal-state wiki compile job events for a vault.
+
+    Emits ``data: {json}\\n\\n`` lines whenever a wiki compile job finishes
+    (completed / permanently failed). Clients refetch the canonical state via
+    the existing REST endpoints on each event. A 15-second keepalive comment
+    keeps proxies and load balancers from idling the connection out.
+    """
+    await _require_vault_read(user, vault_id)
+
+    bus = get_wiki_event_bus()
+    queue = bus.subscribe(vault_id)
+
+    async def event_generator():
+        try:
+            # Hello event so the client has positive proof of subscription.
+            yield f"data: {json.dumps({'type': 'subscribed', 'vault_id': vault_id})}\n\n"
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    yield f"data: {json.dumps(event)}\n\n"
+                except asyncio.TimeoutError:
+                    # Comment-line keepalive (ignored by EventSource clients).
+                    yield ": keepalive\n\n"
+        except asyncio.CancelledError:
+            raise
+        finally:
+            bus.unsubscribe(vault_id, queue)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/wiki_compile_processor.py
+++ b/backend/app/services/wiki_compile_processor.py
@@ -86,6 +86,7 @@ class WikiCompileProcessor:
                     result = await asyncio.to_thread(self._dispatch, job)
                     await asyncio.to_thread(self._complete_job, job.id, result)
                     logger.info("WikiCompileProcessor: completed job id=%d", job.id)
+                    self._publish_event(job, "job_completed", result=result)
                 except Exception as exc:
                     logger.exception(
                         "WikiCompileProcessor: job id=%d failed: %s", job.id, exc
@@ -107,6 +108,7 @@ class WikiCompileProcessor:
                                 "WikiCompileProcessor: job id=%d permanently failed after %d retries",
                                 job.id, new_retry_count,
                             )
+                            self._publish_event(job, "job_failed", error=str(exc))
                     except Exception as e2:
                         logger.error(
                             "WikiCompileProcessor: could not mark job id=%d failed: %s", job.id, e2
@@ -146,6 +148,35 @@ class WikiCompileProcessor:
 
         with self._pool.connection() as conn:
             WikiStore(conn).reset_job_to_pending(job_id)
+
+    def _publish_event(self, job, event_type: str, *, result: Optional[dict] = None, error: Optional[str] = None) -> None:
+        """Fan out a terminal-state event to SSE subscribers for the vault.
+
+        Best-effort: never raise out of the poll loop. The event payload is
+        intentionally small — clients refetch the canonical state via the
+        existing REST endpoints on receipt.
+        """
+        try:
+            from app.services.wiki_events import get_wiki_event_bus
+
+            payload: dict = {
+                "type": event_type,
+                "job_id": job.id,
+                "vault_id": job.vault_id,
+                "trigger_type": job.trigger_type,
+            }
+            if result is not None:
+                payload["result"] = {
+                    "page": result.get("page"),
+                    "claims_count": len(result.get("claims") or []),
+                    "entities_count": len(result.get("entities") or []),
+                    "skipped": bool(result.get("skipped")),
+                }
+            if error is not None:
+                payload["error"] = error
+            get_wiki_event_bus().publish(job.vault_id, payload)
+        except Exception as exc:  # noqa: BLE001 — fan-out must never fail the loop
+            logger.debug("WikiCompileProcessor: event publish failed: %s", exc)
 
     def _dispatch(self, job) -> dict:
         """Dispatch a job to the appropriate handler. Runs in a thread."""

--- a/backend/app/services/wiki_compiler.py
+++ b/backend/app/services/wiki_compiler.py
@@ -813,8 +813,13 @@ class WikiCompiler:
             return {"page": None, "claims": [], "entities": [], "relations_count": 0, "skipped": True}
 
         extraction = extract_entities_from_text(text)
-        if not extraction.acronyms and not extraction.role_claims:
-            return {"page": None, "claims": [], "entities": [], "relations_count": 0, "skipped": True}
+        # Always materialize a page for the document so the wiki reflects every
+        # ingested file. Deterministic claim/entity/relation passes below are
+        # no-ops when extraction is empty; the optional LLM curator can still
+        # populate claims later. Prior behavior short-circuited here and left
+        # the wiki blank for any document whose prose did not match the narrow
+        # acronym / ALL-CAPS-org role patterns.
+        extraction_empty = not extraction.acronyms and not extraction.role_claims
 
         file_name = file_data.get("file_name") or f"file:{file_id}"
         slug = normalize_slug(f"document/{file_name[:60]}")

--- a/backend/app/services/wiki_compiler.py
+++ b/backend/app/services/wiki_compiler.py
@@ -819,7 +819,6 @@ class WikiCompiler:
         # populate claims later. Prior behavior short-circuited here and left
         # the wiki blank for any document whose prose did not match the narrow
         # acronym / ALL-CAPS-org role patterns.
-        extraction_empty = not extraction.acronyms and not extraction.role_claims
 
         file_name = file_data.get("file_name") or f"file:{file_id}"
         slug = normalize_slug(f"document/{file_name[:60]}")

--- a/backend/app/services/wiki_events.py
+++ b/backend/app/services/wiki_events.py
@@ -1,0 +1,67 @@
+"""In-process pub/sub for wiki compile job events.
+
+Publishers (the WikiCompileProcessor) call ``publish(vault_id, event)`` after
+a job reaches a terminal state. Subscribers (the SSE handler at
+``GET /api/wiki/events``) call ``subscribe(vault_id)`` to receive a per-client
+``asyncio.Queue`` of events scoped to that vault.
+
+All operations run on the FastAPI event loop. The processor's poll loop and
+the SSE handlers share the same loop, so ``put_nowait`` is safe without
+cross-thread marshalling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Bounded per-subscriber queue. Wiki job throughput is low; 64 events is
+# generous headroom for a slow client and prevents unbounded memory growth.
+_QUEUE_MAX = 64
+
+
+class WikiEventBus:
+    def __init__(self) -> None:
+        self._subs: dict[int, set[asyncio.Queue]] = {}
+
+    def subscribe(self, vault_id: int) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue(maxsize=_QUEUE_MAX)
+        self._subs.setdefault(vault_id, set()).add(q)
+        return q
+
+    def unsubscribe(self, vault_id: int, q: asyncio.Queue) -> None:
+        subs = self._subs.get(vault_id)
+        if subs is None:
+            return
+        subs.discard(q)
+        if not subs:
+            self._subs.pop(vault_id, None)
+
+    def publish(self, vault_id: int, event: dict) -> None:
+        subs = self._subs.get(vault_id)
+        if not subs:
+            return
+        for q in list(subs):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                # Slow consumer: drop the oldest event to make room. SSE clients
+                # always refetch on any event, so a dropped event is not fatal.
+                try:
+                    q.get_nowait()
+                    q.put_nowait(event)
+                except Exception:
+                    logger.debug("wiki event bus: dropped event for vault %d", vault_id)
+
+
+_bus: Optional[WikiEventBus] = None
+
+
+def get_wiki_event_bus() -> WikiEventBus:
+    global _bus
+    if _bus is None:
+        _bus = WikiEventBus()
+    return _bus

--- a/backend/tests/test_wiki_compile_processor.py
+++ b/backend/tests/test_wiki_compile_processor.py
@@ -250,6 +250,31 @@ class TestCompileIngestJob(unittest.TestCase):
         )
         self.assertTrue(result.get("skipped"))
 
+    def test_creates_page_even_when_extraction_is_empty(self):
+        # Prose with no acronyms and no ALL-CAPS-org role claims must still
+        # produce a wiki page so the wiki reflects every ingested document.
+        plain_text = (
+            "The product team shipped a release on Tuesday. "
+            "Feedback was gathered from beta users and incorporated."
+        )
+        result = self.compiler.compile_ingest_job(
+            vault_id=1, input_json={"file_id": 1, "text": plain_text}
+        )
+        self.assertFalse(
+            result.get("skipped"),
+            "Ingest must produce a page even when deterministic extraction is empty",
+        )
+        self.assertIsNotNone(result.get("page"))
+        self.assertEqual(result["claims"], [])
+        self.assertEqual(result["entities"], [])
+        # The page row must actually exist in the DB.
+        row = self.conn.execute(
+            "SELECT id, page_type, status FROM wiki_pages WHERE id = ?",
+            (result["page"]["id"],),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(dict(row)["status"], "needs_review")
+
 
 # ---------------------------------------------------------------------------
 # WikiStore concurrent claim safety

--- a/frontend/src/pages/WikiJobsPanel.tsx
+++ b/frontend/src/pages/WikiJobsPanel.tsx
@@ -29,9 +29,12 @@ const TRIGGER_LABELS: Record<WikiCompileJob["trigger_type"], string> = {
 
 interface WikiJobsPanelProps {
   vaultId: number;
+  // Incremented by the parent on receipt of a wiki SSE event so this panel
+  // refetches without depending on a manual refresh button click.
+  refreshSignal?: number;
 }
 
-export function WikiJobsPanel({ vaultId }: WikiJobsPanelProps) {
+export function WikiJobsPanel({ vaultId, refreshSignal = 0 }: WikiJobsPanelProps) {
   const [jobs, setJobs] = useState<WikiCompileJob[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [loading, setLoading] = useState(false);
@@ -51,7 +54,7 @@ export function WikiJobsPanel({ vaultId }: WikiJobsPanelProps) {
 
   useEffect(() => {
     refresh();
-  }, [refresh]);
+  }, [refresh, refreshSignal]);
 
   async function handleRetry(jobId: number) {
     setActionLoading(jobId);

--- a/frontend/src/pages/WikiPage.tsx
+++ b/frontend/src/pages/WikiPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useVaultStore } from "@/stores/useVaultStore";
 import { VaultSelector } from "@/components/vault/VaultSelector";
 import { WikiPageList } from "./WikiPageList";
@@ -17,6 +17,8 @@ export default function WikiPage() {
   const [editingPage, setEditingPage] = useState<import("@/lib/api").WikiPage | null>(null);
   const [lintPanelOpen, setLintPanelOpen] = useState(false);
   const [jobsPanelOpen, setJobsPanelOpen] = useState(false);
+  const [jobsRefreshSignal, setJobsRefreshSignal] = useState(0);
+  const eventSourceRef = useRef<EventSource | null>(null);
 
   const {
     pages,
@@ -39,6 +41,45 @@ export default function WikiPage() {
       fetchPages();
       fetchLintFindings();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeVaultId]);
+
+  // Subscribe to wiki compile job completion events for the active vault.
+  // On any terminal job event, refetch pages, lint findings, and bump the
+  // refresh signal so an open WikiJobsPanel reloads too. The auth cookie is
+  // carried over withCredentials; EventSource cannot set Authorization headers.
+  useEffect(() => {
+    if (!activeVaultId) return;
+    // jsdom (vitest) does not provide EventSource. Skip cleanly so unit tests
+    // that don't exercise the live stream still mount the page.
+    if (typeof EventSource === "undefined") return;
+    const apiBase = import.meta.env.VITE_API_URL || "/api";
+    const url = `${apiBase}/wiki/events?vault_id=${activeVaultId}`;
+    const es = new EventSource(url, { withCredentials: true });
+    eventSourceRef.current = es;
+
+    es.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data) as { type?: string };
+        if (data.type === "job_completed" || data.type === "job_failed") {
+          fetchPages();
+          fetchLintFindings();
+          setJobsRefreshSignal((n) => n + 1);
+        }
+      } catch {
+        // Ignore malformed events; SSE keepalives are comment lines and never
+        // reach onmessage.
+      }
+    };
+
+    es.onerror = () => {
+      // Browser auto-reconnects with exponential backoff for SSE. No-op here.
+    };
+
+    return () => {
+      es.close();
+      eventSourceRef.current = null;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeVaultId]);
 
@@ -159,7 +200,7 @@ export default function WikiPage() {
         {/* Jobs panel: right side overlay */}
         {jobsPanelOpen && activeVaultId && (
           <div className="w-80 border-l border-border p-4 overflow-y-auto shrink-0">
-            <WikiJobsPanel vaultId={activeVaultId} />
+            <WikiJobsPanel vaultId={activeVaultId} refreshSignal={jobsRefreshSignal} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Two structural breaks left the wiki blank after queued compile jobs finished, even though the jobs themselves were marked `completed`:

1. **`compile_ingest_job()` short-circuited for ordinary documents.** `backend/app/services/wiki_compiler.py:815-817` unconditionally returned `{"skipped": True}` whenever the deterministic extractor found no acronyms and no ALL-CAPS-org role-claims. The extractor's regexes only match patterns like `X stands for Y` and `[Person] is the [ORG] [Role]`, so anything that isn't an HR-style memo silently produced no `wiki_pages` row, and the optional LLM curator downstream of that early return never ran. The fix drops the unconditional skip so every ingested document materializes a page; the deterministic claim/entity loops are no-ops when extraction is empty, and the curator can still attach claims later.

2. **The frontend had no completion handoff.** `WikiJobsPanel` only refetched on mount and on user actions; `WikiPage` only refetched pages on `activeVaultId` change. Even when pages were created the UI would not pick them up without a vault switch or hard reload. Added an in-process pub/sub (`backend/app/services/wiki_events.py`) keyed by vault id, publish `job_completed` / `job_failed` events from the compile processor after each terminal transition, and exposed them via a new `GET /api/wiki/events` SSE endpoint that mirrors the existing `chat.py` `StreamingResponse(... text/event-stream)` pattern (15s comment-line keepalive, vault read-policy gating, cookie-based auth). `WikiPage.tsx` subscribes via `EventSource` and refetches pages, lint findings, and the jobs panel on each event.

- Backend: `wiki_compiler.py`, `wiki_compile_processor.py`, `api/routes/wiki.py`, new `services/wiki_events.py`
- Frontend: `pages/WikiPage.tsx`, `pages/WikiJobsPanel.tsx`
- New test: `test_creates_page_even_when_extraction_is_empty` in `tests/test_wiki_compile_processor.py`

## Test plan

- [x] `pytest tests/test_wiki_compile_processor.py` — 62/62 passing (incl. new test)
- [x] `pytest tests/test_wiki_compiler.py tests/test_wiki_curator.py tests/test_wiki_linter.py tests/test_wiki_retrieval.py tests/test_wiki_routes.py tests/test_wiki_store.py` — 182/182 passing across the full wiki backend suite
- [x] `npx vitest run` — 1116 frontend tests pass / 1 skipped
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [ ] Manual: upload a plain-prose document (no acronym definitions, no ALL-CAPS orgs) and confirm a wiki page appears without reloading the page
- [ ] Manual: confirm `EventSource` reconnects after a backend restart and the wiki page resumes updating

---
_Generated by [Claude Code](https://claude.ai/code/session_018dZ6pAB6P9quXrpPJBiehG)_