### PR TITLE
[codex] harden chat session forking

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -815,81 +815,135 @@ async def fork_session(
         )
     forked_rows = all_rows[: request.message_index + 1]
 
-    # Create new forked session
+    # Create new forked session and copy messages atomically.
     fork_title = f"Branch of {session_row[2] or 'conversation'}"
-    cursor = await asyncio.to_thread(
-        conn.execute,
-        "INSERT INTO chat_sessions (vault_id, user_id, title, forked_from_session_id, fork_message_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-        (vault_id, user["id"], fork_title, session_id, request.message_index),
-    )
-    await asyncio.to_thread(conn.commit)
-    new_session_id = cursor.lastrowid
+    try:
+        await asyncio.to_thread(conn.execute, "BEGIN")
+        cursor = await asyncio.to_thread(
+            conn.execute,
+            "INSERT INTO chat_sessions (vault_id, user_id, title, forked_from_session_id, fork_message_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            (vault_id, user["id"], fork_title, session_id, request.message_index),
+        )
+        new_session_id = cursor.lastrowid
 
-    # Copy messages into the new session — preserve sources, memories, and wiki_refs.
+        # Copy messages into the new session — preserve sources, memories, and wiki_refs.
+        if has_memories_col and has_wiki_refs_col:
+            for row in forked_rows:
+                await asyncio.to_thread(
+                    conn.execute,
+                    "INSERT INTO chat_messages (session_id, role, content, sources, memories, wiki_refs, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                    (new_session_id, row[0], row[1], row[2], row[3], row[4]),
+                )
+        elif has_memories_col:
+            for row in forked_rows:
+                await asyncio.to_thread(
+                    conn.execute,
+                    "INSERT INTO chat_messages (session_id, role, content, sources, memories, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                    (new_session_id, row[0], row[1], row[2], row[3]),
+                )
+        else:
+            for row in forked_rows:
+                await asyncio.to_thread(
+                    conn.execute,
+                    "INSERT INTO chat_messages (session_id, role, content, sources, created_at) "
+                    "VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                    (new_session_id, row[0], row[1], row[2]),
+                )
+        await asyncio.to_thread(conn.commit)
+    except Exception:
+        await asyncio.to_thread(conn.rollback)
+        raise
+
+    # Return new session info with the newly inserted message IDs.
     if has_memories_col and has_wiki_refs_col:
-        for row in forked_rows:
-            await asyncio.to_thread(
-                conn.execute,
-                "INSERT INTO chat_messages (session_id, role, content, sources, memories, wiki_refs, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
-                (new_session_id, row[0], row[1], row[2], row[3], row[4]),
-            )
+        copied_result = await asyncio.to_thread(
+            conn.execute,
+            "SELECT id, role, content, sources, memories, wiki_refs, created_at FROM chat_messages "
+            "WHERE session_id = ? ORDER BY created_at ASC, id ASC",
+            (new_session_id,),
+        )
     elif has_memories_col:
-        for row in forked_rows:
-            await asyncio.to_thread(
-                conn.execute,
-                "INSERT INTO chat_messages (session_id, role, content, sources, memories, created_at) "
-                "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
-                (new_session_id, row[0], row[1], row[2], row[3]),
-            )
+        copied_result = await asyncio.to_thread(
+            conn.execute,
+            "SELECT id, role, content, sources, memories, created_at FROM chat_messages "
+            "WHERE session_id = ? ORDER BY created_at ASC, id ASC",
+            (new_session_id,),
+        )
     else:
-        for row in forked_rows:
-            await asyncio.to_thread(
-                conn.execute,
-                "INSERT INTO chat_messages (session_id, role, content, sources, created_at) "
-                "VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
-                (new_session_id, row[0], row[1], row[2]),
-            )
-    await asyncio.to_thread(conn.commit)
+        copied_result = await asyncio.to_thread(
+            conn.execute,
+            "SELECT id, role, content, sources, created_at FROM chat_messages "
+            "WHERE session_id = ? ORDER BY created_at ASC, id ASC",
+            (new_session_id,),
+        )
+    copied_rows = await asyncio.to_thread(copied_result.fetchall)
 
-    # Return new session info with copied messages
     messages = []
-    for row in forked_rows:
+    for row in copied_rows:
         sources = None
-        if row[2]:
+        if row[3]:
             try:
-                sources = json.loads(row[2])
+                sources = json.loads(row[3])
             except json.JSONDecodeError:
                 sources = []
         if has_memories_col and has_wiki_refs_col:
             mem_val = None
-            if row[3]:
+            if row[4]:
                 try:
-                    mem_val = json.loads(row[3])
+                    mem_val = json.loads(row[4])
                 except json.JSONDecodeError:
                     mem_val = []
             wiki_val = None
-            if row[4]:
+            if row[5]:
                 try:
-                    wiki_val = json.loads(row[4])
+                    wiki_val = json.loads(row[5])
                 except json.JSONDecodeError:
                     wiki_val = []
             messages.append(
-                {"role": row[0], "content": row[1], "sources": sources, "memories": mem_val, "wiki_refs": wiki_val}
+                {
+                    "id": row[0],
+                    "role": row[1],
+                    "content": row[2],
+                    "sources": sources,
+                    "memories": mem_val,
+                    "wiki_refs": wiki_val,
+                    "created_at": row[6],
+                    "feedback": None,
+                }
             )
         elif has_memories_col:
             mem_val = None
-            if row[3]:
+            if row[4]:
                 try:
-                    mem_val = json.loads(row[3])
+                    mem_val = json.loads(row[4])
                 except json.JSONDecodeError:
                     mem_val = []
             messages.append(
-                {"role": row[0], "content": row[1], "sources": sources, "memories": mem_val, "wiki_refs": None}
+                {
+                    "id": row[0],
+                    "role": row[1],
+                    "content": row[2],
+                    "sources": sources,
+                    "memories": mem_val,
+                    "wiki_refs": None,
+                    "created_at": row[5],
+                    "feedback": None,
+                }
             )
         else:
             messages.append(
-                {"role": row[0], "content": row[1], "sources": sources, "memories": None, "wiki_refs": None}
+                {
+                    "id": row[0],
+                    "role": row[1],
+                    "content": row[2],
+                    "sources": sources,
+                    "memories": None,
+                    "wiki_refs": None,
+                    "created_at": row[4],
+                    "feedback": None,
+                }
             )
 
     return {

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -104,6 +104,8 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
     vault_id INTEGER NOT NULL DEFAULT 1,
     user_id INTEGER,
     title TEXT,
+    forked_from_session_id INTEGER,
+    fork_message_index INTEGER,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (vault_id) REFERENCES vaults(id)

--- a/backend/tests/test_chat_fork.py
+++ b/backend/tests/test_chat_fork.py
@@ -1,0 +1,172 @@
+import json
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.api.routes import chat as chat_routes
+from app.models.database import init_db
+
+
+class FailingMessageCopyConnection(sqlite3.Connection):
+    fail_message_copy = False
+    fail_after_message_copies = 0
+    copied_message_count = 0
+
+    def execute(self, sql, parameters=(), /):
+        if self.fail_message_copy and sql.lstrip().upper().startswith(
+            "INSERT INTO CHAT_MESSAGES"
+        ):
+            self.copied_message_count += 1
+            if self.copied_message_count > self.fail_after_message_copies:
+                raise sqlite3.OperationalError("forced copy failure")
+        return super().execute(sql, parameters)
+
+
+@pytest.mark.asyncio
+async def test_fork_response_returns_inserted_message_ids_and_created_at(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "fork-success.db"
+    init_db(str(db_path))
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    try:
+        source_session_id = conn.execute(
+            "INSERT INTO chat_sessions (vault_id, user_id, title) VALUES (?, ?, ?)",
+            (1, 1, "Original"),
+        ).lastrowid
+        source_message_id = conn.execute(
+            "INSERT INTO chat_messages (session_id, role, content, sources) VALUES (?, ?, ?, ?)",
+            (source_session_id, "user", "Question", None),
+        ).lastrowid
+        conn.execute(
+            "INSERT INTO chat_messages (session_id, role, content, sources) VALUES (?, ?, ?, ?)",
+            (source_session_id, "assistant", "Answer", None),
+        )
+        conn.commit()
+
+        async def allow_write(*args):
+            return True
+
+        monkeypatch.setattr(chat_routes, "evaluate_policy", allow_write)
+
+        response = await chat_routes.fork_session(
+            source_session_id,
+            chat_routes.ForkSessionRequest(message_index=1),
+            conn,
+            {"id": 1},
+        )
+
+        assert response["forked_from_session_id"] == source_session_id
+        assert [message["content"] for message in response["messages"]] == [
+            "Question",
+            "Answer",
+        ]
+        assert all(isinstance(message["id"], int) for message in response["messages"])
+        assert response["messages"][0]["id"] != source_message_id
+        assert all(message["created_at"] for message in response["messages"])
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_and_returns_wiki_refs_when_column_exists(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "fork-wiki-refs.db"
+    init_db(str(db_path))
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    try:
+        conn.execute("ALTER TABLE chat_messages ADD COLUMN wiki_refs TEXT")
+        source_session_id = conn.execute(
+            "INSERT INTO chat_sessions (vault_id, user_id, title) VALUES (?, ?, ?)",
+            (1, 1, "Original"),
+        ).lastrowid
+        wiki_refs = [{"wiki_label": "W1", "title": "Runbook"}]
+        memories = [{"memory_label": "M1", "content": "Known fact"}]
+        conn.execute(
+            "INSERT INTO chat_messages (session_id, role, content, sources, memories, wiki_refs) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                source_session_id,
+                "assistant",
+                "Answer with [W1]",
+                None,
+                json.dumps(memories),
+                json.dumps(wiki_refs),
+            ),
+        )
+        conn.commit()
+
+        async def allow_write(*args):
+            return True
+
+        monkeypatch.setattr(chat_routes, "evaluate_policy", allow_write)
+
+        response = await chat_routes.fork_session(
+            source_session_id,
+            chat_routes.ForkSessionRequest(message_index=0),
+            conn,
+            {"id": 1},
+        )
+
+        forked_session_id = response["id"]
+        copied_wiki_refs = conn.execute(
+            "SELECT wiki_refs FROM chat_messages WHERE session_id = ?",
+            (forked_session_id,),
+        ).fetchone()[0]
+        assert json.loads(copied_wiki_refs) == wiki_refs
+        assert response["messages"][0]["memories"] == memories
+        assert response["messages"][0]["wiki_refs"] == wiki_refs
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fork_rolls_back_session_when_message_copy_fails(tmp_path, monkeypatch):
+    db_path = tmp_path / "fork-atomicity.db"
+    init_db(str(db_path))
+    conn = sqlite3.connect(
+        db_path,
+        check_same_thread=False,
+        factory=FailingMessageCopyConnection,
+    )
+    try:
+        source_session_id = conn.execute(
+            "INSERT INTO chat_sessions (vault_id, user_id, title) VALUES (?, ?, ?)",
+            (1, 1, "Original"),
+        ).lastrowid
+        conn.execute(
+            "INSERT INTO chat_messages (session_id, role, content, sources) VALUES (?, ?, ?, ?)",
+            (source_session_id, "user", "Question", None),
+        )
+        conn.execute(
+            "INSERT INTO chat_messages (session_id, role, content, sources) VALUES (?, ?, ?, ?)",
+            (source_session_id, "assistant", "Answer", None),
+        )
+        conn.commit()
+
+        async def allow_write(*args):
+            return True
+
+        monkeypatch.setattr(chat_routes, "evaluate_policy", allow_write)
+        conn.fail_message_copy = True
+        conn.fail_after_message_copies = 1
+
+        with pytest.raises(sqlite3.OperationalError, match="forced copy failure"):
+            await chat_routes.fork_session(
+                source_session_id,
+                chat_routes.ForkSessionRequest(message_index=1),
+                conn,
+                {"id": 1},
+            )
+
+        branch_count = conn.execute(
+            "SELECT COUNT(*) FROM chat_sessions WHERE forked_from_session_id = ?",
+            (source_session_id,),
+        ).fetchone()[0]
+        assert branch_count == 0
+    finally:
+        conn.close()

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from app.models.database import init_db
+from app.models.database import init_db, migrate_add_fork_columns
 
 
 class TestDatabaseSchema(unittest.TestCase):
@@ -92,6 +92,55 @@ class TestDatabaseSchema(unittest.TestCase):
                 table_names,
                 f"Required table '{table}' was not found after idempotent init_db() calls"
             )
+
+    def test_init_db_creates_fork_columns_on_chat_sessions(self):
+        """Fresh databases should include fork metadata without migrations."""
+        init_db(self.temp_db_path)
+
+        conn = sqlite3.connect(self.temp_db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(chat_sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+
+        self.assertIn("forked_from_session_id", columns)
+        self.assertIn("fork_message_index", columns)
+
+    def test_migrate_add_fork_columns_preserves_existing_sessions(self):
+        """Legacy chat_sessions tables should get nullable fork metadata."""
+        conn = sqlite3.connect(self.temp_db_path)
+        conn.execute("""
+            CREATE TABLE chat_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL DEFAULT 1,
+                user_id INTEGER,
+                title TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.execute(
+            "INSERT INTO chat_sessions (vault_id, user_id, title) VALUES (?, ?, ?)",
+            (1, 1, "Legacy"),
+        )
+        conn.commit()
+        conn.close()
+
+        migrate_add_fork_columns(self.temp_db_path)
+
+        conn = sqlite3.connect(self.temp_db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(chat_sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        cursor.execute(
+            "SELECT title, forked_from_session_id, fork_message_index FROM chat_sessions"
+        )
+        row = cursor.fetchone()
+        conn.close()
+
+        self.assertIn("forked_from_session_id", columns)
+        self.assertIn("fork_message_index", columns)
+        self.assertEqual(row, ("Legacy", None, None))
 
 
 if __name__ == '__main__':

--- a/frontend/src/components/chat/TranscriptPane.test.tsx
+++ b/frontend/src/components/chat/TranscriptPane.test.tsx
@@ -37,6 +37,7 @@ const mockChatState = vi.hoisted(() => ({
   loadChat: vi.fn(),
   newChat: vi.fn(),
 }));
+const mockNavigate = vi.hoisted(() => vi.fn());
 
 // Mock the hooks and dependencies
 vi.mock("@/stores/useChatStore", () => ({
@@ -83,20 +84,25 @@ vi.mock("@/stores/useChatShellStore", () => ({
 }));
 vi.mock("@/hooks/useSendMessage");
 vi.mock("@/hooks/useChatHistory");
+vi.mock("@/lib/api", () => ({
+  forkChatSession: vi.fn(),
+}));
 vi.mock("react-router-dom", () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
 }));
 vi.mock("./MessageBubble", () => ({
-  MessageBubble: ({ message }: { message: { id: string; role: string; content: string } }) => (
+  MessageBubble: ({ message, onFork }: { message: { id: string; role: string; content: string }; onFork?: () => void }) => (
     <div data-testid="message-bubble" data-message-id={message.id}>
       {message.content}
+      {onFork && <button type="button" aria-label={`Fork ${message.id}`} onClick={onFork}>Fork</button>}
     </div>
   ),
 }));
 vi.mock("./AssistantMessage", () => ({
-  AssistantMessage: ({ message }: { message: { id: string; role: string; content: string } }) => (
+  AssistantMessage: ({ message, onFork }: { message: { id: string; role: string; content: string }; onFork?: () => void }) => (
     <div data-testid="message-bubble" data-message-id={message.id}>
       {message.content}
+      {onFork && <button type="button" aria-label={`Fork ${message.id}`} onClick={onFork}>Fork</button>}
     </div>
   ),
 }));
@@ -137,6 +143,7 @@ vi.mock("@tanstack/react-virtual", () => ({
 
 import { useSendMessage, MAX_INPUT_LENGTH } from "@/hooks/useSendMessage";
 import { useChatHistory } from "@/hooks/useChatHistory";
+import { forkChatSession } from "@/lib/api";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 // Helper to render Composer with required providers
@@ -160,10 +167,9 @@ describe("TranscriptPane", () => {
   const mockHandleStop = vi.fn();
   const mockRefreshHistory = vi.fn();
   const mockGetActiveVault = vi.fn();
-  const mockNavigate = vi.fn();
-
   beforeEach(() => {
     vi.clearAllMocks();
+    (useChatStore as unknown as { getState: ReturnType<typeof vi.fn> }).getState = vi.fn(() => mockChatState);
 
     // Reset shared mock state
     mockChatState.messageIds = [];
@@ -242,6 +248,68 @@ describe("TranscriptPane", () => {
 
       render(<TranscriptPane />);
       expect(screen.getByText("Test message")).toBeInTheDocument();
+    });
+
+    it("guards fork requests against duplicate clicks while pending", async () => {
+      let resolveFork!: (value: Awaited<ReturnType<typeof forkChatSession>>) => void;
+      const forkPromise = new Promise<Awaited<ReturnType<typeof forkChatSession>>>((resolve) => {
+        resolveFork = resolve;
+      });
+      vi.mocked(forkChatSession).mockReturnValue(forkPromise);
+      mockChatState.activeChatId = "10";
+      _mockMessageCount = 2;
+      setMockMessages([
+        { id: "m1", role: "user", content: "Question" },
+        { id: "m2", role: "assistant", content: "Answer" },
+      ]);
+
+      render(<TranscriptPane />);
+
+      await userEvent.dblClick(screen.getByLabelText("Fork m2"));
+
+      expect(forkChatSession).toHaveBeenCalledTimes(1);
+      expect(forkChatSession).toHaveBeenCalledWith(10, 1);
+      await waitFor(() => expect(screen.queryByLabelText("Fork m2")).not.toBeInTheDocument());
+
+      resolveFork({
+        id: 20,
+        vault_id: 1,
+        title: "Branch of Original",
+        created_at: "2026-05-12T00:00:00Z",
+        updated_at: "2026-05-12T00:00:00Z",
+        forked_from_session_id: 10,
+        fork_message_index: 1,
+        messages: [
+          {
+            id: 101,
+            role: "user",
+            content: "Question",
+            sources: null,
+            created_at: "2026-05-12T00:00:00Z",
+          },
+          {
+            id: 102,
+            role: "assistant",
+            content: "Answer",
+            sources: null,
+            wiki_refs: [{ wiki_label: "W1", title: "Runbook" }],
+            created_at: "2026-05-12T00:00:00Z",
+          },
+        ],
+      });
+
+      await waitFor(() => expect(mockChatState.loadChat).toHaveBeenCalledTimes(1));
+      expect(mockChatState.loadChat).toHaveBeenCalledWith(
+        "20",
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "102",
+            wikiRefs: [{ wiki_label: "W1", title: "Runbook" }],
+          }),
+        ])
+      );
+      expect(mockRefreshHistory).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/chat/20");
     });
   });
 

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -142,7 +142,7 @@ interface MessageRowProps {
   highlightedId: string | null;
   onRetry: () => void;
   onEdit: (messageId: string, content: string) => void;
-  onFork: (messageId: string) => void;
+  onFork?: (messageId: string) => void;
   onFeedback: (messageId: string, feedback: "up" | "down" | null) => void;
 }
 
@@ -187,7 +187,7 @@ const MessageRow = memo(function MessageRow({
               isStreaming={isAssistantStreaming}
               showDebug={showDebug}
               onRetry={onRetry}
-              onFork={() => onFork(messageId)}
+              onFork={onFork ? () => onFork(messageId) : undefined}
               sessionId={String(activeSessionId ?? "")}
               messageFeedback={safeMessage.feedback}
               onFeedback={(fb) => onFeedback(messageId, fb)}
@@ -198,7 +198,7 @@ const MessageRow = memo(function MessageRow({
         <MessageBubble
           message={safeMessage}
           isStreaming={isAssistantStreaming}
-          onFork={() => onFork(messageId)}
+          onFork={onFork ? () => onFork(messageId) : undefined}
           userInitial={userInitial}
           onEdit={onEdit}
         />
@@ -238,6 +238,8 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
   const [, setIsAtBottom] = useState(true);
   const showDebug = import.meta.env.DEV;
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
+  const [isForking, setIsForking] = useState(false);
+  const isForkingRef = useRef(false);
 
   // Ref-backed pinned-bottom state — read inside scroll callbacks without
   // creating stale closures over isAtBottom (which is captured by useEffect).
@@ -393,10 +395,15 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
 
   // Fork
   const handleFork = useCallback(async (messageId: string) => {
+    if (isForkingRef.current) return;
     const { activeChatId } = useChatStore.getState();
     if (!activeChatId) return;
     const { messageIds: ids } = useChatStore.getState();
     const msgIndex = ids.indexOf(messageId);
+    if (msgIndex < 0) return;
+
+    isForkingRef.current = true;
+    setIsForking(true);
     try {
       const forked = await forkChatSession(parseInt(activeChatId), msgIndex);
       const forkMessages = forked.messages.map((m) => ({
@@ -405,6 +412,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
         content: m.content,
         sources: m.sources ?? undefined,
         memoriesUsed: m.memories ?? undefined,
+        wikiRefs: m.wiki_refs ?? undefined,
         created_at: m.created_at,
         feedback: m.feedback ?? null,
       }));
@@ -414,6 +422,9 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
     } catch (err) {
       console.error("Fork failed:", err);
       toast.error("Failed to branch conversation. Please try again.");
+    } finally {
+      isForkingRef.current = false;
+      setIsForking(false);
     }
   }, [loadChat, refreshHistory, navigate]);
 
@@ -459,7 +470,7 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
                       highlightedId={highlightedMessageId}
                       onRetry={handleRetry}
                       onEdit={handleEdit}
-                      onFork={handleFork}
+                      onFork={isForking ? undefined : handleFork}
                       onFeedback={handleFeedback}
                     />
                   </div>


### PR DESCRIPTION
# Summary

- Wrap chat fork session creation and message copying in one transaction so copy failures roll back the whole fork.
- Add fork metadata columns to the fresh base schema while preserving the legacy migration.
- Add frontend pending guards to prevent duplicate fork requests from double-clicks.
- Return inserted fork message ids and timestamps so the frontend receives the payload shape it expects.

# Validation

- python -m pytest backend\tests\test_chat_fork.py backend\tests\test_database.py -q
- npm test -- --run src/components/chat/TranscriptPane.test.tsx
- npm run typecheck
- npm run lint
- python -m py_compile backend\app\api\routes\chat.py backend\app\models\database.py backend\tests\test_chat_fork.py backend\tests\test_database.py
