### PR TITLE
[codex] Make auto-assignment user creation atomic

### DIFF
--- a/.agents/skills/commit-pr/SKILL.md
+++ b/.agents/skills/commit-pr/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: commit-pr
+description: >
+  Apply when committing, pushing, opening a PR, writing a pull request, creating release
+  notes, or updating a changelog. Enforces conventional commit format, mandatory release
+  notes, 5-tier test suite, SHA-pinning for workflow changes, and correct PR body format.
+effort: medium
+---
+
+## Commit & PR Protocol
+
+Follow every step in order. Do not skip steps.
+
+### Step −1 — ⛔ MANDATORY: Engineering invariant audit (read AGENTS.md, not "looks fine")
+
+**Before** running any test tier, before any build, before any push: read [`AGENTS.md`](../../../AGENTS.md) at the repo root and audit your change against the 12 non-negotiable invariants. The invariant list and the historical failure map are in [`docs/engineering-invariants.md`](../../../docs/engineering-invariants.md).
+
+For every invariant **touched** by this PR (not "maybe touched" — actually touched), produce a one-line entry of the form `<id> (<short name>): touched — <evidence>`. Evidence must be a concrete artifact: a command + its output, a test that proves the invariant, a grep showing no remaining anti-patterns, or a quoted spec citation. "Looks fine" is not evidence. The PR body must include a `## Invariant audit` section in the format shown in `AGENTS.md` (12 lines, one per invariant, each marked touched/not-touched with evidence).
+
+Hard stop:
+
+> **If any touched invariant cannot be proven from source and test output, do not push.**
+
+#### Required invariant-specific validations (run when the named invariants are touched)
+
+**(1, 2, 3) Plugin initialization, runtime portability, or any subprocess change** — run all three:
+
+```bash
+bun run build
+node scripts/repro-704.mjs
+node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"
+```
+
+The `repro-704.mjs` harness asserts plugin entry resolves under a deadline; the `dist import` line catches Node-ESM regressions (top-level `bun:` imports, broken default export shape) before CI does.
+
+**(3) Subprocesses** — grep every changed file for spawn call sites and account for each one in the audit:
+
+```bash
+git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\(" || true
+```
+
+For every match, the `## Invariant audit` evidence must confirm the call passes `cwd` (or `git -C <directory>` for Git CLI calls), `stdin: 'ignore'` (unless intentionally interactive), `timeout`, bounded stdio, and `proc.kill()` in `finally`.
+
+**(11) Tool registration** — run the tool / config tests:
+
+```bash
+bun --smol test tests/unit/config --timeout 60000
+for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; done
+```
+
+`/swarm doctor tools` is the runtime equivalent — its tests must remain green.
+
+**(7) Test writing** — confirm you loaded the writing-tests skill (`.Codex/skills/writing-tests/SKILL.md` or `.opencode/skills/writing-tests/SKILL.md`). Confirm any new mocks use a file-scoped `_internals` DI seam, not `mock.module`, OR are isolated to a test file whose `mock.module` cannot leak into other suites.
+
+**(6) `test_runner` safety** — the OpenCode `test_runner` tool is for targeted agent validation only. Do NOT use it with `scope: 'all'` or broad `'graph'` / `'impact'` scope for repo validation. For repo validation, use the shell commands in Step 5 below.
+
+### Step 0 — Session start hygiene
+
+**Run before anything else.** Prevents the three most common CI failures (stale state, stale base, dirty working tree).
+
+```bash
+# Ensure you're on the latest main as your branch point
+git fetch origin main
+
+# Create (or verify) a branch rooted at the latest main
+# If already on a feature branch, skip this line
+# git switch -c <branch> origin/main
+
+# Clear stale evidence files from prior sessions — these pollute
+# evidence-first gate checks and cause non-deterministic test failures
+rm -f .swarm/evidence/*.json
+
+# Verify working tree is clean — no uncommitted changes from prior sessions
+git status --short
+```
+
+If `git status` shows uncommitted changes, either commit them (if they're part of this PR) or stash them (if they're from a prior session).
+
+### Step 1 — Format every commit message correctly
+
+Use `<type>(<scope>): <description>` exactly:
+- Description must be **lowercase** and **not end with a period**
+- Scope is optional but encouraged
+- Allowed types: `feat`, `fix`, `perf`, `revert`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`
+- For a breaking change, append `!` to the type (e.g. `feat!:`) or add a `BREAKING CHANGE:` footer
+
+Valid: `feat(architect): add retry backoff to SME delegation`
+Invalid: `Fix stuff`, `feat: Add new feature.`, `feature: new thing`
+
+### Step 2 — Choose the correct PR title type
+
+The PR title is the squash merge commit message. Choose based on primary change:
+- New capability → `feat` (minor bump)
+- Bug fix only → `fix` (patch bump)
+- Mixed feat + fix → use `feat` (minor subsumes patch)
+- `docs`/`chore`/`refactor`/`test`/`ci`/`build` only → no version bump is triggered
+
+### Step 3 — Determine NEXT_VERSION and create the release notes file
+
+1. Read `.release-please-manifest.json` to find the current version
+2. Determine the bump from your commit type:
+   - `fix`, `perf`, `revert` → patch (e.g. `6.33.1` → `6.33.2`)
+   - `feat` → minor (e.g. `6.33.1` → `6.34.0`)
+   - breaking change (`!` or `BREAKING CHANGE:` footer) → major (e.g. `6.33.1` → `7.0.0`)
+   - `docs`, `chore`, `refactor`, `test`, `ci`, `build` → no bump; use the current version as NEXT_VERSION (still create the file)
+3. Create `docs/releases/v{NEXT_VERSION}.md` with freeform markdown covering:
+   - **What changed** — changes grouped by theme
+   - **Why** — motivation (bug report, feature request, hardening)
+   - **Migration steps** — if any API, config, or behavior changed
+   - **Breaking changes** — if any
+   - **Known caveats** — anything users should watch out for
+
+This file is **mandatory on every PR, no exceptions**, including one-line fixes.
+
+### Step 4 — Never touch these files manually
+
+Do **not** edit `package.json` version field, `CHANGELOG.md`, or `.release-please-manifest.json`. Release-please manages them; manual edits cause merge conflicts and break the pipeline.
+
+### Step 5 — ⛔ MANDATORY: Build + run the full 5-tier test suite before pushing
+
+**This step is MANDATORY. It is not optional, skippable, or conditional.**
+
+Every tier MUST be run in order, regardless of:
+- Whether the swarm's internal QA gates already ran lint/checks (swarm scope ≠ CI scope)
+- Whether the change looks trivial or cosmetic
+- Whether tests passed locally in isolation
+- Whether you are in a hurry
+
+Skipping this step WILL cause CI failures that waste time and require a follow-up commit.
+
+#### Pre-flight: build and check dist/ drift (runs before all test tiers)
+
+Build first. If `dist/` is tracked in the repo, verify a fresh build produces no uncommitted diffs.
+CI's dist-check passes by comparing committed `dist/` against a fresh build; any diff is a hard failure.
+
+```bash
+bun run build
+
+# Check for dist drift — MUST be clean before proceeding to tests
+if git diff --exit-code -- dist/; then
+    echo "dist/ is clean"
+else
+    echo "dist/ has uncommitted changes after build — stage and commit them:"
+    echo "  git add dist/ && git commit -m \"chore: update dist artifacts\""
+    echo "Then re-run this pre-flight check."
+    exit 1
+fi
+```
+
+If the build produces non-deterministic diffs on every run (no source changes), investigate before proceeding — this will also fail CI on every subsequent PR.
+
+#### Run every tier in order. Fix failures before proceeding.
+
+```bash
+# Tier 1 — quality
+bun run typecheck
+bunx biome ci .   # MUST run on the full project — never scope to modified files only.
+                  # CI runs it on all files; a scoped run will miss errors in files you
+                  # touched indirectly (e.g. reformatted by another tool, or modified via
+                  # biome --write on one file but not re-checked globally).
+                  #
+                  # If you ran `bunx biome check --write` to auto-fix formatting,
+                  # re-run `bunx biome ci .` afterwards and commit the auto-fixed files
+                  # BEFORE pushing — biome --write produces unstaged changes that will
+                  # cause the quality CI check to fail on the un-fixed commit.
+
+# Tier 2 — unit tests (per-file isolation to match CI and prevent mock conflicts)
+for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; done
+for f in tests/unit/services/*.test.ts; do bun --smol test "$f" --timeout 30000; done
+for f in tests/unit/agents/*.test.ts; do bun --smol test "$f" --timeout 30000; done
+# hooks must run per-file — batch mode can mask failures that CI's per-file isolation catches
+for f in tests/unit/hooks/*.test.ts; do bun --smol test "$f" --timeout 30000; done
+bun --smol test tests/unit/cli tests/unit/commands tests/unit/config --timeout 120000
+
+# Tier 3 — integration tests
+# IMPORTANT: always run Tier 3 after fixing Tier 2 failures — the same root cause
+# often appears in integration test fixtures that unit tests don't cover.
+bun test tests/integration ./test --timeout 120000
+
+# Tier 4 — security and adversarial tests
+bun test tests/security --timeout 120000
+bun test tests/adversarial --timeout 120000
+
+# Tier 5 — smoke (no rebuild — already done in pre-flight)
+bun test tests/smoke --timeout 120000
+```
+
+**Routing console calls through a debug-gated logger: extra step required.**
+When you change `console.log/warn/error` to `logger.log/warn()` (which gates output behind `OPENCODE_SWARM_DEBUG=1`):
+1. Grep for all tests that spy on those console methods and assert they ARE called:
+   ```bash
+   grep -rn "spyOn(console" tests/ --include="*.ts"
+   grep -rn "toHaveBeenCalled\|console\.warn\|console\.log\|console\.error" tests/ --include="*.ts"
+   ```
+2. For every spy that asserts the call IS made: determine whether the original call was an operational error (e.g., `catch` block reporting a real failure). Operational errors must remain as direct `console.warn/error` — never gate them behind `logger.warn()`. Only diagnostic/trace messages should be routed through the debug-gated logger.
+3. Run the affected hook test files per-file after the fix to confirm spy assertions pass.
+
+Failing to do this breaks tests silently in isolation but fails loudly in CI's per-file run.
+
+**Schema or field name changes: extra step required.**
+When you rename a field in a Zod schema, TypeScript interface, or serialized format (e.g. `task_id` → `taskId`):
+1. Grep for the old field name across ALL test files — unit AND integration:
+   ```bash
+   grep -rn "old_field_name" tests/ --include="*.ts"
+   ```
+2. Update every test fixture that writes JSON with the old field name.
+3. Update every assertion that reads the old field name from parsed JSON.
+4. Run Tier 2 and Tier 3 together after fixing all fixtures.
+
+Failing to do this causes test fixtures to write stale-format JSON that passes Zod validation for the write but fails on the read path — a silent correctness hazard.
+
+### Troubleshooting — CI fails on tests that seem unrelated to your changes
+
+If a test fails and you suspect it is pre-existing (unrelated to your changes):
+
+1. **Confirm on a clean main checkout** using a disposable Git worktree:
+   ```bash
+   git worktree add /tmp/repro-check origin/main
+   bun --smol test /tmp/repro-check/<path-to-failing-test> --timeout 30000
+   git worktree remove /tmp/repro-check
+   ```
+   This avoids the risks of `git stash` (lost state, untracked files, locked files on Windows).
+
+2. **If it also fails on main**: note the failure and its test file name in the PR description under `## Pre-existing failures`. Do NOT skip the other test tiers — a pre-existing failure in one tier does not exempt you from running the others. The PR will be evaluated on net change; pre-existing failures are flagged separately.
+
+3. **If it only fails on your branch**: the failure was introduced by your changes. Fix it before proceeding.
+
+### Step 6 — SHA-pin any workflow changes
+
+If you add or modify any file in `.github/workflows/`, every `uses:` reference to a third-party action must be pinned to a full 40-character commit SHA with the version as a comment:
+
+```yaml
+# Correct
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+# Wrong — will fail security tests
+- uses: actions/checkout@v4
+- uses: actions/checkout@main
+```
+
+Find the SHA for a tag:
+```bash
+gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
+```
+
+### Step 7 — Squash to a single clean commit
+
+Before pushing, collapse all interim commits into one. The PR must land as a single commit whose message is the canonical record of the change.
+
+**Before squashing, verify no tool or IDE files were accidentally staged:**
+```bash
+git diff --name-only HEAD origin/main | grep -E '\.(local\.json|vscode|idea)' || true
+# Look for: .Codex/settings.local.json, .vscode/, .idea/, etc.
+# If any appear, remove them: git checkout origin/main -- <path>
+```
+These files are modified by Codex and IDEs during a session but must never be committed.
+
+```bash
+# Fetch main to ensure origin/main is current (CI may have merged main into your branch)
+git fetch origin main
+
+# See what you're about to squash (sanity check)
+git log --oneline origin/main..HEAD
+
+# Squash everything relative to current main
+# Using origin/main instead of git merge-base HEAD main is important because
+# CI may have auto-merged main into your branch, creating a merge commit
+# that would confuse merge-base.
+git reset --soft origin/main
+git commit -m "type(scope): description"
+
+# Force-push with lease (never plain --force)
+git push --force-with-lease -u origin <branch-name>
+```
+
+**Rules:**
+- The squash commit message must match the PR title exactly — they are the same thing.
+- Use `--force-with-lease`, never `--force`. Lease rejects the push if the remote has commits you haven't seen.
+- If a review cycle is already in progress (reviewer comments reference specific commit SHAs), do **not** squash until all review threads are resolved — squashing rewrites history and orphans inline comments.
+- Any dist/ build artifact commits must be included in the squash (stage them before `git commit`).
+
+**Why:** Interim commits (`fix attempt 1`, `wip`, `address review`) are noise in the project history. A single well-named commit makes `git log`, `git bisect`, and release notes meaningful. The PR title doubles as the squash commit message — both must be correct conventional-commit format.
+
+### Step 8 — Open the PR with the correct body format
+
+```bash
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2 if needed>
+- <bullet 3 if needed>
+
+## Test plan
+- [ ] <what you tested>
+- [ ] <additional test step>
+
+EOF
+)" --base main
+```
+
+`## Summary` must have 1–3 bullets explaining what and why. `## Test plan` must be a markdown checklist. Do not replace the body of an existing release-please PR — prepend only.
+
+### Step 9 — Pre-merge checklist
+
+Verify every item before asking for a merge:
+- [ ] Step −1 invariant audit completed; `## Invariant audit` section present in the PR body in the format from `AGENTS.md`
+- [ ] If the audit lists invariants 1, 2, or 3 as touched: `bun run build`, `node scripts/repro-704.mjs`, and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` all ran cleanly with output in context
+- [ ] If invariant 3 (subprocesses) is touched: every `bunSpawn` / `spawn` / `spawnSync` call in changed files passes `cwd` (or `git -C <directory>` for Git CLI calls), `stdin: 'ignore'`, `timeout`, bounded stdio, and `proc.kill()` in `finally`
+- [ ] `test_runner` was NOT used with `scope: 'all'` or broad `'graph'` / `'impact'` scope to validate this repo (use shell commands instead)
+- [ ] Branch has exactly **one commit** — the squashed commit from Step 7 (`git log --oneline origin/main..HEAD` shows one line)
+- [ ] That commit message matches the PR title exactly, and both follow `<type>(<scope>): <description>`
+- [ ] `docs/releases/v{NEXT_VERSION}.md` exists with meaningful release notes
+- [ ] `package.json` version, `CHANGELOG.md`, `.release-please-manifest.json` are untouched
+- [ ] All 5 test tiers from Step 5 were actually run (not assumed — you must have the output in context), including `bunx biome ci .` on the full project (not scoped)
+- [ ] If the repo tracks `dist/` files: `bun run build` was run and dist/ artifacts are included in the squash commit
+- [ ] All workflow `uses:` references are SHA-pinned (if workflows changed)
+- [ ] PR body has `## Summary`, `## Invariant audit`, and `## Test plan`
+- [ ] All CI checks are green before merging

--- a/.agents/skills/engineering-conventions/SKILL.md
+++ b/.agents/skills/engineering-conventions/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: engineering-conventions
+description: >
+  Guidelines and non-negotiable engineering invariants for modifying opencode-swarm.
+  Load before architecture, plugin initialization, subprocess, tool registration, plan
+  durability, .swarm storage, runtime portability, session/global state, guardrails/retry,
+  chat/system message hooks, or release/cache changes. Authoritative source: AGENTS.md
+  at the repo root and docs/engineering-invariants.md.
+effort: medium
+---
+
+# Engineering Conventions for opencode-swarm (Codex)
+
+**Authoritative source:** [`AGENTS.md`](../../../AGENTS.md) at the repo root and [`docs/engineering-invariants.md`](../../../docs/engineering-invariants.md). This skill is a pointer + summary so Codex loads the right invariants before touching dangerous areas. **Read `AGENTS.md` first.** When this skill conflicts with `AGENTS.md`, `AGENTS.md` wins.
+
+## When to load this skill
+
+Load this skill **before** beginning implementation work that touches any of:
+
+- `src/index.ts` (plugin entry / `initializeOpenCodeSwarm`)
+- `src/hooks/*` (any hook that may run during init or QA review)
+- `src/tools/*` (tool registration, working-directory anchoring, test_runner)
+- `src/utils/bun-compat.ts` (subprocess shim — every spawn in the repo eventually flows through here)
+- `src/utils/timeout.ts` (the `withTimeout` primitive used by every bounded init step)
+- `src/utils/gitignore-warning.ts` (Git hygiene; runs on plugin init path)
+- `package.json`, build configuration, `dist/`, plugin export shape
+- Plan ledger / projection / checkpoint code (`src/plan/*`, `.swarm/plan-*`)
+- Session / guardrails / runtime state (`src/state.ts`, `src/hooks/guardrails.ts`)
+- Tests involving subprocesses, plugin startup, `mock.module`, or temp directories
+
+If you are not sure whether you are touching one of these, you are touching one of these.
+
+## Highest-risk invariants (the ones that have already shipped regressions)
+
+The full list of 12 invariants is in `AGENTS.md`. The four that have caused the most recent production regressions:
+
+1. **Plugin initialization is bounded and fail-open.** Every awaited operation on the plugin-init path must be wrapped in `withTimeout(...)` and degrade non-fatally on timeout. Issue #704 (v7.0.3) and the v7.3.3 git-hygiene regression both stem from violating this. The OpenCode plugin host silently drops a plugin whose entry never resolves; users see "no agents in TUI / GUI" with no error.
+2. **Subprocesses are bounded, non-interactive, and killable.** Every `bunSpawn(['<bin>', ...])` call must pass `cwd`, `stdin: 'ignore'` (unless intentionally interactive), `timeout: <ms>`, bounded stdio, and call `proc.kill()` in a `finally`. An outer `withTimeout` is not enough — it lets the awaiter proceed but does not abort the child.
+3. **Runtime portability — Node-ESM-loadable + v1 plugin shape.** No top-level `bun:` imports in `dist/index.js`. Default export is `{ id, server }`. All `Bun.*` calls go through `src/utils/bun-compat.ts`. v6.86.8 / v6.86.9 are the cautionary tales.
+4. **Test mock isolation.** `mock.module(...)` leaks across files in Bun's shared test-runner process. Use a file-scoped `_internals` dependency-injection seam (see `src/utils/gitignore-warning.ts:_internals` and `src/hooks/diff-scope.ts:_internals`) instead. Restore in `afterEach`. The writing-tests skill covers this in detail; load it before modifying tests.
+
+## Cross-link: writing tests
+
+For test changes, also load [`.Codex/skills/writing-tests/SKILL.md`](../writing-tests/SKILL.md). It covers `bun:test` API, mock isolation rules, CI per-file isolation, and cross-platform anti-patterns.
+
+## Hard warning: do NOT use broad `test_runner` for repo validation
+
+The OpenCode `test_runner` tool is for **targeted agent validation** with explicit `files: [...]` or small targeted scopes. It is not the way to validate the full repo from inside a Codex session that orchestrates OpenCode. In this repo:
+
+- `MAX_SAFE_TEST_FILES = 50` (`src/tools/test-runner.ts:26`). Resolutions exceeding this return `outcome: 'scope_exceeded'` with a SKIP. Do not lean on this — broad scopes can stall or kill OpenCode before that guard fires.
+- For repo validation, run the shell commands in `contributing.md` / `TESTING.md` directly (per-file isolation loops + tier orchestration).
+- `scope: 'all'` requires `allow_full_suite: true` and is intended for opt-in CI mirrors only. Default to `files: [...]` instead.
+
+## The invariant-audit gate (PR-time)
+
+Every PR that touches a relevant area must include an `## Invariant audit` section in its description. The format is in `AGENTS.md` ("Invariant audit required in PRs"). The `commit-pr` skill enforces this gate before push/PR — load it before committing.
+
+If you cannot prove a touched invariant from source and test output, **do not push**.

--- a/.agents/skills/issue-tracer/SKILL.md
+++ b/.agents/skills/issue-tracer/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: issue-tracer
+description: "Use when asked to trace, investigate, root-cause, plan, fix, close, or prepare a PR for a GitHub issue or bug report. Runs an evidence-first issue workflow: GitHub intake, reproduction, reasoning-guided localization, no-gap fix planning, independent critic review, user approval gate, implementation, tests, and PR-ready closure."
+allowed-tools: Read Grep Glob Bash Edit MultiEdit Write WebFetch TodoWrite
+---
+
+# Issue Tracer
+
+Use this skill to drive a GitHub issue or bug report from intake to a reviewed closure plan, then, after explicit approval, to a minimal verified fix and PR-ready output.
+
+The default behavior is plan-first. You MUST trace the issue end to end, produce a rock-solid plan, send that plan to an independent critic, incorporate the critic's feedback, present the reviewed plan to the user, and wait for explicit user approval before changing production code.
+
+## Source Policy
+
+Use these sources in this order.
+
+1. GitHub source of truth:
+   - If `github_mcp_direct` is available, prefer it for issue fetch, PR metadata, repository metadata, file content, and repository search before falling back to CLI commands.
+   - Prefer `gh issue view`, `gh issue list`, `gh pr view`, `gh api`, `git log`, `git blame`, `git diff`, and local repo files.
+   - If a GitHub MCP server is available, use it for issue, PR, discussion, and repository metadata.
+   - Do not ask the user for GitHub credentials. If GitHub access fails, report the exact blocked operation and fall back to local issue text only.
+2. Web source of truth:
+   - Use `WebFetch` or equivalent web access for current framework/API behavior, release notes, deprecations, security advisories, and external service semantics.
+   - Any plan claim based on external docs must include the URL in the plan.
+3. Repository source of truth:
+   - Never speculate about code. Open every file before referencing it.
+   - Verify every symbol, type, command, test, config entry, and path against the repo.
+
+## Non-Negotiable Rules
+
+1. Quality is the only metric that matters. Time pressure does not exist.
+2. Do not implement before the user explicitly approves the reviewed plan.
+3. Reproduce or explain non-reproducibility before localizing.
+4. Localize before fixing. A plausible patch is not enough.
+5. Prefer the smallest patch that fully closes the issue without unwired functionality, untested branches, or hidden regressions.
+6. Use parallel reads/searches for independent files and subsystems whenever available.
+7. Maintain written artifacts so context compaction or handoff cannot erase the investigation state.
+8. If confidence drops below 90%, stop and surface the uncertainty instead of guessing.
+9. Do not disable, delete, weaken, or skip tests to make the run green.
+10. Do not push, merge, publish, delete data, drop databases, rewrite history, or perform destructive operations without explicit user approval.
+
+## Required Artifacts
+
+Create a trace directory before meaningful investigation:
+
+```text
+.Codex/issue-traces/<issue-id-or-slug>/
+├── 01-issue-summary.md
+├── 02-reproduction.md
+├── 03-localization-log.md
+├── 04-root-cause.md
+├── 05-fix-plan.md
+├── 06-critic-review.md
+├── 07-approved-plan.md
+├── 08-test-results.md
+├── 09-pr-body.md
+└── state.md
+```
+
+If `.Codex/` is not writable or should not be modified in the project, use `tmp/issue-traces/<issue-id-or-slug>/` and say so.
+
+Always update `state.md` at phase boundaries with current phase, completed gates, active hypothesis, selected fix candidate, unresolved risks, and next action.
+
+Detailed templates are in:
+
+- `references/evidence-artifacts.md`
+- `references/localization-playbook.md`
+- `references/critic-gate.md`
+- `assets/pr-template.md`
+
+Read the relevant reference before starting that phase.
+
+## Phase 0: Setup and Scope Control
+
+1. Parse the user request into:
+   - issue URL, issue number, or bug description
+   - repo path or GitHub owner/repo if provided
+   - requested mode: plan-only, plan-then-approval, or approved implementation
+2. Check repo state:
+   - `git status --short`
+   - current branch
+   - remotes
+   - top-level files such as `AGENTS.md`, `README*`, package manifests, test configs, CI configs
+3. If the worktree has unrelated user changes, do not overwrite them. Continue read-only until you can isolate your changes or ask the user.
+4. Create the trace directory and initialize `state.md`.
+5. Create a todo list with all phases. Mark only one step in progress at a time, and mark steps complete only after gate verification.
+
+### Phase 0 Gate
+
+Proceed only when:
+
+- repo and issue target are identified or the missing identifier is explicitly documented
+- worktree safety is checked
+- trace directory exists
+- todo list exists
+- `state.md` records the starting state
+
+## Phase 1: Intake and Reproduction
+
+Goal: convert the issue into a precise, reproducible engineering problem.
+
+1. Retrieve and read the full issue:
+   - `gh issue view <id> --comments --json number,title,body,author,labels,state,comments,createdAt,updatedAt,url`
+   - Also read linked PRs, commits, discussions, screenshots, logs, and external docs referenced by the issue.
+2. Extract into `01-issue-summary.md`:
+   - observed behavior
+   - expected behavior
+   - exact error messages and stack traces
+   - reproduction steps
+   - environment, platform, versions, feature flags, config
+   - acceptance criteria
+   - ambiguity list
+3. Identify the project's verification commands by reading actual repo files:
+   - `AGENTS.md`
+   - `README*`
+   - package manifests
+   - Makefiles
+   - CI workflow files
+   - test configs
+4. Attempt reproduction using the smallest faithful command or scenario.
+5. Capture exact commands, exit codes, and output in `02-reproduction.md`.
+6. If no reproduction exists, create a minimal failing test, script, fixture, or manual reproduction checklist. The reproduction must target the reported behavior, not a guessed implementation detail.
+
+### Phase 1 Gate
+
+Proceed only when one is true:
+
+- the issue is reproduced with exact failing output
+- a regression test is written and confirmed failing for the reported behavior
+- the issue is not reproducible, and `02-reproduction.md` documents every attempted command, environment mismatch, and missing input needed from the user
+
+If reproduction is impossible because required data, credentials, environment, or hardware is missing, stop and ask for the minimum missing information. Do not jump to a speculative fix.
+
+## Phase 2: Root-Cause Localization
+
+Goal: isolate the root cause to the narrowest truthful granularity: file, symbol, line range, invariant, and triggering input.
+
+Use `references/localization-playbook.md`.
+
+1. Build candidate locations from issue evidence:
+   - stack traces and error text
+   - failing test names
+   - UI route/API endpoint/CLI command names
+   - labels and linked PRs
+   - recent commits touching related areas
+2. Search and read in parallel where possible:
+   - `rg` for symbols, routes, commands, strings, errors, config keys
+   - `git grep` for tracked-file confirmation
+   - `git log --oneline --decorate -- <path>`
+   - `git blame -L <start>,<end> -- <path>` where useful
+3. Use reasoning-guided hierarchical localization:
+   - file-level: which files can plausibly affect the symptom
+   - element-level: which functions, classes, handlers, tests, or configs matter
+   - line-level: which conditions, calls, assignments, invariants, or boundary checks are wrong
+4. Maintain `03-localization-log.md`:
+   - every hypothesis
+   - files read and why
+   - commands run and results
+   - evidence for and against each hypothesis
+   - ruled-out paths
+5. Follow call chains in both directions:
+   - from input/event to failure
+   - from failure back to origin
+   - through config, serialization, async boundaries, state transitions, and feature flags
+6. Stop localization only when you can write `04-root-cause.md` in this shape:
+
+```markdown
+# Root Cause
+
+## Summary
+[One paragraph: what failed, where, and why.]
+
+## Exact Location
+- File: `path/to/file.ext`
+- Symbol: `functionOrClassName`
+- Lines: `start-end`
+
+## Broken Contract
+[The invariant/assumption/contract that was violated.]
+
+## Triggering Conditions
+[Inputs, environment, state, flags, or sequence required.]
+
+## Evidence Chain
+1. [Issue symptom or failing test]
+2. [Code path evidence]
+3. [Focused command/test evidence]
+4. [Why alternatives were ruled out]
+```
+
+### Phase 2 Gate
+
+Proceed only when:
+
+- at least two plausible hypotheses were considered or the stack trace/repro uniquely identifies the fault
+- the selected root cause has direct code evidence
+- every referenced symbol/path was opened and verified
+- the triggering condition is known
+- alternative explanations are ruled out or explicitly documented as residual risk
+
+If two or more hypotheses remain equally plausible, stop and ask for the smallest additional evidence needed.
+
+## Phase 3: Fix Plan and Independent Critic Gate
+
+Goal: produce a no-gap plan, independently review it, revise it, and ask the user for approval before implementation.
+
+Use `references/critic-gate.md`.
+
+1. Generate 3-5 fix candidates when realistic. For trivial single-line defects, include at least the chosen fix and one rejected alternative.
+2. Rank candidates by:
+   - correctness against root cause
+   - minimality
+   - regression risk
+   - public API compatibility
+   - architectural fit
+   - testability
+   - rollback simplicity
+3. Perform impact analysis:
+   - callers/importers of changed symbols
+   - affected tests and fixtures
+   - config and docs surfaces
+   - UI/API/CLI contracts
+   - persistence/migration implications
+   - concurrency, async, idempotency, and retry behavior
+   - security and privacy implications
+4. Write `05-fix-plan.md` with:
+   - issue summary
+   - root cause
+   - candidates considered and ranking
+   - selected fix
+   - exact files expected to change
+   - functions/classes expected to change
+   - edge cases
+   - test plan
+   - rollout/risk/rollback
+   - explicit "unwired functionality" checklist
+5. Send the plan to an independent critic:
+   - If running in the main session and the `Agent` tool is available, launch a separate critic subagent with `references/critic-gate.md` and the trace artifacts as context.
+   - If running as a subagent through `.Codex/agents/issue-tracer.md`, do not attempt nested subagent invocation. Codex subagents cannot spawn other subagents. Run the full fallback self-critic pass from `references/critic-gate.md` and disclose this to the user.
+   - If no independent subagent is available in the current environment, run the fallback adversarial critic pass and clearly label it "Fallback self-critic: independent critic unavailable."
+6. The critic must return one of:
+   - `APPROVE`
+   - `NEEDS_REVISION`
+   - `BLOCKED`
+7. Revise `05-fix-plan.md` until all critic blockers are resolved or explicitly escalated.
+8. Copy the final reviewed plan to `07-approved-plan.md` with an unchecked approval line.
+9. Present the final reviewed plan to the user and stop. Ask for explicit approval to implement.
+
+### Phase 3 Gate
+
+Do not write production code until:
+
+- `05-fix-plan.md` exists
+- `06-critic-review.md` exists
+- all critic blockers are resolved or disclosed
+- `07-approved-plan.md` exists
+- the user explicitly approves implementation
+
+## Phase 4: Implementation After Approval
+
+Goal: implement the smallest complete patch that matches the approved plan.
+
+Begin only after explicit user approval.
+
+1. Re-check `git status --short`.
+2. Create or confirm an isolated branch unless the user asked otherwise:
+   - `git switch -c fix/<issue-id>-<short-slug>` or equivalent
+3. Write or update the failing regression test first.
+4. Run the regression test and confirm it fails for the expected reason.
+5. Apply the minimal fix.
+6. Re-read every changed file.
+7. Run the regression test and confirm it passes.
+8. Run impacted tests based on the dependency graph and changed files.
+9. Run project quality checks discovered in Phase 1:
+   - test suite or impacted suite
+   - lint
+   - typecheck
+   - formatting check
+   - build
+   - security/static checks if the repo already has them
+10. Record commands and results in `08-test-results.md`.
+11. If any test fails unexpectedly, treat it as signal. Re-enter localization for that failure before changing code again.
+
+### Phase 4 Gate
+
+Proceed only when:
+
+- implementation matches the approved plan or deviations are documented and approved
+- regression protection exists
+- impacted tests pass
+- required quality checks pass or failures are documented as unrelated with evidence
+- no TODO, stub, placeholder, dead branch, or unwired path was introduced
+
+## Phase 5: Closure and PR-Ready Output
+
+Goal: leave the issue ready for human review or PR creation.
+
+1. Inspect the final diff:
+   - `git diff --stat`
+   - `git diff`
+   - `git diff --check`
+2. Verify no unrelated files changed.
+3. Write `09-pr-body.md` using `assets/pr-template.md`.
+4. Prepare a conventional commit message:
+   - `fix(<scope>): <short issue-specific description>`
+5. If the user explicitly asked you to commit or open a PR, do so only after confirming there are no unrelated changes.
+6. Final response must include:
+   - root cause with file/line references
+   - exact change summary
+   - tests and checks run with results
+   - regression coverage
+   - unresolved risks, if any
+   - PR body or PR link if created
+
+## Test Validation and Drift Review
+
+This section applies to every phase.
+
+Whenever any of the following change, actively review tests for drift:
+
+- command selection logic or framework detection
+- fixture expectations or test helper behavior
+- workflow assertions or pipeline step ordering
+- scanner coverage behavior or tool registration
+- prompt content that affects agent behavior
+- documentation or comments claiming system behavior
+
+Requirements:
+
+1. Touched tests must be verified against current and intended behavior.
+2. Stale tests must be realigned to verified behavior, not left as drift.
+3. Prefer behavior-level validation over brittle string-only expectations.
+4. New behavior needs positive and negative cases.
+5. Boundary-critical or security-sensitive behavior needs adversarial cases.
+6. The release verification sweep must include a focused test-drift regression check.
+7. Do not accept work where tests pass by coincidence rather than correctness.
+
+## No-Gap Closure Checklist
+
+Before declaring the issue ready:
+
+- [ ] The reported symptom is reproduced or non-reproducibility is proven.
+- [ ] The root cause is localized to exact code and triggering conditions.
+- [ ] The fix addresses the root cause, not only the visible symptom.
+- [ ] Every changed path is wired into the actual runtime path.
+- [ ] Public API, CLI, UI, persistence, config, and docs surfaces are checked where relevant.
+- [ ] Edge cases are tested or explicitly ruled out.
+- [ ] Regression test fails before the fix and passes after the fix when feasible.
+- [ ] Impacted tests, lint/type/build checks are run.
+- [ ] Independent critic review completed before user approval.
+- [ ] User approval obtained before implementation.
+- [ ] PR-ready summary is complete.
+
+## Escalation Triggers
+
+Stop and ask the user or present options when:
+
+- reproduction requires unavailable credentials, secrets, data, hardware, or external services
+- the issue is actually a feature request or product decision
+- a fix requires breaking public API compatibility
+- a data migration or destructive operation is required
+- root cause spans multiple subsystems and the approved scope is too narrow
+- the critic returns `BLOCKED`
+- confidence remains below 90% after reasonable investigation

--- a/.agents/skills/issue-tracer/assets/pr-template.md
+++ b/.agents/skills/issue-tracer/assets/pr-template.md
@@ -1,0 +1,36 @@
+# PR Description Template
+
+### Root Cause
+
+[One paragraph explaining what was broken, where, and why. Include file paths, symbols, line ranges, and triggering conditions.]
+
+### Fix
+
+[Concise description of the minimal patch and why it is necessary and sufficient.]
+
+- [Specific code change]
+- [Specific code change]
+- [Specific code change]
+
+### Tests
+
+- Regression test: `[command]` -> PASS
+- Impacted suite: `[command]` -> PASS
+- Lint/type/build/security checks: `[commands]` -> PASS
+
+### Regression Protection
+
+- [New/updated test path and scenario]
+- [Negative/boundary/adversarial case if relevant]
+- [Test drift review result]
+
+### Risk and Rollback
+
+- Risk level: [low/medium/high]
+- Rollback: [revert commit / disable flag / restore config / migration rollback]
+- Residual risk: [none or explicit risk]
+
+### Issue Closure
+
+Closes #[issue-number]
+

--- a/.agents/skills/issue-tracer/references/critic-gate.md
+++ b/.agents/skills/issue-tracer/references/critic-gate.md
@@ -1,0 +1,122 @@
+# Independent Critic Gate
+
+Use this reference in Phase 3 before presenting the plan to the user.
+
+## Critic Mission
+
+The critic is adversarial and independent. It does not improve the wording of the plan. It tries to prove that the plan would fail to fully close the issue.
+
+The critic reviews only evidence and plan quality. It must not write production code.
+
+## Preferred Invocation
+
+If subagent delegation is available, launch a separate critic with this prompt:
+
+```markdown
+You are an independent critic reviewing an issue-tracer fix plan before implementation.
+
+Your task is to find gaps, unwired functionality, unsupported assumptions, missed edge cases, missing tests, unsafe scope, and root-cause errors.
+
+Read these artifacts:
+- 01-issue-summary.md
+- 02-reproduction.md
+- 03-localization-log.md
+- 04-root-cause.md
+- 05-fix-plan.md
+
+Also inspect any files referenced in the plan. Do not trust summaries if the underlying code is available.
+
+Return exactly:
+
+# Critic Review
+
+## Verdict
+APPROVE / NEEDS_REVISION / BLOCKED
+
+## Evidence Sufficiency
+[Is root cause proven? What evidence is missing?]
+
+## Plan Correctness
+[Would the selected fix address the root cause?]
+
+## Unwired Functionality
+[Any entry point, export, caller, config, route, UI path, CLI path, docs path, or test path not connected?]
+
+## Edge Cases
+[Missed null/empty/error/concurrent/idempotent/security/backward-compat cases.]
+
+## Test Gaps
+[Positive, negative, regression, integration, fixture, drift, and adversarial gaps.]
+
+## Scope Risk
+[Overreach, underreach, public API, migration, external service, or rollout risks.]
+
+## Required Revisions
+- [Required change or NONE]
+```
+
+## Fallback Invocation
+
+If no independent subagent is available, create `06-critic-review.md` with:
+
+```markdown
+# Critic Review
+
+Fallback self-critic: independent critic unavailable.
+
+## Verdict
+APPROVE / NEEDS_REVISION / BLOCKED
+
+## Evidence Sufficiency
+[Is root cause proven? What evidence is missing?]
+
+## Plan Correctness
+[Would the selected fix address the root cause?]
+
+## Unwired Functionality
+[Any entry point, export, caller, config, route, UI path, CLI path, docs path, or test path not connected?]
+
+## Edge Cases
+[Missed null/empty/error/concurrent/idempotent/security/backward-compat cases.]
+
+## Test Gaps
+[Positive, negative, regression, integration, fixture, drift, and adversarial gaps.]
+
+## Scope Risk
+[Overreach, underreach, public API, migration, external service, or rollout risks.]
+
+## Required Revisions
+- [Required change or NONE]
+```
+
+Write the full fallback review in one pass. Do not leave a stub artifact containing only the fallback disclosure.
+
+## Required Critic Questions
+
+The critic must answer:
+
+1. Does the reproduction actually match the issue, or did the tracer reproduce a nearby symptom?
+2. Is the claimed root cause necessary and sufficient?
+3. Could the fix make the test pass while leaving the real runtime path unwired?
+4. Are all callers/importers/entry points covered?
+5. Are config defaults, feature flags, docs, and generated code surfaces considered?
+6. Are both positive and negative tests included?
+7. Are boundary cases covered: null, empty, missing, malformed, duplicate, concurrent, retry, cancellation, timeout, permission denied, and partial failure?
+8. Does the patch preserve public API and backward compatibility?
+9. Does the plan avoid broad refactors and unrelated cleanup?
+10. Is rollback straightforward?
+
+## Verdict Semantics
+
+- `APPROVE`: No blocker remains. Minor suggestions may exist, but implementation can proceed after user approval.
+- `NEEDS_REVISION`: The plan is probably fixable, but one or more revisions are required before user approval.
+- `BLOCKED`: The plan lacks enough evidence, has a wrong root cause, requires a product decision, or needs unavailable context.
+
+## Revision Rules
+
+If the critic returns `NEEDS_REVISION` or `BLOCKED`:
+
+1. Revise `05-fix-plan.md`.
+2. Record the response to every critic item.
+3. Re-run the critic or perform a second critic pass.
+4. Do not present the plan as ready until blockers are resolved or explicitly escalated.

--- a/.agents/skills/issue-tracer/references/evidence-artifacts.md
+++ b/.agents/skills/issue-tracer/references/evidence-artifacts.md
@@ -1,0 +1,240 @@
+# Evidence Artifacts
+
+Use these templates to keep the investigation auditable and resumable.
+
+## `01-issue-summary.md`
+
+```markdown
+# Issue Summary
+
+## Source
+- Issue: [URL or user-provided text]
+- Repo: [owner/repo or local path]
+- Labels: [labels]
+- State: [open/closed/unknown]
+
+## Observed Behavior
+[What actually happens. Include exact errors and stack traces.]
+
+## Expected Behavior
+[What should happen.]
+
+## Reproduction Steps
+1. [Step]
+2. [Step]
+3. [Step]
+
+## Environment
+- Runtime:
+- OS/platform:
+- Browser/device:
+- Feature flags/config:
+- External services:
+
+## Acceptance Criteria
+- [ ] [Measurable behavior]
+- [ ] [Measurable behavior]
+
+## Ambiguities
+- [Question or missing input]
+```
+
+## `02-reproduction.md`
+
+```markdown
+# Reproduction Evidence
+
+## Commands Tried
+
+### Attempt 1
+- Command:
+- Exit code:
+- Result: CONFIRMED / NOT REPRODUCED / BLOCKED
+
+```text
+[Exact output]
+```
+
+## Minimal Reproduction
+- Test/script/checklist:
+- Why it matches the reported issue:
+
+## Reproduction Verdict
+[Confirmed, blocked, or non-reproducible with reason.]
+```
+
+## `03-localization-log.md`
+
+```markdown
+# Localization Log
+
+## Active Hypotheses
+
+### H1: [Hypothesis]
+- Status: active / confirmed / ruled_out / inconclusive
+- Suspected file/symbol:
+- Evidence for:
+- Evidence against:
+- Commands/tests:
+- Verdict:
+
+## Files Read
+- `path/file.ext:lines` - [why read] - [what was learned]
+
+## Searches Run
+- `rg "pattern"` - [result]
+
+## Tests/Commands Run
+- `command` - PASS/FAIL/BLOCKED - [meaning]
+
+## Ruled-Out Paths
+- [Path] - [why ruled out]
+```
+
+## `04-root-cause.md`
+
+```markdown
+# Root Cause
+
+## Summary
+[What failed, where, and why.]
+
+## Exact Location
+- File:
+- Symbol:
+- Lines:
+
+## Broken Contract
+[Invariant or behavioral contract violated.]
+
+## Triggering Conditions
+[Inputs/state/environment required.]
+
+## Evidence Chain
+1. [Symptom]
+2. [Code evidence]
+3. [Command/test evidence]
+4. [Ruled-out alternatives]
+
+## Confidence
+[0-100% with reason. Stop below 90%.]
+```
+
+## `05-fix-plan.md`
+
+```markdown
+# Fix Plan
+
+## Issue
+[Short summary.]
+
+## Root Cause
+[From 04-root-cause.md.]
+
+## Candidate Fixes
+| Candidate | Approach | Files | Pros | Cons | Verdict |
+|---|---|---|---|---|---|
+| A | [Minimal guard/logic/config/state/API fix] | [files] | [pros] | [cons] | selected/rejected |
+
+## Selected Fix
+[Exact behavioral change and why it is necessary and sufficient.]
+
+## Files Expected to Change
+- `path/file.ext` - [exact reason]
+
+## Impact Analysis
+- Callers/importers:
+- Tests/fixtures:
+- Config/docs:
+- API/UI/CLI:
+- Persistence/migrations:
+- Security/privacy:
+- Concurrency/idempotency:
+
+## Edge Cases
+- [edge] - covered by [test/check]
+
+## Test Plan
+1. [Failing regression test]
+2. [Impacted suite]
+3. [Lint/type/build/security checks]
+
+## Unwired Functionality Checklist
+- [ ] Entry point reaches new/changed logic.
+- [ ] All callers use the updated contract correctly.
+- [ ] Error path is observable and handled.
+- [ ] No new branch lacks tests or manual verification.
+- [ ] Documentation/comments match actual behavior.
+
+## Risk and Rollback
+- Risk:
+- Rollback:
+
+## Critic Status
+- Critic verdict:
+- Required revisions:
+```
+
+## `06-critic-review.md`
+
+```markdown
+# Critic Review
+
+## Verdict
+APPROVE / NEEDS_REVISION / BLOCKED
+
+## Blockers
+- [blocker]
+
+## Risks
+- [risk]
+
+## Missed Edge Cases
+- [edge case]
+
+## Test Gaps
+- [test gap]
+
+## Required Plan Revisions
+- [revision]
+```
+
+## `07-approved-plan.md`
+
+```markdown
+# Reviewed Plan Awaiting Approval
+
+[Copy final 05-fix-plan.md here.]
+
+## User Approval
+- [ ] User explicitly approved implementation on [date/time/session note]
+```
+
+## `08-test-results.md`
+
+```markdown
+# Test Results
+
+## Regression Test
+- Command:
+- Before fix: FAIL / not run with reason
+- After fix: PASS / FAIL
+
+## Impacted Tests
+- Command:
+- Result:
+
+## Quality Checks
+- Lint:
+- Typecheck:
+- Build:
+- Format:
+- Security/static checks:
+
+## Verification Reasoning
+[Why the fix is correct beyond merely making tests pass.]
+
+## Test Drift Review
+[Any stale tests found and how they were handled.]
+```
+

--- a/.agents/skills/issue-tracer/references/localization-playbook.md
+++ b/.agents/skills/issue-tracer/references/localization-playbook.md
@@ -1,0 +1,110 @@
+# Localization Playbook
+
+Use this playbook during Phase 2. The goal is not to read the most code. The goal is to build the shortest evidence chain from symptom to root cause.
+
+## Tier 1: Trace-Driven Localization
+
+Use when the issue includes a stack trace, failing test output, panic, exception, compiler error, log line, request ID, or command output.
+
+1. Extract file paths, symbols, line numbers, route names, command names, config keys, and exact error strings.
+2. Start from the first project-owned frame, not framework/library frames.
+3. Read the frame, its immediate caller, and any input validation or error-mapping code.
+4. Confirm whether the visible crash site is the cause or only the symptom.
+5. If the trace points to generic error handling, walk backward to the first domain-specific invariant break.
+
+Common trace interpretations:
+
+- Null/undefined/type errors often originate at a missing guard or wrong contract before the crash line.
+- Index/bounds errors often originate in filtering, slicing, pagination, or off-by-one logic.
+- Assertion failures often indicate an upstream invariant break.
+- Timeout/deadlock symptoms require call-chain, lock, retry, cancellation, and external-service review.
+- Serialization errors often require checking both producer and consumer schemas.
+
+## Tier 2: Semantic and Structural Localization
+
+Use when the stack trace is missing, generic, misleading, or incomplete.
+
+1. Convert issue text into search terms:
+   - user-visible strings
+   - endpoint names
+   - component labels
+   - command flags
+   - config names
+   - domain nouns and verbs
+2. Search broadly, then narrow:
+   - `rg "<exact error>"`
+   - `rg "<route-or-command>"`
+   - `rg "<domain term>|<config key>|<flag>"`
+   - `git grep "<tracked symbol>"`
+3. Build a candidate file table:
+   - file
+   - relevant symbol
+   - why it could cause the symptom
+   - confidence
+   - next evidence needed
+4. Inspect dependency direction:
+   - who calls this code
+   - what this code calls
+   - where state/config enters
+   - where errors are transformed
+5. Use git archaeology sparingly but deliberately:
+   - `git log --oneline -- <path>`
+   - `git show <commit> -- <path>`
+   - `git blame -L <start>,<end> -- <path>`
+
+## Tier 3: Hypothesis-Driven Localization
+
+Use when multiple plausible locations remain.
+
+1. Generate 2-5 competing hypotheses.
+2. For each hypothesis, define the evidence that would confirm it and the evidence that would falsify it.
+3. Test hypotheses in likelihood order.
+4. Keep no more than three active hypotheses.
+5. Do not preserve weak hypotheses once evidence contradicts them.
+
+Hypothesis format:
+
+```markdown
+### H[N]: [short name]
+The bug is in `path:symbol` because [specific condition] violates [specific contract], causing [reported symptom] when [triggering input/state].
+
+- Confirm if:
+- Falsify if:
+- Evidence:
+- Verdict:
+```
+
+## Granularity Rules
+
+Localize at multiple levels before planning a patch:
+
+1. File-level: which file owns the failing behavior.
+2. Element-level: which function/class/config/test helper is responsible.
+3. Line-level: which condition, call, assignment, invariant, or boundary check is wrong.
+
+Function or element-level evidence is usually the most useful planning granularity. Line-level evidence is required before editing, but avoid overfitting the plan to one line if the issue is a broken contract across a whole function.
+
+## Call-Chain Exploration
+
+When the failure propagates across components:
+
+1. Start at the failing entry point.
+2. Follow calls one layer at a time.
+3. At each layer, ask:
+   - what data enters
+   - what contract is assumed
+   - what state changes
+   - what errors are swallowed/transformed
+   - what output leaves
+4. Backtrack when evidence weakens.
+5. Record pruned branches in `03-localization-log.md`.
+
+## Stop Conditions
+
+Stop localization and escalate if:
+
+- the root cause requires unavailable production-only data
+- two hypotheses remain equally supported
+- the issue requires a product decision rather than a code correction
+- the suspected fix crosses subsystem boundaries beyond the approved scope
+

--- a/.agents/skills/qa-sweep/SKILL.md
+++ b/.agents/skills/qa-sweep/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: qa-sweep
+description: >
+  Apply when implementing features, fixing bugs, debugging errors, investigating failures,
+  tracing root causes, reviewing tech debt, tracing issues, planning fixes, or completing
+  any task. Enforces parallel sub-agent implementation, independent adversarial review,
+  and a 95% confidence gate before stopping.
+effort: high
+---
+
+## QA & Independent Review Protocol
+
+Follow this protocol on every implementation, fix, debugging, or review task.
+
+### Phase 1 — Parallel Implementation
+- Use parallel sub-agents to speed up independent units of work wherever possible.
+- Each sub-agent must read relevant source code end-to-end before making changes.
+- Reference official documentation to verify whether any behavior is intended before treating it as a bug.
+- Do not trust assumptions — prove every behavior against actual code.
+
+### Phase 2 — Independent Adversarial Review (Mandatory)
+After implementation, spawn a FRESH sub-agent that has not participated in any prior work. Give it this directive verbatim:
+> "Assume all work done by the implementing agent is incorrect until you can prove otherwise with
+> absolute evidence from the actual code. The implementing agent makes frequent mistakes and tends
+> to miss edge cases. Do not trust any claim without tracing it yourself. Review every change,
+> test, and edge case end-to-end through the real source."
+
+The review agent must:
+- Independently trace each change end-to-end through the codebase
+- Search for related issues and regressions the implementing agent may have introduced
+- Verify documented behavior vs. actual code behavior
+- Surface every edge case not explicitly covered
+
+### Phase 3 — Completeness Verification
+Spawn a SECOND independent agent to verify original planned work vs. delivered work:
+> "Assume nothing was completed correctly or fully. Map every originally planned item to actual
+> code changes and verify each one independently. Do not trust the implementing agent's report."
+
+### Stop Condition
+Do NOT stop until ≥95% confident that:
+- All issues, related issues, and edge cases are covered
+- All review agent findings have been addressed
+- Delivered work matches the original plan completely
+
+If below 95%, state what remains and continue working.

--- a/.agents/skills/research-first/SKILL.md
+++ b/.agents/skills/research-first/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: research-first
+description: >
+  Apply when planning fixes, investigating tech debt, architecting solutions, or
+  diagnosing unknown issues. Search online for current documentation and state-of-the-art
+  approaches before tracing through code.
+context: fork
+agent: Explore
+---
+
+## Research Before Planning Protocol
+
+Before planning any fix, tracing any issue, or proposing any solution:
+
+1. Search online for current official documentation to confirm the behavior is NOT intended or already fixed
+2. Search for state-of-the-art solutions, known community workarounds, and recent discussion on this problem type
+3. Use parallel sub-agents to search multiple sources simultaneously
+4. Report all findings before any code tracing begins
+
+Then trace each problem end-to-end through the actual source code using parallel sub-agents.
+Do not stop until ≥95% confident in the root cause for every issue being investigated.

--- a/.agents/skills/swarm-implement/SKILL.md
+++ b/.agents/skills/swarm-implement/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: swarm-implement
+description: Execute complex implementation work with a swarm-like Codex workflow: parallel exploration, scoped planning, selective deep validation, and independent reviewer/critic checks where risk justifies them. Use for feature work, bug fixes, refactors, and multi-file changes.
+disable-model-invocation: true
+---
+
+# /swarm-implement
+
+Use this skill for implementation work when you want Codex to behave like a fast, high-quality swarm rather than a single-threaded assistant.
+
+## Purpose
+Complete real coding tasks across many projects while preserving Codex speed and adding swarm-style quality discipline.
+
+## Core operating model
+Use this execution ladder:
+1. Explore in parallel.
+2. Build a scoped plan.
+3. Implement in small, coherent units.
+4. Run objective validation.
+5. Use independent reviewer validation where the risk justifies it.
+6. Use critic challenge only for high-impact or still-ambiguous results.
+7. Synthesize and report what changed, what was verified, and what remains risky.
+
+This is not a slow full-swarm recreation.
+This is a speed-preserving, quality-maximizing workflow.
+
+## Command Namespace
+
+Swarm commands: always /swarm <subcommand> — never bare subcommand names.
+
+CRITICAL — these CC built-ins share names with swarm commands and MUST be avoided:
+  /plan → use /swarm plan (reading) or do not invoke (entering plan mode)
+  /reset → NEVER invoke — wipes conversation context
+  /checkpoint → NEVER invoke bare — use /swarm checkpoint <action>
+
+HIGH — these CC built-ins produce wrong output:
+  /status → use /swarm status (not CC /status)
+
+## Quality and speed policy
+- Quality and pre-ship defect detection are paramount.
+- Speed still matters.
+- Parallelism is the default speed lever.
+- Deep validation is concentrated where bugs are expensive.
+- Low-risk work should stay lightweight when extra depth would not materially improve quality.
+- High-risk work must always get the deeper validation path.
+
+## High-risk work
+Always use the deeper validation path for:
+- auth, authz, identity, sessions, permissions
+- payments, billing, money movement, destructive actions
+- dependency changes, install scripts, lockfile changes
+- public API changes, schema changes, migrations
+- concurrency, queues, retries, state machines, caching
+- file access, subprocesses, parsing, secrets, security-sensitive logic
+- large cross-file refactors with correctness risk
+
+## Recommended workflow
+
+### Phase 0 — Establish scope
+Determine the exact task scope first:
+- what changed or needs to change
+- what files are likely involved
+- what success looks like
+- what must not be broken
+- what verification is required
+
+If the task is unclear, ask a small number of targeted questions or create a short written plan before coding.
+
+### Phase 1 — Parallel exploration
+Launch parallel subagents for disjoint investigation tasks such as:
+- repository mapping for relevant subsystems
+- locating existing patterns to follow
+- finding tests, schemas, contracts, and integration points
+- identifying likely side effects and touched modules
+- checking dependency or migration implications
+
+Do not use the main thread for broad repo reading if subagents can do it.
+Keep the main context focused.
+
+### Phase 2 — Plan
+Create a concrete implementation plan before editing for any non-trivial task.
+The plan should include:
+- files to change
+- intended behavior
+- risks and likely regressions
+- validation commands
+- whether reviewer and critic passes will be required
+
+### Phase 3 — Implement in scoped units
+Implement in coherent, reviewable chunks.
+Avoid giant speculative rewrites.
+Follow existing repository patterns unless there is a strong reason not to.
+
+### Phase 4 — Objective validation
+Always run the strongest objective checks available for the task:
+- tests
+- lint
+- typecheck
+- build
+- targeted repro scripts
+- local runtime verification where relevant
+
+If you cannot verify it, do not claim it is done.
+
+### Phase 5 — Independent reviewer validation
+Use an independent reviewer subagent when the task is:
+- high-risk
+- cross-file
+- behavior-sensitive
+- likely to hide edge-case bugs
+- security-sensitive
+- likely to produce false confidence from the implementation context
+
+Reviewer responsibilities:
+- inspect the implementation with fresh context
+- look for correctness bugs, edge cases, regressions, claim-vs-actual mismatches, and test blind spots
+- be hyper-critical and suspicious
+- default to disbelief until evidence supports the change
+- identify whether issues are CONFIRMED, DISPROVED, UNVERIFIED, or PRE_EXISTING when useful
+
+### Phase 6 — Critic challenge
+Use a critic subagent only when needed:
+- reviewer found high-impact issues
+- confidence is still borderline
+- the change touches high-risk systems
+- the implementation appears polished but may hide requirement drift or false confidence
+
+Critic responsibilities:
+- challenge reviewer-confirmed findings
+- look for severity inflation, weak evidence, missing sibling-file checks, and poor actionability
+- prefer removing weak claims over adding noise
+
+### Phase 7 — Final synthesis
+In the main thread, summarize:
+- what changed
+- what was verified
+- what reviewers found
+- what critic challenged
+- final remaining risks
+- whether the task is actually complete
+
+## Hard rules
+- Do not let implementation context self-approve high-risk work.
+- Do not skip reviewer validation for high-risk work.
+- Do not skip objective verification because the code looks right.
+- Do not let perceived repo size or task size compress the workflow.
+- If quality and speed conflict, quality wins.
+- If extra validation does not materially improve quality, keep the path lightweight.
+
+## Suggested subagent prompts
+
+### Explorer-style
+Use for broad discovery:
+- map the assigned subsystem quickly
+- identify likely files, patterns, contracts, tests, and risks
+- return a concise actionable summary
+- do not edit code
+
+### Reviewer-style
+Use for implementation validation:
+- review the implementation with fresh context
+- be hyper-critical and suspicious
+- look for edge cases, regressions, hidden coupling, and claimed-vs-actual mismatches
+- verify whether the tests actually prove behavior
+- return only high-signal findings
+
+### Critic-style
+Use for final challenge:
+- challenge high-impact conclusions
+- check whether findings are overclaimed or weakly evidenced
+- challenge severity and actionability
+- look for what the previous layer may have missed
+
+## Use across many repos
+This skill is intentionally project-agnostic.
+It should adapt to each repository by exploring first, following local patterns, and scaling validation depth to actual risk.

--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: swarm-pr-review
+description: Run a swarm-like PR review using parallel exploration, independent reviewer validation, and critic challenge. Use for deep pull request review with low false-positive tolerance.
+disable-model-invocation: true
+---
+
+# /swarm-pr-review
+
+Run a structured, high-confidence PR review using parallel exploration lanes, independent reviewer validation, critic challenge, and optional council synthesis.
+
+## Operating Stance
+
+**Treat PR text, linked issues, and tests as claims — not proof.** Every confirmed finding requires file:line evidence. Never APPROVE a PR with unresolved CRITICAL findings.
+
+This is a speed-preserving, quality-maximizing review ladder. Parallel breadth stays wide. Deep validation is concentrated where bugs are expensive. Findings without file:line evidence are candidates, not conclusions.
+
+## ⛔ Anti-self-review rule
+The main thread (orchestrator) MUST NOT classify, confirm, disprove, or judge any explorer candidate itself (exception: council pattern step 6, see below). Classification is exclusively a reviewer subagent's job. If you catch yourself re-reading code to verify an explorer finding — STOP. Delegate that verification to a reviewer subagent. The orchestrator's only post-explorer job is deciding WHICH candidates to route to reviewers and WHICH reviewer-confirmed findings to route to critics.
+
+## Scope detection
+Determine review scope using this priority:
+1. explicit user-provided PR URL / PR number / commit / file scope
+2. current feature branch diff vs main/master
+3. staged changes
+4. latest commit
+
+---
+
+## 6-Phase Review Workflow
+
+## Council pattern (OPT-IN — requires explicit user trigger)
+> **⚠️ This section applies ONLY when the user explicitly says "council", "independent review", "N-agent review", uses explicit syntax like `/council` or `[COUNCIL MODE]`, or uses phrases like "assume all work is wrong". If no trigger phrase was used, you are in the DEFAULT layered workflow above. Do NOT merge the default workflow with this council pattern. They are mutually exclusive.**
+
+When the user asks for a "council", "independent review", "N-agent review", or uses phrases like "assume all work is wrong", run the explorer lanes as a parallel **adversarial council**:
+
+1. Launch all council agents in a **single message with multiple Agent tool calls** so they run in parallel, in the background (`run_in_background: true`), using the `Explore` subagent type.
+2. Each agent is told to **assume all work is WRONG until code evidence proves otherwise** and to hunt for bugs in its lane only.
+3. Default lane set for a 5-agent council:
+   - correctness and edge cases
+   - security and trust boundaries
+   - dependency and deployment safety
+   - docs and intent-vs-actual
+   - tests and falsifiability
+   A 6th `performance and architecture` lane may be added when risk justifies it.
+4. Each agent's prompt must include: branch name, commit list (`git log origin/main..HEAD`), scope of files owned by that lane, explicit bug-hunting checklist, and a "return CONFIRMED / SUSPICIOUS / CLEAN with file:line evidence, cap N words" instruction.
+5. Agents are launched in parallel so the orchestrator must NOT duplicate their work. The main thread only collates, validates, and synthesizes.
+6. When all agents return, the main thread acts as the **independent reviewer**: re-read the flagged file:line evidence directly and classify each candidate CONFIRMED / DISPROVED / UNVERIFIED / PRE_EXISTING before reporting. DISPROVED findings must be called out — agents overclaim regularly.
+> Note: Step 6 (main-thread-as-reviewer) is specific to the council pattern. In the default workflow, reviewer validation MUST be delegated to a reviewer subagent per the anti-self-review rule above.
+7. Apply the **critic challenge** to every remaining CONFIRMED finding: challenge severity inflation, weak evidence, missing mitigating context (e.g., "is the architect single-threaded? is this exercised?"), and non-actionable fixes.
+8. The final synthesis must distinguish: real ship blockers, low-severity real issues, pre-existing accepted caveats, disproved agent claims, and follow-up quality work. Do not copy agent severities verbatim.
+
+---
+
+## Default 6-Phase Review Workflow
+
+### Phase 1: Intent Reconstruction (Obligation Extraction Cascade)
+
+Reconstruct what the PR is obligated to deliver before looking for bugs.
+
+**Deterministic precedence (highest to lowest):**
+1. Checkbox items in PR description
+2. Linked issues / tickets
+3. Commit scopes (what the commit says it does)
+4. Test names (what tests claim to verify)
+5. Interface diff (API/function signatures changed)
+6. LLM synthesis (only when no higher-precedence source exists)
+
+**Output: Obligation List (O-001, O-002, ...)**
+
+For each obligation, record:
+- Source (checkbox, issue, commit, test name, interface diff, LLM synthesis)
+- Verification status (UNVERIFIED → IN_PROGRESS → MET / NOT MET / UNVERIFIABLE)
+- Link to corresponding finding if non-met
+
+---
+
+### Phase 2: Parallel Explorer Lanes (6 lanes, launch in single message)
+
+Launch all 6 lanes in parallel in a **single message with multiple Agent tool calls** (`run_in_background: true`). Each lane produces candidate findings with exact file:line evidence — not final verdicts.
+
+| Lane | Focus | Lane-Specific Checklist |
+|------|-------|----------------------|
+| **Lane 1: Correctness** | Logic errors, null/undefined handling, race conditions, edge cases, off-by-one errors, incorrect operators | `null` checks, error path coverage, async/await correctness, loop termination, type coercion |
+| **Lane 2: Security** | Injection, auth bypass, secret exposure, privilege escalation, SSRF, path traversal, unsafe deserialization | Input sanitization, authnz enforcement points, credential handling, permission boundaries |
+| **Lane 3: Dependencies** | Import changes, version bumps, breaking API changes, new transitive deps, license issues | `package.json`/`requirements.txt`/Cargo.toml changes, lockfile drift, breaking API replacements |
+| **Lane 4: Docs vs Intent** | PR claims vs actual code changes, undocumented behavior, misleading variable names, absent changelog entries | Claims made in PR text vs what diff actually does, side effects not mentioned |
+| **Lane 5: Tests** | Coverage gaps, flaky patterns, weak assertions, test isolation violations, missing edge case tests | Assertion quality, mock isolation, happy-path-only coverage, missing error-path tests |
+| **Lane 6: Performance/Architecture** | Complexity changes, memory leaks, algorithmic regressions, coupling between modules, architectural debt | Cyclomatic complexity deltas, GC pressure, connection pool usage, shared mutable state |
+
+**Explorer output format per finding:**
+```
+[CANDIDATE] | severity | category | file:line | evidence_summary | confidence: LOW/MEDIUM/HIGH
+```
+
+Explorers optimize for **recall and speed** — over-reporting is expected. Do not interpret explorer output as final findings.
+
+---
+
+### Phase 3: Independent Reviewer Confirmation
+
+Re-read each candidate's file:line evidence directly. Validate every candidate that is:
+- HIGH or CRITICAL severity
+- Security-related
+- Business-logic-related
+- Claim-vs-actual-related
+- Cross-file or contract-sensitive
+- Likely to generate false positives without deeper context
+
+**Reviewer classifications:**
+
+| Classification | Meaning |
+|----------------|---------|
+| **CONFIRMED** | Evidence is real and the finding is valid |
+| **DISPROVED** | The candidate claim is incorrect or does not apply |
+| **UNVERIFIED** | Cannot determine validity from available evidence |
+| **PRE_EXISTING** | Issue exists on the base branch, not introduced by this PR |
+
+**Evidence classification:**
+
+| Type | Definition |
+|------|------------|
+| **STRUCTURALLY_PROVEN** | file:line evidence directly demonstrates the bug (e.g., missing null check, incorrect operator) |
+| **PLAUSIBLE_BUT_UNVERIFIED** | Code pattern suggests risk, but reachability or mitigating context unconfirmed |
+
+**DISPROVED findings must be called out explicitly** — agents regularly overclaim.
+
+---
+
+### Phase 4: Critic Challenge (HIGH/CRITICAL only)
+
+For every remaining CONFIRMED HIGH or CRITICAL finding, apply adversarial challenge:
+
+- **Severity inflation:** Is this truly HIGH/CRITICAL, or is it MEDIUM/LOW in practice?
+- **Weak evidence:** Does the file:line actually prove the finding, or just suggest it?
+- **Missing mitigating context:** Is there a schema validation check, middleware, framework default, or caller guard that prevents exploitation?
+- **Non-actionable fixes:** Is the suggested fix vague or impossible to implement correctly?
+- **Sibling-file gaps:** Did the review scope miss related files that must change together?
+
+Refuted findings are downgraded to **ADVISORY**.
+
+Run the **Runtime-Aware False-Positive Guard Checklist** (below) before confirming any finding.
+
+---
+
+### Phase 5: Synthesis
+
+**Obligation Assessment:**
+
+| Status | Meaning |
+|--------|---------|
+| **MET** | All obligations from this source are fulfilled by the PR |
+| **PARTIALLY MET** | Some obligations fulfilled, some not |
+| **NOT MET** | Obligations unfulfilled or actively violated |
+| **UNVERIFIABLE** | No evidence available to assess (commented-out code, feature-flagged) |
+
+**Findings Table:**
+
+| ID | Severity | Category | File:Line | Classification | Status |
+|----|----------|----------|-----------|----------------|--------|
+| F-001 | CRITICAL | Security | `src/auth.ts:47` | STRUCTURALLY_PROVEN | CONFIRMED |
+| F-002 | HIGH | Correctness | `src/parser.ts:112` | PLAUSIBLE_BUT_UNVERIFIED | CONFIRMED → ADVISORY (refuted by critic) |
+
+**Merge Recommendation:** See Merge Recommendation Table below.
+
+---
+
+### Phase 6: Council Variant (when `--council` flag)
+
+When user requests council review or uses phrases like "independent review", "5-agent review", "assume all work is wrong":
+
+1. Launch all 6 explorer lanes as **adversarial council agents** in parallel (`run_in_background: true`)
+2. Each agent assumes **all work is WRONG until code evidence proves otherwise**
+3. Each agent returns: `CONFIRMED / SUSPICIOUS / CLEAN` with file:line evidence, capped at N words
+4. Main thread acts as **independent reviewer** — re-reads file:line evidence directly and classifies candidates
+5. Apply critic challenge to reviewer-confirmed HIGH/CRITICAL findings
+6. **Council findings are supplementary, not authoritative overrides.** Council may miss context the main thread has. Do not adopt council severities verbatim without independent validation.
+7. Final synthesis merges validated council findings with main-thread-only findings, clearly labeled by source
+
+---
+
+## 11 Plugin-Specific Review Categories
+
+When reviewing the opencode-swarm plugin codebase, apply domain expertise across these categories:
+
+1. **Architect prompt integrity** — prompt injection, scope escape, system prompt leakage, unchecked `{{variable}}` interpolation
+2. **Council orchestration** — veto logic correctness, quorum enforcement, evidence integrity in verdict synthesis
+3. **Guardrail bypass paths** — scope guard evasion, delegation gate circumvention, rate limiter defeat
+4. **Evidence schema drift** — JSON schema evolution, missing required fields in evidence bundles, type mismatches
+5. **Knowledge base contract** — CRUD semantics violations, quarantine entry inconsistency, tier confusion (swarm vs hive)
+6. **Phase transition validation** — gate ordering correctness, retro requirement enforcement, premature phase completion
+7. **Model-to-role mapping** — agent prefix enforcement, tool restriction violations, unauthorized tool access
+8. **Config ratchet semantics** — once-enabled gates cannot be disabled, configuration drift, lock-state integrity
+9. **URL sanitization** — scheme allowlist enforcement, private IP blocking, credential stripping from user-supplied URLs
+10. **Git safety** — branch detection reliability, `reset --hard` safety checks, Windows path retry logic, .git directory protection
+11. **Test infrastructure** — bun:test usage, mock isolation correctness, cross-platform CI paths, `bun:test` vs `vitest` API compliance
+
+---
+
+## Runtime-Aware False-Positive Guard Checklist
+
+Before confirming **any** finding, verify all that apply:
+
+- [ ] **Schema validation gate:** Is the flagged code path behind a JSON schema validation check that would reject malformed input before it reaches the flagged line?
+- [ ] **Middleware interception:** Does middleware intercept and handle the request before the flagged code path executes?
+- [ ] **Framework default mitigation:** Does the framework's default behavior (e.g., Express JSON parsing, Django ORM parameterization) inherently prevent the vulnerability?
+- [ ] **Caller context correctness:** Is the caller context correct? Who actually invokes this code — only internal calls or also external/untrusted callers?
+- [ ] **Execution reachability:** Is the flagged path actually reachable in normal execution, or is it behind a feature flag, commented-out code, or dead branch?
+- [ ] **State-machine constraints:** Do state-machine transition rules prevent reaching the flagged state (e.g., ordering guarantees, mutex protection)?
+
+If **any** answer is yes and unaccounted for in the finding, the finding is downgraded to **ADVISORY** or **DISPROVED**.
+
+---
+
+## Merge Recommendation Table
+
+| Verdict | Condition |
+|---------|-----------|
+| **APPROVE** | Zero CRITICAL findings, zero unresolved HIGH findings, all obligations MET |
+| **APPROVE_WITH_NOTES** | Zero CRITICAL findings, HIGH findings are confirmed ADVISORY only (not ship blockers) |
+| **REQUEST_CHANGES** | Any unresolved HIGH finding; or multiple MEDIUM findings in the same functional area |
+| **BLOCK** | Any unresolved CRITICAL finding |
+
+---
+
+## Hard Rules
+
+1. **Never APPROVE with unresolved CRITICAL findings.**
+2. **Every confirmed finding must have file:line evidence.** No finding may be confirmed on sentiment, naming, or hunch alone.
+3. **Never invent facts not supported by the diff.** If the diff does not show it, it is not evidence.
+4. **Council findings are supplementary, not authoritative overrides.** Always re-validate council findings through the main thread.
+5. **DISPROVED findings must be called out explicitly.** Do not silently drop overclaiming agent findings.
+6. **Explorer lanes optimize for recall.** Do not treat explorer output as final verdicts.
+7. **Obligation precedence is deterministic.** Do not skip higher-precedence sources to fill gaps with LLM synthesis.
+
+---
+
+## Final Output
+
+## ⛔ Pre-synthesis gate (MANDATORY)
+Before writing the final output, you MUST print this checklist to stdout with filled values.
+Every blank field = gate not run = final output is INVALID.
+
+```
+[VALIDATION] reviewer dispatched: ___ (agent type, task description)
+[VALIDATION] reviewer returned: ___ (APPROVED / REJECTED / CONCERNS — copy verdict text)
+[VALIDATION] critic dispatched: ___ (agent type, task description) OR "SKIPPED — no reviewer-confirmed HIGH or borderline-confidence findings"
+[VALIDATION] critic returned: ___ (APPROVED / CONCERNS) OR "N/A"
+[VALIDATION] findings confirmed by reviewer: ___ (count)
+[VALIDATION] findings rejected by reviewer as false positive: ___ (count)
+[VALIDATION] findings escalated by reviewer to critic: ___ (count)
+[VALIDATION] findings confirmed by critic after challenge: ___ (count)
+```
+
+If the reviewer returned REJECTED for any candidate: you MUST route that rejection back to the coder (if implementation-related) or mark the explorer candidate as invalid (if evidence was insufficient). Do NOT silently downgrade a rejection.
+
+You MUST NOT write the final output section until this checklist has been printed with all fields filled.
+
+### Subagent failure handling
+If a reviewer or critic subagent fails, times out, or returns malformed output: mark all affected findings as UNVERIFIED, note the failure reason in the validation provenance, and proceed to final output. Do NOT silently drop findings or fabricate validation results.
+
+## Final output
+Produce:
+- PR intent
+- implementation summary
+- intended vs actual mapping
+- Validation provenance (REQUIRED — cannot be omitted):
+  - For each finding: which reviewer confirmed it and whether critic challenged it
+  - List any findings that were DISPROVED by reviewer (with reason)
+  - List any findings that were DOWNGRADED by critic (with reason)
+  - If zero findings: explicitly state "No findings — all lanes CLEAN" with a lane-by-lane summary
+- confirmed findings
+- pre-existing findings
+- unverified but plausible risks
+- test / coverage gaps
+- verdict
+- merge recommendation
+
+Do not let speed degrade validation quality.

--- a/.agents/skills/swarm/SKILL.md
+++ b/.agents/skills/swarm/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: swarm
+description: Enable a high-quality swarm-like Codex workflow for the current session, and optionally execute a task immediately using that mode. Uses parallel subagents for breadth, independent reviewer validation for precision, and critic challenge for final confidence. Use when the user wants swarm-like behavior, higher review rigor, or maximum quality without sacrificing Codex speed.
+disable-model-invocation: true
+argument-hint: "[optional task]"
+---
+
+# /swarm
+
+Enable swarm mode for the current session.
+If arguments are provided, enable swarm mode first and then execute that task using the swarm-like implementation workflow.
+
+Argument handling:
+- If no arguments are provided: only enable swarm mode.
+- If the first word of `$ARGUMENTS` is a **known plugin subcommand** (see list below): do NOT treat it as a swarm task. Instead, tell the user to run it as a slash command directly (e.g., `/swarm close`, `/swarm handoff`). These are OpenCode plugin commands handled by the swarm plugin's command system, not tasks for the swarm workflow. Do NOT try to interpret or execute them yourself.
+- Otherwise: enable swarm mode, then treat `$ARGUMENTS` as the task to execute immediately.
+
+### SWARM-NAMESPACED subcommands — DO NOT confuse with Codex built-in commands
+
+These are invoked as `/swarm <subcommand>`, NOT as bare `/subcommand`:
+
+- `/swarm status` — show current swarm status
+- `/swarm plan` — view or manage implementation plan
+- `/swarm agents` — list available swarm agents
+- `/swarm history` — view swarm execution history
+- `/swarm config` — view swarm configuration
+- `/swarm evidence` — view evidence files
+- `/swarm handoff` — hand off to another agent
+- `/swarm archive` — archive swarm sessions
+- `/swarm diagnose` / `/swarm diagnosis` — diagnose swarm issues
+- `/swarm preflight` — run preflight checks
+- `/swarm sync-plan` — sync plan with repository
+- `/swarm benchmark` — run benchmarks
+- `/swarm export` — export swarm data
+- `/swarm reset` — reset swarm state
+- `/swarm rollback` — rollback to previous state
+- `/swarm retrieve` — retrieve swarm data
+- `/swarm clarify` — clarify swarm task
+- `/swarm analyze` — analyze swarm execution
+- `/swarm specify` — specify swarm requirements
+- `/swarm brainstorm` — brainstorm swarm tasks
+- `/swarm qa-gates` — manage QA gates
+- `/swarm dark-matter` — detect hidden couplings
+- `/swarm knowledge` — manage knowledge base
+- `/swarm curate` — curate knowledge
+- `/swarm turbo` — enable turbo mode
+- `/swarm full-auto` — enable full auto mode
+- `/swarm write-retro` — write retrospective
+- `/swarm reset-session` — reset session
+- `/swarm simulate` — simulate swarm execution
+- `/swarm promote` — promote knowledge
+- `/swarm issue` — create issue
+- `/swarm pr-review` — review pull request
+- `/swarm checkpoint` — checkpoint session state
+- `/swarm close` — close swarm session
+
+### CRITICAL NAMING CONFLICTS
+
+These swarm subcommands share exact names with CC built-in commands.
+Invoking the bare form instead of `/swarm <name>` causes irreversible damage:
+
+| Swarm Command | CC Built-in | Damage |
+|---|---|---|
+| `/swarm plan` | CC `/plan` | Enters CC plan mode — blocks execution |
+| `/swarm reset` | CC `/reset` | Wipes entire conversation context |
+| `/swarm checkpoint` | CC `/checkpoint` | Reverts conversation history |
+
+All swarm commands: `/swarm <subcommand>`. Never the bare name.
+
+### COMMAND INVOCATION RULE
+
+All commands in this list are invoked as `/swarm <subcommand>`.
+Never invoke the bare subcommand as a standalone slash command.
+`/plan`, `/status`, `/reset`, `/checkpoint`, `/agents`, `/config`, `/export`, `/doctor`
+are Codex built-in commands with completely different behaviors.
+The `/swarm` prefix is mandatory, not optional.
+
+Examples:
+- `/swarm` — enable swarm mode only
+- `/swarm implement OAuth login without breaking existing session handling` — enable swarm mode, then execute the task
+- `/swarm fix the failing auth refresh tests and verify the session flow` — enable swarm mode, then execute the task
+- `/swarm close` — this is a plugin subcommand; tell the user it will be handled by the plugin command system
+- `/swarm handoff` — this is a plugin subcommand; tell the user it will be handled by the plugin command system
+
+## Goal
+Turn Codex into a swarm-like orchestrator while preserving Codex speed advantages.
+
+## What this mode changes
+When enabled, Codex should:
+- use parallel subagents aggressively for disjoint exploration, codebase mapping, and specialist review
+- separate candidate generation from validation
+- use independent reviewer and critic contexts that are explicitly skeptical and suspicious
+- avoid letting implementation and verification happen in the same context when verification quality would benefit from separation
+- keep quality as the only metric that matters
+- treat time pressure as nonexistent
+- preserve normal Codex strengths: parallel subagents, scoped exploration, and fast synthesis
+- protect speed by spending the deepest validation effort only where it materially reduces ship risk
+
+## Quality and speed policy
+Code quality and pre-ship defect detection are paramount.
+Speed still matters.
+The point of swarm mode is not to recreate slow serial swarm behavior inside Codex.
+The point is to keep Codex fast by parallelizing everything that can safely be parallelized while preserving a strict validation architecture.
+
+That means:
+- parallelize breadth aggressively
+- validate in depth selectively based on risk
+- avoid running the heaviest critic loop on every low-value issue
+- spend the most time on correctness, security, edge cases, regressions, and claimed-vs-actual mismatches
+- keep low-risk nits cheap
+
+If a workflow step does not materially improve quality, correctness, or trust, keep it lightweight or skip it.
+If a workflow step prevents real bugs from shipping, keep it even if it costs time.
+
+## Default triage model
+Use this default escalation ladder:
+1. Parallel exploration and mapping for breadth
+2. Parallel specialist review for disjoint concerns
+3. Independent reviewer validation for findings that are high-risk, ambiguous, cross-file, or likely false-positive-prone
+4. Critic challenge only for reviewer-confirmed high-impact findings or when confidence is still not high enough
+
+Do not force every task through every layer if the extra layer adds cost but not quality.
+Do not force high-risk work through the full ladder.
+
+High-risk work includes:
+- auth, authz, permissions, identity, session handling
+- payments, billing, data mutation, destructive actions
+- dependency changes, install scripts, lockfile changes
+- public API changes, schema changes, migrations
+- concurrency, retries, state machines, caching, queueing
+- security-sensitive parsing, file access, subprocesses, secrets
+
+Lower-risk work can use a lighter path if evidence is strong:
+- docs-only changes
+- localized refactors with strong existing test coverage
+- small UI copy changes
+- isolated low-risk cleanup with no behavior change
+
+## Enablement steps
+1. Create `.Codex/session/` if it does not exist.
+2. Create or overwrite `.Codex/session/swarm-mode.md` with the exact content below.
+3. Confirm that swarm mode is now enabled for this session.
+4. For the user's next complex task, follow the swarm-mode contract automatically unless the user disables it.
+
+Write this exact file:
+
+```md
+# Swarm Mode Contract
+
+Swarm mode is enabled for this session.
+
+## Core principles
+- Quality is the only success metric.
+- There is no time pressure.
+- There is no reward for finishing in fewer passes.
+- Large tasks require more disciplined verification, not less.
+- Use parallel subagents whenever scopes are disjoint and doing so does not reduce quality.
+- Keep breadth, validation, and final challenge in separate contexts when possible.
+
+## Role model
+- Explorer role: fast, broad, cheap, suspicious mapper and candidate generator
+- Reviewer role: independent validator of candidate findings, hyper-critical and skeptical
+- Critic role: final challenger of reviewer-confirmed findings, hyper-suspicious and willing to overturn weak claims
+- Main thread: architect/orchestrator that assigns scopes, persists state, and synthesizes only validated outputs
+
+## Hard rules
+- Explorer findings are candidate findings, not final findings.
+- Candidate findings should be validated by an independent reviewer context before being treated as confirmed whenever the task is important enough to justify it.
+- Reviewer should default to DISPROVED or UNVERIFIED unless the finding is actually supported by code evidence and, when relevant, runtime-aware verification.
+- Critic should challenge reviewer-confirmed findings in small batches.
+- If quality and speed conflict, quality wins.
+- Do not batch more aggressively or skip validation because the repo is large.
+- Premature completion is a failure state.
+
+## Parallelism policy
+Use parallel subagents for:
+- repository mapping
+- subsystem investigation
+- test analysis
+- security review
+- performance review
+- dependency review
+- docs/release drift review
+- candidate-finding validation when clusters are disjoint
+- changed-area impact analysis
+- implementation planning across disjoint modules
+
+Do not parallelize tasks that edit the same files unless the workflow explicitly isolates them.
+Parallelism is the default speed lever.
+Use it aggressively wherever scopes are disjoint.
+Serial work is for synthesis, conflict-prone edits, and final high-confidence validation.
+
+## Default execution pattern for complex tasks
+1. Explore and map in parallel.
+2. Build a plan.
+3. Implement in scoped units.
+4. Validate with independent reviewer context.
+5. Challenge with critic context when needed.
+6. Synthesize only validated results.
+
+## Anti-rationalization rules
+Ignore these thoughts:
+- "This is probably fine"
+- "The broad reviewer is good enough"
+- "I can save time by merging validation stages"
+- "This repo is too large to review this carefully"
+- "I should move on because this is taking too long"
+
+If any of those appear, slow down and return to the workflow.
+```
+
+## How to behave after activation
+For subsequent complex tasks in this session:
+- spawn subagents in parallel for disjoint scopes
+- use one or more reviewer subagents to validate findings from explorer subagents or to validate implementation quality
+- use critic subagents only after reviewer validation, not as the primary false-positive filter
+- synthesize outputs with explicit status labels such as candidate, confirmed, disproved, unverified, or pre-existing when useful
+- keep the main context clean by pushing reading-heavy work into subagents
+
+## If a task argument was provided
+After enabling swarm mode, immediately execute `$ARGUMENTS` using this swarm-like implementation ladder:
+1. Determine exact scope and success criteria.
+2. Launch parallel exploration for disjoint investigation work.
+3. Create a scoped plan.
+4. Implement in coherent units.
+5. Run objective verification.
+6. Use independent reviewer validation where risk justifies it.
+7. Use critic challenge only for high-impact or still-ambiguous results.
+8. Summarize what changed, what was verified, and what risks remain.
+
+Do not treat the presence of `$ARGUMENTS` as permission to skip the swarm-mode contract.
+The task must still follow the quality, speed, and risk-tiering rules above.
+
+## Suggested subagent prompts
+When you need an explorer-style subagent, tell it:
+- map the assigned scope quickly
+- find candidate issues only
+- be broad and suspicious
+- return exact file/line references
+- do not present findings as final truth
+
+When you need a reviewer-style subagent, tell it:
+- validate candidate findings from another subagent
+- be hyper-critical and default to disbelief
+- actively look for mitigating context that disproves each candidate
+- use runtime-aware validation when safe and needed
+- classify each item as CONFIRMED, DISPROVED, UNVERIFIED, or PRE_EXISTING
+
+When you need a critic-style subagent, tell it:
+- challenge reviewer-confirmed findings in small batches
+- look for overclaimed severity, weak evidence, missing sibling-file checks, and poor actionability
+- prefer removal over noisy weak inclusion
+
+## Notes
+- This skill enables swarm mode for the current session by writing a session file.
+- It does not permanently change project behavior.
+- Re-run `/swarm` if needed after clearing or resetting session context.

--- a/.agents/skills/tech-debt-ci-review/SKILL.md
+++ b/.agents/skills/tech-debt-ci-review/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: tech-debt-ci-review
+description: Deep technical debt and CI stability audit for identifying test theater, missing or mis-scoped tests, actual and potential test failures, flaky-test risk, dependency/toolchain brittleness, and structural debt that prevents PRs from going green safely.
+disable-model-invocation: true
+---
+
+# /tech-debt-ci-review
+
+Run a deep technical debt and CI stability audit of the current repository.
+
+## Mission
+
+Identify every meaningful source of:
+- technical debt with real CI impact
+- test theater
+- missing or mis-scoped tests
+- actual and potential test failures
+- CI instability
+- flaky-test risk
+- dependency/build/toolchain brittleness
+- verification gaps that prevent the repository from reaching and staying green in pull requests
+
+Do not build features.
+Do not do opportunistic cleanup for its own sake.
+Do not preserve noisy tests or workflows just because they make dashboards look busy.
+
+## Operating stance
+
+- Treat green-looking CI, high coverage, test names, comments, docs, release notes, and examples as claims or hints, not proof.
+- Treat code and tests as plausible until verified, not correct until disproven.
+- No finding is valid without exact file path and line evidence, or exact workflow/job/command evidence for CI-level issues.
+- No approval-like conclusion is valid without positive evidence of what was checked.
+- If a finding depends on runtime behavior, framework behavior, timing, sequencing, state, or exploitability, do not over-claim from static code alone if safe validation is available.
+
+## Quality-over-speed directive
+
+Confidence in the test and CI signal is the main success metric.
+There is no time pressure.
+There is no reward for finishing in fewer passes.
+Do not batch more aggressively, skip validation, or stop early because the repository is large or the audit feels expensive.
+Large codebases require more disciplined verification, not less.
+
+## Required workflow
+
+### Phase 0 — Inventory first
+Read enough of the repo to build a quality and CI map:
+- dependency manifests and lockfiles
+- CI workflows and job configs first
+- top-level README/docs
+- existing QA reports, CI handoffs, or known-failure notes if present
+- test runner configuration
+- any task brief / PR text / diff context if relevant
+
+Build a map of:
+- tech stack
+- CI surface
+- test surface
+- quality surface
+- debt surface
+- public/risky surfaces
+
+### Phase 1 — Parallel exploration
+Use subagents for breadth so the main context stays clean.
+Split the repo into disjoint scopes and/or audit families.
+Prefer small, focused scopes over giant repo-wide sweeps.
+
+Recommended exploration lanes:
+- CI workflow and job graph correctness
+- test theater and falsifiability
+- flaky-test risk and nondeterminism
+- required-vs-optional test necessity
+- debt hotspots and maintainability drag
+- dependency/build/toolchain brittleness
+- behavioral regression exposure in risky modules
+
+Explorer-style subagents should:
+- read every file in their assigned scope
+- stay focused on one scope or issue family
+- return candidate findings only, not final truth
+- cite exact paths and lines
+- call out where deeper validation is needed
+
+### Phase 2 — Candidate validation in a fresh reviewer context
+Treat exploration output as a hypothesis engine, not a final verdict.
+Use one or more fresh reviewer contexts to validate candidate findings.
+
+For each candidate finding, classify exactly one:
+- CONFIRMED
+- DISPROVED
+- UNVERIFIED
+- PRE_EXISTING
+
+Reviewer must:
+1. Re-open the exact files and lines referenced by the explorer
+2. Read enough surrounding context to judge correctly
+3. Check callers, callees, tests, config, CI jobs, manifests, scripts, docs, and runtime assumptions as needed
+4. Check whether a mitigating control invalidates the candidate
+5. Run the smallest safe validation loop available when the claim depends on runtime behavior, timing, sequencing, or environment state
+6. Reclassify severity if the explorer overclaimed it
+7. Record the reason for disproof when rejecting a candidate
+
+If the issue cannot be proven due to ambiguity or missing context, mark it UNVERIFIED, not DISPROVED.
+
+### Phase 3 — Audit checklist
+Apply this checklist across the repo:
+
+1. Actual CI failure risk
+- broken workflow YAML or invalid job wiring
+- incorrect needs/dependency graph
+- CI commands that do not match real repo tooling
+- matrix values or OS assumptions likely to fail
+- caches restoring incompatible artifacts
+- missing setup/bootstrap steps
+- local-only assumptions in CI
+- required checks whose producer/consumer contracts have drifted
+
+2. Test theater
+- tests asserting only existence, truthiness, or snapshots with no behavioral meaning
+- tests that would pass if the implementation were removed
+- tests validating mocks instead of behavior
+- edge-case-named tests that only exercise happy path
+- coverage theater that ignores critical paths
+
+3. Need for tests
+- changed behavior with no regression tests
+- public API/schema changes with no protective tests
+- critical paths lacking focused tests
+- expensive edge cases not covered
+- places where tests are unnecessary or low ROI
+- opportunities to replace brittle E2E with cheaper lower-level tests
+
+4. Actual and potential test failures
+- currently failing tests
+- tests likely to fail in CI despite passing locally
+- environment-sensitive, order-sensitive, timing-sensitive, or race-prone tests
+- hidden shared state between tests
+- improper cleanup/teardown
+- dependence on wall clock, timezone, locale, random seeds, network, filesystem, temp paths, or machine performance
+- brittle selectors or snapshot churn
+- hidden credential or unavailable service assumptions
+
+5. Flaky-test risk
+- intermittent assertions
+- retries masking failures instead of fixing them
+- sleeps, polling hacks, fixed delays
+- nondeterministic data generation without seeding
+- parallel execution hazards
+- flaky fixture setup or external dependency reliance
+- quarantine/retry practices that keep CI green while hiding root causes
+
+6. Mutation-minded test quality
+Use mutation thinking even if no mutation tool exists.
+For important tests, ask:
+- would this fail if the function returned early?
+- would it fail if a boolean were inverted?
+- would it fail if an error path were swallowed?
+- would it fail if a result were hardcoded?
+- would it fail if the dependency call were skipped?
+If not, the test is likely theater or too weak.
+
+7. Technical debt with CI impact
+- duplicated logic increasing bug-fix surface area
+- high-complexity modules hard to test safely
+- hidden coupling across modules or fixtures
+- stale abstractions and wrappers with no value
+- outdated or partially migrated tooling
+- dead code or dead tests raising maintenance cost
+- brittle build/bootstrap flows
+- lack of ownership signals for flaky tests or red suites
+
+8. Dependency, build, and toolchain brittleness
+- phantom or suspicious dependencies
+- undeclared runtime tools
+- local and CI install/build drift
+- lockfile or version drift
+- cross-platform dependency issues
+- build scripts relying on hidden global tools
+- optional tools treated as required without guardrails
+
+9. Intended-vs-actual verification for CI and testing
+For every important workflow claim, verify whether the repo actually does what it claims, for example:
+- PRs are green by default
+- tests catch regressions
+- lint/typecheck/build are enforced
+- reviewers can trust CI
+- this suite protects behavior X
+
+### Phase 4 — Runtime-aware validation
+Use runtime validation selectively, not blindly.
+If a candidate depends on actual behavior, timing, workflow sequencing, role/state transitions, or environment interaction, use the smallest safe validation loop available.
+Do not use retries as proof of correctness.
+Retries can help separate flaky from deterministic failures, but they are not a fix.
+
+### Phase 5 — Final output
+Write the final report to `tech-debt-report.md`.
+
+Use this structure:
+
+# Technical Debt and CI Stability Report
+Generated: [timestamp]
+Scope: [scopes and artifacts covered]
+Files reviewed: [count]
+Parallel exploration used: YES | NO
+Independent reviewer validation used: YES | NO
+Runtime validation used: YES | NO
+
+## Executive Summary
+[2-4 sentences]
+
+## Current PR/CI Blockers
+[only issues actively breaking or very likely to break PR CI]
+
+## Critical and High Findings
+[full detail for CONFIRMED and PRE_EXISTING only]
+
+## Test Theater Findings
+[tests that create confidence without protection]
+
+## Missing or Mis-Scoped Tests
+[where tests are needed, where they are not needed, and where the testing pyramid is wrong]
+
+## Flaky-Test Risks
+[confirmed or likely nondeterminism sources]
+
+## Structural Debt with CI Impact
+[coupling, brittle setup, outdated tooling, duplicated logic, etc.]
+
+## Dependency and Toolchain Risks
+[build/install/runtime brittleness]
+
+## Coverage Notes
+[what remained unverified and why]
+
+## Validation Notes
+- candidate findings generated: N
+- reviewer confirmed: N
+- reviewer disproved: N
+- reviewer unverified: N
+- reviewer pre_existing: N
+
+## Green-PR Remediation Order
+1. current red-build blockers
+2. flaky tests and nondeterministic CI failures
+3. test theater in critical paths
+4. missing tests for expensive regressions
+5. structural debt directly causing CI and change fragility
+6. lower-value cleanup only after the above
+
+When presenting the report, include:
+1. the current PR/CI blockers in one-line form
+2. the most important test theater patterns
+3. the highest-value missing-test gaps
+4. the top flaky-test risks
+5. the minimal remediation order required to get PR CI trustworthy and green
+
+## Final rules
+- No finding without exact evidence.
+- No approval-like conclusion without positive evidence of what was checked.
+- If a candidate cannot be proven, mark it UNVERIFIED rather than CONFIRMED.
+- Do not recommend tests that do not materially improve defect detection.
+- Do not preserve test theater just because it makes dashboards look good.
+- The point is not to maximize test count or finding count.
+- The point is to maximize confidence that PR CI can go green without unsafe bypasses.

--- a/.agents/skills/unswarm/SKILL.md
+++ b/.agents/skills/unswarm/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: unswarm
+description: Disable swarm mode for the current Codex session and return to normal behavior.
+disable-model-invocation: true
+---
+
+# /unswarm
+
+Disable swarm mode for the current session.
+
+## Steps
+1. If `.Codex/session/swarm-mode.md` exists, delete it.
+2. Confirm that swarm mode is now disabled.
+3. Resume normal Codex behavior for future tasks.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: writing-tests
+description: >
+  Apply when writing tests, modifying test files, fixing test failures, debugging CI failures,
+  adding test coverage, creating adversarial tests, or reviewing any file under tests/.
+  Also apply when implementing features or fixes that require corresponding test changes.
+  Enforces bun:test framework rules, mock isolation, cross-platform compatibility (Linux,
+  macOS, Windows), and CI pipeline awareness. Load this skill before touching any test file.
+effort: medium
+---
+
+# Writing Tests for opencode-swarm
+
+## Framework: bun:test Only
+
+All test files MUST import from `bun:test`:
+
+```typescript
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+```
+
+Bun provides a vitest compatibility layer (`vi.mock`, `vi.fn`, `vi.spyOn`) that works on Linux and macOS. However, `vi.mock()` has critical isolation bugs in Bun when multiple test directories run in the same process. Prefer `bun:test` native APIs:
+
+| vitest API | bun:test equivalent | Notes |
+|-----------|-------------------|-------|
+| `vi.fn()` | `mock(() => ...)` | Import `mock` from `bun:test` |
+| `vi.spyOn(obj, method)` | `spyOn(obj, method)` | Import `spyOn` from `bun:test` |
+| `vi.mock('module', factory)` | `mock.module('module', factory)` | Import `mock` from `bun:test` |
+| `vi.restoreAllMocks()` | `mock.restore()` | Call in `afterEach` |
+
+## Mock Isolation Rules
+
+**CRITICAL: Module-level mocks leak across test files within the same Bun process.**
+
+The CI pipeline runs test directories in groups. All files in a group share one Bun process and one module cache. A `vi.mock()` or `mock.module()` call in file A replaces the module for file B if they run in the same group.
+
+### Rules
+
+1. **Never mock a module that another test file in the same CI group imports directly.** If `tests/unit/cli/run-dispatch.test.ts` mocks `../../src/commands/agents.js`, then `tests/unit/commands/agents.test.ts` (in the same group) will get the mock instead of the real module.
+
+2. **If you must use module-level mocks, isolate the test in its own CI step** or use dependency injection instead of module replacement.
+
+3. **Never create circular mock imports.** This pattern deadlocks Bun:
+```typescript
+// BROKEN — imports from the module it's about to mock
+import { realFn } from '../../src/module.js';
+vi.mock('../../src/module.js', () => ({
+  realFn: (...args) => realFn(...args),  // circular!
+  otherFn: vi.fn(),
+}));
+```
+Instead, inline the function logic or extract the real functions into a separate utility module.
+
+4. **Prefer constructor/parameter injection over module mocking.** The swarm's hook factories (`createScopeGuardHook`, `createDelegationLedgerHook`, etc.) accept injected dependencies — test them by passing mock callbacks, not by replacing modules.
+
+## CI Pipeline Structure
+
+The CI runs on three platforms (ubuntu, macos, windows). Tests are split into sequential steps within each platform's job.
+
+**Per-file isolation:** Each test file runs in its own Bun process via `for f in dir/*.test.ts; do bun --smol test "$f"; done`. This prevents module cache poisoning between files within the same step.
+
+**Cascade termination:** Each step uses `exit $failed` — the first failing step terminates the entire platform's job. This means failures in later steps are hidden until earlier steps pass. When fixing Windows issues, expect to peel back layers: fixing Step 4 may reveal a failure in Step 5 that was previously hidden.
+
+```
+Step 1: hooks - guardrails            (Linux/macOS only, skipped on Windows)
+Step 2: hooks - knowledge             (Linux/macOS only, skipped on Windows)
+Step 3: hooks - system-enhancer       (Linux/macOS only, skipped on Windows)
+Step 4: hooks - delegation + others   (Linux/macOS only, skipped on Windows)
+Step 5: commands + config             (all platforms)
+Step 6: cli                           (all platforms)
+Step 7: tools                         (all platforms)
+Step 8: services + build + quality + sast + sbom + scripts  (all platforms)
+Step 9: state + agents + knowledge + evidence + plan + misc (all platforms)
+```
+
+When writing a test, know which step your file will run in. Do not assume isolation from other files in the same step.
+
+**Job timeout: 15 minutes.** A single hanging test will kill the entire platform's test run.
+
+## File Placement
+
+### Convention
+
+| Test type | Location | When to use |
+|-----------|----------|-------------|
+| Unit tests for `src/hooks/*.ts` | `tests/unit/hooks/` | Testing hook factories and hook behavior |
+| Unit tests for `src/tools/*.ts` | `tests/unit/tools/` | Testing tool execute functions |
+| Unit tests for `src/commands/*.ts` | `tests/unit/commands/` | Testing CLI command handlers |
+| Unit tests for `src/config/*.ts` | `tests/unit/config/` | Testing schema validation, config loading |
+| Unit tests for `src/agents/*.ts` | `tests/unit/agents/` | Testing agent prompt generation, factory logic |
+| Colocated tests | `src/**/*.test.ts` | Integration-style tests tightly coupled to the source module |
+| Integration tests | `tests/integration/` | Cross-module workflows, plugin initialization |
+| Security tests | `tests/security/` | Adversarial input handling, injection resistance |
+| Smoke tests | `tests/smoke/` | Built package validation |
+
+### Naming
+
+- Base test: `<module>.test.ts`
+- Adversarial variant: `<module>.adversarial.test.ts`
+
+Only create an adversarial variant if it tests **distinct attack vectors** not covered by the base test. Do not duplicate base test assertions with different inputs — that's redundancy, not security coverage.
+
+### Regression tests (review-surfaced bugs)
+
+When fixing a bug surfaced by code review, swarm review, or post-merge audit, **always add a regression test** with the following shape so the test's purpose survives future cleanup:
+
+```typescript
+describe('<feature> — regression: <one-line description> (F#)', () => {
+  it('<exact behavior the bug violated>', () => {
+    // Previous code did <bad thing>: e.g. the regex `/^\.\/+/` only stripped
+    // a single leading `./`, so `././util.ts` survived as `./util.ts`.
+    expect(normalizeGraphPath('././util.ts')).toBe('util.ts');
+  });
+});
+```
+
+Rules:
+- The describe label includes the original finding ID (e.g. `F8`, `F9`, `F1.1`) so future readers can map back to the review.
+- The leading comment in the body explains the **prior buggy behavior** in concrete terms — what the code did before, not what it does now.
+- One regression test per finding. Do not pile unrelated assertions into a single regression block.
+
+Examples in-tree: `tests/unit/graph/graph-query.test.ts` (`normalizeGraphPath — regression (F8)`, `getBlastRadius — regression: depthReached (F9)`), `tests/unit/graph/import-extractor.test.ts` (`paren-preceded strings (F1)`, `member-expression require/import (F1.1)`).
+
+## Test Quality Standards
+
+### DO
+
+- Test real behavior: call the actual function with real inputs, assert on real outputs.
+- Test error paths: what happens with `null`, `undefined`, empty string, oversized input?
+- Use temp directories (`fs.mkdtemp`) for file I/O tests. Clean up in `afterEach`.
+- Assert on specific values, not just truthiness: `expect(result.status).toBe('pending')` not `expect(result).toBeTruthy()`.
+
+### DO NOT
+
+- **Do not test type definitions.** `expect(event.type === 'foo').toBe(true)` tests TypeScript, not your code.
+- **Do not test framework behavior.** "Zod schema parses valid input" tests Zod, not your schema.
+- **Do not test test utilities.** If it only exists to support other tests, it doesn't need its own test.
+- **Do not mock everything.** If every dependency is mocked, you're testing the mock setup. Prefer real dependencies for pure functions and only mock I/O boundaries (filesystem, network, timers).
+- **Do not hardcode version numbers.** Version bumps are automated — a test asserting `version === '6.31.3'` breaks on every release.
+- **Do not use `sleep` or `setTimeout` for synchronization.** Use explicit signals, resolved promises, or `Bun.sleep()` with tight bounds.
+- **Do not spawn `cat /dev/zero`, `yes`, or other infinite-output commands.** Use `sleep 30` for "blocking command" tests.
+
+## Cross-Entry Invariants (config maps)
+
+When you modify any entry of a "map of agents/tools/roles" in `src/config/constants.ts` (`AGENT_TOOL_MAP`, `DEFAULT_MODELS`, `QA_AGENTS`, `PIPELINE_AGENTS`, etc.), there are tests that assert **parity across sibling entries**, not just shape of one entry.
+
+Known parity assertions:
+
+| Test | Invariant |
+|---|---|
+| `tests/unit/config/critic-registration.test.ts:67` | `AGENT_TOOL_MAP.critic_sounding_board.length === AGENT_TOOL_MAP.critic.length` |
+| `tests/unit/config/agent-tool-map.test.ts:26` | `AGENT_TOOL_MAP.architect.length` is strictly greater than every other agent's |
+| `tests/unit/config/agent-tool-map.test.ts:34` | every subagent's tool list `<= 20` entries |
+| `tests/unit/config/constants.test.ts:48` | `ALL_SUBAGENT_NAMES.length === 13` |
+| `tests/unit/config/constants.test.ts:137` | `Object.keys(DEFAULT_MODELS).length === 14` |
+
+Workflow when adding a tool to a single agent:
+1. Add the entry.
+2. Run `bun --smol test tests/unit/config --timeout 60000` **before pushing**.
+3. If a parity test fails, decide: mirror the change to sibling agents (most common — see this PR's `repo_map` mirrored to `critic_sounding_board` + `critic_drift_verifier`), or update the invariant test if the design intent has actually changed.
+4. To inspect runtime shape quickly: `bun -e "import { AGENT_TOOL_MAP } from './src/config/constants.ts'; for (const [k,v] of Object.entries(AGENT_TOOL_MAP)) console.log(k, v.length);"`
+
+Do **not** push a constants change to CI without running the config test directory locally — these failures cascade through the per-OS unit jobs and waste minutes per push.
+
+## Cross-Platform Requirements
+
+All tests must pass on Linux, macOS, and Windows unless explicitly gated.
+
+### Skipping tests on specific platforms
+
+Use the `skipIf` chaining pattern:
+```typescript
+// Skip on Windows only
+test.skipIf(process.platform === 'win32')('test name', async () => { ... });
+
+// Skip on non-Linux (use when test relies on Linux-specific behavior)
+test.skipIf(process.platform !== 'linux')('test name', async () => { ... });
+
+// Skip entire describe block
+describe.skipIf(process.platform === 'win32')('group name', () => { ... });
+```
+
+### Temp directories and path handling
+- Use `path.join()` or `path.resolve()`, never string concatenation with `/`.
+- Temp directories: use `os.tmpdir()`, never hardcoded `/tmp`.
+- **CRITICAL: Wrap `mkdtempSync` with `realpathSync` when using `process.chdir`:**
+  ```typescript
+  // WRONG — on macOS, /tmp is a symlink to /private/tmp.
+  // mkdtempSync returns /tmp/... but process.cwd() resolves to /private/tmp/...
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
+  process.chdir(tempDir);
+  // process.cwd() !== tempDir on macOS!
+
+  // CORRECT — resolve symlinks first
+  const tempDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'test-')),
+  );
+  process.chdir(tempDir);
+  ```
+- File comparisons: normalize paths before comparing (`path.resolve(a) === path.resolve(b)`).
+
+### Permissions (`fs.chmodSync`)
+- `chmodSync` is a **no-op for directories** on Windows and unreliable for files.
+- Tests that rely on chmod to simulate permission errors should guard with platform checks:
+  ```typescript
+  if (process.platform !== 'win32') {
+    fs.chmodSync(filePath, 0o000);
+    // ... test permission error behavior ...
+    fs.chmodSync(filePath, 0o644); // restore
+  } else {
+    // On Windows, skip or use a mock to throw EPERM
+  }
+  ```
+- If the test asserts that the tool handles permission errors **gracefully** (returns success despite write failure), the test may pass on Windows even without chmod — the write just succeeds. Verify this before adding guards.
+
+### Symlinks
+- `fs.symlinkSync` requires **administrator or developer mode** on Windows.
+- Use a runtime capability check:
+  ```typescript
+  let canCreateSymlinks = false;
+  try {
+    const testLink = path.join(tempDir, '.symlink-test');
+    fs.symlinkSync(tempDir, testLink);
+    fs.unlinkSync(testLink);
+    canCreateSymlinks = true;
+  } catch {}
+
+  test.skipIf(!canCreateSymlinks)('symlink test', async () => { ... });
+  ```
+
+### Process spawning
+- Use `.cmd` extension on Windows for npm/bun binaries: `process.platform === 'win32' ? 'bun.cmd' : 'bun'`.
+- Use array-form `spawn`/`spawnSync`, never shell string commands.
+- **`npx` in empty temp dirs hangs on Windows.** If a test creates a temp directory with a `package.json` (for framework detection) and then calls a tool that spawns `npx vitest run` or similar, the spawn will hang until the test timeout fires. Skip these tests on non-Linux:
+  ```typescript
+  // Flaky on macOS/Windows: spawns vitest in temp dir without node_modules
+  test.skipIf(process.platform !== 'linux')(
+    'test that triggers process execution',
+    async () => { ... },
+    15000,
+  );
+  ```
+
+### Timestamps
+- Avoid comparing strings that embed `new Date().toISOString()`. Two sequential calls can span a millisecond boundary, especially on Windows CI. Strip or normalize volatile timestamps before comparison:
+  ```typescript
+  const stripTimestamp = (s: string) =>
+    s.replace(/Updated: \d{4}-\d{2}-\d{2}T[\d:.]+Z/, 'Updated: <FROZEN>');
+  expect(stripTimestamp(output1)).toBe(stripTimestamp(output2));
+  ```
+
+## Running Tests
+
+> **⚠️ Do NOT use the OpenCode `test_runner` tool to validate the full repo.** It is for targeted agent validation with explicit `files: [...]` or small targeted scopes. `scope: 'all'` requires `allow_full_suite: true` and is intended for opt-in CI mirrors only. Broad scopes can stall or kill OpenCode before the `MAX_SAFE_TEST_FILES = 50` (`src/tools/test-runner.ts:26`) guard fires. For repo validation, use the shell commands below — per-file isolation loops match CI behavior. `allow_full_suite` should be used only when intentional and justified in the PR description. See [`AGENTS.md`](../../../AGENTS.md) invariant 6 for the full contract.
+
+```bash
+# Full suite (all platforms)
+bun test
+
+# Single file
+bun test tests/unit/hooks/scope-guard.test.ts
+
+# Single directory
+bun --smol test tests/unit/hooks --timeout 30000
+
+# CI-equivalent run (per-file isolation, matches actual CI behavior)
+for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 120000; done
+
+# Quick directory run (faster but may have cross-file cache pollution)
+bun --smol test tests/unit/cli --timeout 120000
+bun --smol test tests/unit/commands tests/unit/config --timeout 120000
+```
+
+The `--smol` flag reduces Bun's memory footprint. Use it when running large directories (50+ files).
+
+The `--timeout 120000` flag sets per-test timeout to 120 seconds. Individual tests should complete in under 5 seconds. If a test needs more than 10 seconds, it's doing too much — split it or mock the slow dependency.
+
+**Note:** CI runs each file in its own Bun process (`for f in dir/*.test.ts; do bun --smol test "$f"; done`). Running an entire directory at once (`bun --smol test tests/unit/tools/`) can mask cache-poisoning issues that only appear in CI. When debugging CI failures, test files individually.
+
+## Debugging CI failures
+
+When CI reports a `unit (ubuntu-latest|macos-latest|windows-latest)` failure:
+
+1. **Identify the actual failing test from the job log first.** Do not assume it's a pre-existing failure based on a local repro of a different test. Open the failing job's URL (`https://github.com/<owner>/<repo>/actions/runs/<run-id>/job/<job-id>`) and find the `<file>:<line>` in the Bun output. WebFetch can scrape this if the `gh` CLI isn't available.
+2. **Reproduce that exact file locally** with the per-file CI command:
+   ```bash
+   bun --smol test tests/unit/<dir>/<file>.test.ts --timeout 30000
+   ```
+3. **Then check if the same failure reproduces on `main`.** If yes, document as pre-existing in the PR description and continue with your branch's work; do not silently inherit the failure.
+4. **For dist-check failures:** any change under `src/` that the bundler picks up requires `bun run build` + commit of `dist/` in the same PR. The job compares committed `dist/` against a fresh build.
+5. **For matrix-OS-only failures:** check `process.platform` guards, `mkdtempSync` realpath wrapping, chmod guards, symlink capability checks, and `npx`-spawn skips (sections above).
+
+## Before Submitting
+
+1. Run the tests for your changed files: `bun test path/to/your.test.ts`
+2. Run the full CI group your tests belong to (see pipeline structure above)
+3. Verify no `process.cwd()` usage — use the `directory` parameter from `createSwarmTool` or hook constructor
+4. Verify no hardcoded paths (`/tmp/...`, `C:\...`) — use `os.tmpdir()` + `path.join()`
+5. Verify mocks are restored in `afterEach` if using `spyOn` or `mock.module`
+6. Verify `mkdtempSync` is wrapped with `realpathSync` if you use `process.chdir` on the result
+7. Verify `chmodSync` calls are guarded with `process.platform !== 'win32'`
+8. Verify symlink creation is guarded or uses a `canCreateSymlinks` capability check
+9. Verify no `new Date().toISOString()` in equality assertions — strip volatile timestamps
+10. Verify tests that spawn `npx`/`vitest`/`jest` in temp dirs are skipped on non-Linux

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -94,16 +94,15 @@ async def register(
             "INSERT INTO users (username, hashed_password, full_name, role, is_active) VALUES (?, ?, ?, ?, 1)",
             (body.username, hashed_pw, body.full_name, role),
         )
-        db.commit()
         user_id = cursor.lastrowid
+
+        # Keep user creation and default access grants in one transaction.
+        _auto_assign_user_to_defaults(db, user_id)
+        db.commit()
     except Exception:
         db.rollback()
-        logger.error("Failed to create user", exc_info=True)
+        logger.error("Failed to create user with default assignments", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again later.")
-
-    # Auto-assign user to Default org, All Users group, and vault 1 access
-    _auto_assign_user_to_defaults(db, user_id)
-    db.commit()
 
     # Create tokens for auto-login
     access_token = create_access_token(user_id, body.username, role)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -199,14 +199,18 @@ async def create_user(
 
         # Auto-assign user to Default org, All Users group, and vault 1 access
         _auto_assign_user_to_defaults(conn, user_id)
-        conn.commit()
 
-        # Fetch the created user
+        # Fetch the created user before commit so response construction remains
+        # part of the same rollback boundary as creation and default grants.
         cursor = conn.execute(
             "SELECT id, username, full_name, role, is_active, created_at FROM users WHERE id = ?",
             (user_id,),
         )
         row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("Failed to retrieve created user")
+
+        conn.commit()
 
         return {
             "id": row[0],

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,6 +1,7 @@
 """User management routes (admin/superadmin only)."""
 
 import asyncio
+import logging
 import sqlite3
 from typing import List, Optional
 
@@ -18,6 +19,7 @@ from app.security import csrf_protect
 from app.services.auth_service import hash_password, password_strength_check
 
 router = APIRouter(prefix="/users", tags=["users"])
+logger = logging.getLogger(__name__)
 
 
 def _auto_assign_user_to_defaults(conn, user_id: int) -> None:
@@ -187,13 +189,12 @@ async def create_user(
                 detail=f"Username '{body.username}' already exists",
             )
 
-        # Insert the new user
+        # Insert the new user and default assignments in one transaction.
         cursor = conn.execute(
             """INSERT INTO users (username, hashed_password, full_name, role, is_active)
             VALUES (?, ?, ?, ?, 1)""",
             (body.username, hashed_password, body.full_name, body.role),
         )
-        conn.commit()
         user_id = cursor.lastrowid
 
         # Auto-assign user to Default org, All Users group, and vault 1 access
@@ -215,6 +216,16 @@ async def create_user(
             "is_active": bool(row[4]),
             "created_at": row[5],
         }
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        logger.error("Failed to create user with default assignments", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="An internal error occurred. Please try again later.",
+        ) from exc
     finally:
         pool.release_connection(conn)
 

--- a/backend/tests/test_user_creation_default_assignment_atomic.py
+++ b/backend/tests/test_user_creation_default_assignment_atomic.py
@@ -1,7 +1,6 @@
 """Atomic default-assignment coverage for user creation paths."""
 
 import sqlite3
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/backend/tests/test_user_creation_default_assignment_atomic.py
+++ b/backend/tests/test_user_creation_default_assignment_atomic.py
@@ -1,0 +1,244 @@
+"""Atomic default-assignment coverage for user creation paths."""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, Response
+from starlette.requests import Request
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/auth/register",
+            "headers": [],
+            "client": ("testclient", 50000),
+            "scheme": "http",
+        }
+    )
+
+
+def _init_db(tmp_path: Path) -> Path:
+    from app.models.database import init_db, run_migrations
+
+    db_path = tmp_path / "app.db"
+    init_db(str(db_path))
+    run_migrations(str(db_path))
+    return db_path
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
+
+
+def _assert_default_assignments(conn: sqlite3.Connection, user_id: int) -> None:
+    assert (
+        conn.execute(
+            """
+            SELECT 1
+            FROM organizations o
+            JOIN org_members om ON om.org_id = o.id
+            WHERE o.name = 'Default' AND om.user_id = ?
+            """,
+            (user_id,),
+        ).fetchone()
+        is not None
+    )
+    assert (
+        conn.execute(
+            """
+            SELECT 1
+            FROM groups g
+            JOIN group_members gm ON gm.group_id = g.id
+            WHERE g.name = 'All Users' AND gm.user_id = ?
+            """,
+            (user_id,),
+        ).fetchone()
+        is not None
+    )
+    assert (
+        conn.execute(
+            """
+            SELECT 1
+            FROM vault_group_access vga
+            JOIN groups g ON g.id = vga.group_id
+            WHERE vga.vault_id = 1
+              AND vga.permission = 'read'
+              AND g.name = 'All Users'
+            """
+        ).fetchone()
+        is not None
+    )
+    assert (
+        conn.execute(
+            """
+            SELECT 1
+            FROM vault_members
+            WHERE vault_id = 1 AND user_id = ? AND permission = 'write'
+            """,
+            (user_id,),
+        ).fetchone()
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_registration_commits_user_and_default_assignments_together(
+    tmp_path, monkeypatch
+):
+    from app.api.routes import auth
+    from app.config import settings
+
+    db_path = _init_db(tmp_path)
+    conn = _connect(db_path)
+    monkeypatch.setattr(
+        settings,
+        "jwt_secret_key",
+        "test-secret-key-for-testing-at-least-32-chars-long",
+    )
+    monkeypatch.setattr(auth, "hash_password", lambda password: f"hashed:{password}")
+
+    try:
+        result = await auth.register(
+            request=_request(),
+            response=Response(),
+            body=auth.RegisterRequest(username="firstuser", password="Password123"),
+            db=conn,
+            _csrf_token="csrf",
+        )
+        assert result["role"] == "superadmin"
+        _assert_default_assignments(conn, result["id"])
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_registration_rolls_back_user_when_default_assignment_fails(
+    tmp_path, monkeypatch
+):
+    from app.api.routes import auth
+    from app.config import settings
+
+    db_path = _init_db(tmp_path)
+    conn = _connect(db_path)
+    monkeypatch.setattr(
+        settings,
+        "jwt_secret_key",
+        "test-secret-key-for-testing-at-least-32-chars-long",
+    )
+    monkeypatch.setattr(auth, "hash_password", lambda password: f"hashed:{password}")
+
+    def fail_assignment(_conn, _user_id):
+        raise RuntimeError("assignment failed")
+
+    monkeypatch.setattr(auth, "_auto_assign_user_to_defaults", fail_assignment)
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await auth.register(
+                request=_request(),
+                response=Response(),
+                body=auth.RegisterRequest(
+                    username="rollbackuser", password="Password123"
+                ),
+                db=conn,
+                _csrf_token="csrf",
+            )
+        assert exc_info.value.status_code == 500
+        assert (
+            conn.execute(
+                "SELECT id FROM users WHERE username = ?", ("rollbackuser",)
+            ).fetchone()
+            is None
+        )
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_create_user_preserves_default_assignment_success(
+    tmp_path, monkeypatch
+):
+    from app.api.routes import users
+    from app.config import settings
+    from app.models.database import _pool_cache
+
+    db_path = _init_db(tmp_path)
+    monkeypatch.setattr(settings, "data_dir", tmp_path)
+    monkeypatch.setattr(users, "hash_password", lambda password: f"hashed:{password}")
+    _pool_cache.clear()
+
+    try:
+        result = await users.create_user(
+            body=users.CreateUserRequest(
+                username="createduser",
+                password="Password123",
+                full_name="Created User",
+                role="member",
+            ),
+            user={"id": 1, "username": "admin", "role": "admin", "is_active": True},
+            _csrf_token="csrf",
+        )
+        conn = _connect(db_path)
+        try:
+            _assert_default_assignments(conn, result["id"])
+        finally:
+            conn.close()
+    finally:
+        _pool_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_admin_create_user_rolls_back_when_default_assignment_fails(
+    tmp_path, monkeypatch
+):
+    from app.api.routes import users
+    from app.config import settings
+    from app.models.database import _pool_cache
+
+    db_path = _init_db(tmp_path)
+    monkeypatch.setattr(settings, "data_dir", tmp_path)
+    monkeypatch.setattr(users, "hash_password", lambda password: f"hashed:{password}")
+
+    def fail_assignment(_conn, _user_id):
+        raise RuntimeError("assignment failed")
+
+    monkeypatch.setattr(users, "_auto_assign_user_to_defaults", fail_assignment)
+    _pool_cache.clear()
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await users.create_user(
+                body=users.CreateUserRequest(
+                    username="rollbackuser",
+                    password="Password123",
+                    full_name="Rollback User",
+                    role="member",
+                ),
+                user={
+                    "id": 1,
+                    "username": "admin",
+                    "role": "admin",
+                    "is_active": True,
+                },
+                _csrf_token="csrf",
+            )
+        assert exc_info.value.status_code == 500
+        conn = _connect(db_path)
+        try:
+            assert (
+                conn.execute(
+                    "SELECT id FROM users WHERE username = ?", ("rollbackuser",)
+                ).fetchone()
+                is None
+            )
+        finally:
+            conn.close()
+    finally:
+        _pool_cache.clear()


### PR DESCRIPTION
## Summary

Make registration and admin user creation atomic with default organization, group, and vault assignment.

## Root Cause

Both user creation paths committed the user row before calling `_auto_assign_user_to_defaults`. If default assignment failed, the user could remain committed without the expected baseline org/group/vault access.

## Changes

- Move registration user insert and default assignment into a single transaction.
- Move admin-created user insert and default assignment into a single transaction.
- Roll back the admin creation connection on HTTP and unexpected failures before releasing it.
- Add focused tests covering successful default assignment and rollback behavior for both paths.

## Validation

- `python -m pytest backend\tests\test_user_creation_default_assignment_atomic.py -q` -> `4 passed`
- `python -m py_compile backend\app\api\routes\auth.py backend\app\api\routes\users.py backend\tests\test_user_creation_default_assignment_atomic.py`
- Independent reviewer pass found no blockers.