### PR TITLE
feat(documents): add search metadata and source context

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -350,13 +350,21 @@ def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
     )
 
 
+def _build_files_fts_query(raw_search: str) -> str:
+    tokens = re.findall(r"[A-Za-z0-9_]+", raw_search.lower())
+    return " ".join(f"{token}*" for token in tokens[:8])
+
+
 @router.get("", response_model=DocumentListResponse)
 @router.get("/", response_model=DocumentListResponse)
 async def list_documents(
     vault_id: Optional[int] = Query(None, description="Filter by vault ID"),
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(50, ge=1, le=200, description="Items per page"),
-    search: Optional[str] = Query(None, description="Filter by filename (case-insensitive substring)"),
+    search: Optional[str] = Query(
+        None,
+        description="Filter by document name or metadata fields (case-insensitive substring)",
+    ),
     status: Optional[str] = Query(None, description="Filter by processing status"),
     conn: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
@@ -367,7 +375,7 @@ async def list_documents(
 
     Returns a list of files with their id, file_name, file_path, status,
     chunk_count, created_at, and processed_at fields.
-    Optionally filter by vault_id, search (filename substring), or status.
+    Optionally filter by vault_id, search (document name/metadata substring), or status.
     Supports pagination via page/per_page.
     """
     offset = (page - 1) * per_page
@@ -376,8 +384,22 @@ async def list_documents(
     extra_where: list[str] = []
     extra_params: list = []
     if search and search.strip():
-        extra_where.append("LOWER(file_name) LIKE ?")
-        extra_params.append(f"%{search.strip().lower()}%")
+        fts_query = _build_files_fts_query(search.strip())
+        if fts_query:
+            extra_where.append(
+                """(
+                    LOWER(file_name) LIKE ?
+                    OR id IN (
+                        SELECT rowid FROM files_search_fts
+                        WHERE files_search_fts MATCH ?
+                    )
+                )"""
+            )
+            extra_params.append(f"%{search.strip().lower()}%")
+            extra_params.append(fts_query)
+        else:
+            extra_where.append("LOWER(file_name) LIKE ?")
+            extra_params.append(f"%{search.strip().lower()}%")
     if status and status.strip():
         extra_where.append("status = ?")
         extra_params.append(status.strip())

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -4,17 +4,20 @@ Semantic search API routes for document chunks.
 Provides endpoints for searching document chunks using vector similarity.
 """
 
+import asyncio
 import json
+import sqlite3
+from collections.abc import Callable
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from app.api.deps import (
-    evaluate_policy,
     get_current_active_user,
     get_db,
     get_embedding_service,
+    get_evaluate_policy,
     get_vector_store,
 )
 from app.services.embeddings import EmbeddingError, EmbeddingService
@@ -55,6 +58,45 @@ class SearchResponse(BaseModel):
     search_type: str = "diagnostic"
 
 
+class ChunkContextResponse(BaseModel):
+    """Expanded context for a retrieved chunk."""
+
+    id: str
+    file_id: str
+    filename: str
+    chunk_index: int | str
+    chunk_text: str
+    context_text: str
+    context_source: str
+
+
+def _record_get(record: Any, key: str, default: Any = None) -> Any:
+    if isinstance(record, dict):
+        return record.get(key, default)
+    return getattr(record, key, default)
+
+
+def _parse_metadata(record: Any) -> Dict[str, Any]:
+    metadata = _record_get(record, "metadata", {})
+    if isinstance(metadata, dict):
+        return metadata
+    if isinstance(metadata, str):
+        try:
+            parsed = json.loads(metadata)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return {}
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 @router.post("/search", response_model=SearchResponse)
 async def search(
     request: SearchRequest,
@@ -62,6 +104,7 @@ async def search(
     db=Depends(get_db),
     embedding_service: EmbeddingService = Depends(get_embedding_service),
     vector_store: VectorStore = Depends(get_vector_store),
+    evaluate: Callable = Depends(get_evaluate_policy),
 ):
     """
     Semantic search endpoint for document chunks.
@@ -86,7 +129,7 @@ async def search(
     # Vault permission scoping
     if request.vault_id is not None:
         # Specific vault requested — check read access
-        if not await evaluate_policy(user, "vault", request.vault_id, "read"):
+        if not await evaluate(user, "vault", request.vault_id, "read"):
             raise HTTPException(status_code=403, detail="No read access to this vault")
     else:
         # No vault specified — non-admins must specify a vault
@@ -113,21 +156,7 @@ async def search(
         results = []
         for record in raw_results:
             # Parse metadata JSON string if present
-            metadata = {}
-            record_metadata = (
-                record.get("metadata")
-                if isinstance(record, dict)
-                else getattr(record, "metadata", None)
-            )
-            if record_metadata:
-                try:
-                    metadata = (
-                        json.loads(record_metadata)
-                        if isinstance(record_metadata, str)
-                        else record_metadata
-                    )
-                except (json.JSONDecodeError, TypeError):
-                    metadata = {}
+            metadata = _parse_metadata(record)
 
             # Get similarity score (_distance is returned by LanceDB)
             score = (
@@ -168,3 +197,82 @@ async def search(
         raise HTTPException(
             status_code=500, detail=f"Search operation failed: {str(e)}"
         )
+
+
+@router.get("/search/chunks/{chunk_id}/context", response_model=ChunkContextResponse)
+async def get_chunk_context(
+    chunk_id: str,
+    user: dict = Depends(get_current_active_user),
+    db: sqlite3.Connection = Depends(get_db),
+    vector_store: VectorStore = Depends(get_vector_store),
+    evaluate: Callable = Depends(get_evaluate_policy),
+):
+    """
+    Fetch a retrieved chunk plus stored parent-window context for lazy previews.
+
+    The endpoint is intentionally point-look-up only: it does not run semantic
+    search or scan the corpus, so expanding a source preview does not change
+    query performance characteristics.
+    """
+    try:
+        chunks = await vector_store.get_chunks_by_uid([chunk_id])
+    except VectorStoreError as e:
+        raise HTTPException(status_code=500, detail=f"Vector store error: {str(e)}")
+
+    if not chunks:
+        raise HTTPException(status_code=404, detail="Chunk not found")
+
+    chunk = chunks[0]
+    metadata = _parse_metadata(chunk)
+    file_id = str(_record_get(chunk, "file_id", metadata.get("file_id", "")) or "")
+    vault_id = _coerce_int(_record_get(chunk, "vault_id", metadata.get("vault_id")))
+    filename = (
+        metadata.get("source_file")
+        or metadata.get("filename")
+        or metadata.get("section_title")
+        or "Unknown document"
+    )
+
+    file_id_int = _coerce_int(file_id)
+    if file_id_int is None:
+        raise HTTPException(status_code=404, detail="Chunk not found")
+
+    cursor = await asyncio.to_thread(
+        db.execute,
+        "SELECT file_name, vault_id FROM files WHERE id = ?",
+        (file_id_int,),
+    )
+    row = await asyncio.to_thread(cursor.fetchone)
+    if not row:
+        raise HTTPException(status_code=404, detail="Chunk not found")
+
+    filename = row["file_name"] or filename
+    vault_id = _coerce_int(row["vault_id"])
+    if vault_id is None:
+        raise HTTPException(status_code=404, detail="Chunk not found")
+
+    if not await evaluate(user, "vault", vault_id, "read"):
+        raise HTTPException(status_code=404, detail="Chunk not found")
+
+    chunk_text = str(_record_get(chunk, "text", "") or "")
+    parent_window_text = metadata.get("parent_window_text")
+    raw_text = metadata.get("raw_text")
+    if isinstance(parent_window_text, str) and parent_window_text.strip():
+        context_text = parent_window_text
+        context_source = "parent_window"
+    elif isinstance(raw_text, str) and raw_text.strip():
+        context_text = raw_text
+        context_source = "raw_text"
+    else:
+        context_text = chunk_text
+        context_source = "chunk"
+
+    return ChunkContextResponse(
+        id=str(_record_get(chunk, "id", chunk_id) or chunk_id),
+        file_id=file_id,
+        filename=str(filename),
+        chunk_index=_record_get(chunk, "chunk_index", metadata.get("chunk_index", 0)),
+        chunk_text=chunk_text,
+        context_text=context_text,
+        context_source=context_source,
+    )

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -62,6 +62,36 @@ CREATE TABLE IF NOT EXISTS files (
     FOREIGN KEY (vault_id) REFERENCES vaults(id)
 );
 
+-- Full-text search index for document list metadata search
+CREATE VIRTUAL TABLE IF NOT EXISTS files_search_fts USING fts5(
+    file_name,
+    file_type,
+    status,
+    source,
+    email_subject,
+    email_sender,
+    document_date,
+    content='files',
+    content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS files_search_fts_insert AFTER INSERT ON files BEGIN
+    INSERT INTO files_search_fts(rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+    VALUES (new.id, new.file_name, new.file_type, new.status, new.source, new.email_subject, new.email_sender, new.document_date);
+END;
+
+CREATE TRIGGER IF NOT EXISTS files_search_fts_delete AFTER DELETE ON files BEGIN
+    INSERT INTO files_search_fts(files_search_fts, rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+    VALUES ('delete', old.id, old.file_name, old.file_type, old.status, old.source, old.email_subject, old.email_sender, old.document_date);
+END;
+
+CREATE TRIGGER IF NOT EXISTS files_search_fts_update AFTER UPDATE ON files BEGIN
+    INSERT INTO files_search_fts(files_search_fts, rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+    VALUES ('delete', old.id, old.file_name, old.file_type, old.status, old.source, old.email_subject, old.email_sender, old.document_date);
+    INSERT INTO files_search_fts(rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+    VALUES (new.id, new.file_name, new.file_type, new.status, new.source, new.email_subject, new.email_sender, new.document_date);
+END;
+
 -- Memories table: stores processed document chunks with embeddings
 CREATE TABLE IF NOT EXISTS memories (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -512,6 +542,31 @@ def init_db(sqlite_path: str) -> None:
         conn.execute("PRAGMA busy_timeout=30000;")
         conn.execute("PRAGMA foreign_keys = ON;")
         migrate_add_user_id_to_chat_sessions(sqlite_path, conn=conn)
+        existing_tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        if "files" in existing_tables:
+            existing_file_cols = {
+                row[1] for row in conn.execute("PRAGMA table_info(files)").fetchall()
+            }
+            for name, ddl in (
+                ("vault_id", "INTEGER NOT NULL DEFAULT 1"),
+                ("file_size", "INTEGER DEFAULT 0"),
+                ("file_type", "TEXT"),
+                ("source", "TEXT NOT NULL DEFAULT 'upload'"),
+                ("email_subject", "TEXT"),
+                ("email_sender", "TEXT"),
+                ("modified_at", "TIMESTAMP DEFAULT NULL"),
+                ("document_date", "TEXT"),
+                ("supersedes_file_id", "INTEGER"),
+                ("ingestion_version", "INTEGER DEFAULT 1"),
+                ("wiki_pending", "INTEGER NOT NULL DEFAULT 0"),
+            ):
+                if name not in existing_file_cols:
+                    conn.execute(f"ALTER TABLE files ADD COLUMN {name} {ddl}")
         conn.executescript(SCHEMA)
         # Ensure default vault exists
         conn.execute(
@@ -599,6 +654,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_jobs_retry_count(sqlite_path)
     migrate_add_files_parsed_text(sqlite_path)
     migrate_add_files_processing_progress(sqlite_path)
+    migrate_add_files_search_fts(sqlite_path)
     migrate_add_curator_claim_support(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
@@ -1629,6 +1685,87 @@ def migrate_add_files_processing_progress(sqlite_path: str) -> None:
             "ON files(file_hash, vault_id, status)"
         )
         conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_files_search_fts(sqlite_path: str) -> None:
+    """Create and backfill the document-list metadata FTS index."""
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        def _drop_files_search_fts() -> None:
+            for trigger in (
+                "files_search_fts_insert",
+                "files_search_fts_delete",
+                "files_search_fts_update",
+            ):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            conn.execute("DROP TABLE IF EXISTS files_search_fts")
+
+        existing_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(files)").fetchall()
+        }
+        # init_db() may have created FTS triggers before a legacy files table
+        # gained newer metadata columns. Drop them before ALTER TABLE so SQLite
+        # never has to compile triggers that reference missing OLD/NEW columns.
+        if not {
+            "file_type",
+            "source",
+            "email_subject",
+            "email_sender",
+            "document_date",
+        }.issubset(existing_cols):
+            _drop_files_search_fts()
+
+        for name, ddl in (
+            ("file_type", "TEXT"),
+            ("source", "TEXT NOT NULL DEFAULT 'upload'"),
+            ("email_subject", "TEXT"),
+            ("email_sender", "TEXT"),
+            ("document_date", "TEXT"),
+            ("supersedes_file_id", "INTEGER"),
+            ("ingestion_version", "INTEGER DEFAULT 1"),
+        ):
+            if name not in existing_cols:
+                conn.execute(f"ALTER TABLE files ADD COLUMN {name} {ddl}")
+
+        conn.executescript(
+            """
+            CREATE VIRTUAL TABLE IF NOT EXISTS files_search_fts USING fts5(
+                file_name,
+                file_type,
+                status,
+                source,
+                email_subject,
+                email_sender,
+                document_date,
+                content='files',
+                content_rowid='id'
+            );
+
+            CREATE TRIGGER IF NOT EXISTS files_search_fts_insert AFTER INSERT ON files BEGIN
+                INSERT INTO files_search_fts(rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+                VALUES (new.id, new.file_name, new.file_type, new.status, new.source, new.email_subject, new.email_sender, new.document_date);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS files_search_fts_delete AFTER DELETE ON files BEGIN
+                INSERT INTO files_search_fts(files_search_fts, rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+                VALUES ('delete', old.id, old.file_name, old.file_type, old.status, old.source, old.email_subject, old.email_sender, old.document_date);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS files_search_fts_update AFTER UPDATE ON files BEGIN
+                INSERT INTO files_search_fts(files_search_fts, rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+                VALUES ('delete', old.id, old.file_name, old.file_type, old.status, old.source, old.email_subject, old.email_sender, old.document_date);
+                INSERT INTO files_search_fts(rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+                VALUES (new.id, new.file_name, new.file_type, new.status, new.source, new.email_subject, new.email_sender, new.document_date);
+            END;
+            """
+        )
+        conn.execute("INSERT INTO files_search_fts(files_search_fts) VALUES('rebuild')")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         conn.close()
 

--- a/backend/app/services/document_retrieval.py
+++ b/backend/app/services/document_retrieval.py
@@ -531,10 +531,14 @@ class DocumentRetrievalService:
             or chunk.metadata.get("heading")
             or ""
         )
-        # Construct unique ID per chunk to avoid duplicate React keys
+        # Prefer the persisted chunk UID so frontend lazy preview can fetch the
+        # exact indexed row, including reupload-safe hash-prefixed IDs.
         chunk_index = chunk.metadata.get("chunk_index", "")
         chunk_scale = chunk.metadata.get("chunk_scale", "")
-        if chunk_scale:
+        stored_chunk_id = chunk.metadata.get("_chunk_id") or chunk.metadata.get("chunk_uid")
+        if stored_chunk_id:
+            unique_id = str(stored_chunk_id)
+        elif chunk_scale:
             unique_id = f"{chunk.file_id}_{chunk_scale}_{chunk_index}"
         else:
             unique_id = f"{chunk.file_id}_{chunk_index}"

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -8,7 +8,12 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from app.models.database import init_db, migrate_add_fork_columns
+from app.models.database import (
+    init_db,
+    migrate_add_files_search_fts,
+    migrate_add_fork_columns,
+    run_migrations,
+)
 
 
 class TestDatabaseSchema(unittest.TestCase):
@@ -92,6 +97,106 @@ class TestDatabaseSchema(unittest.TestCase):
                 table_names,
                 f"Required table '{table}' was not found after idempotent init_db() calls"
             )
+
+    def test_run_migrations_upgrades_legacy_files_table_before_files_fts(self):
+        """Legacy files schema should not trip FTS triggers that reference new columns."""
+        conn = sqlite3.connect(self.temp_db_path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE files (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT NOT NULL,
+                    file_name TEXT NOT NULL,
+                    file_hash TEXT,
+                    file_size INTEGER NOT NULL,
+                    chunk_count INTEGER DEFAULT 0,
+                    status TEXT DEFAULT 'pending',
+                    error_message TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    processed_at TIMESTAMP
+                );
+                """
+            )
+            conn.execute(
+                "INSERT INTO files (file_path, file_name, file_size, status) VALUES (?, ?, ?, ?)",
+                ("/tmp/legacy.txt", "legacy.txt", 10, "indexed"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        run_migrations(self.temp_db_path)
+
+        conn = sqlite3.connect(self.temp_db_path)
+        try:
+            row = conn.execute(
+                "SELECT rowid FROM files_search_fts WHERE files_search_fts MATCH ?",
+                ("legacy*",),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertIsNotNone(row)
+
+    def test_files_search_fts_migration_rebuilds_stale_legacy_triggers(self):
+        """Legacy files FTS triggers are dropped before missing metadata columns are added."""
+        conn = sqlite3.connect(self.temp_db_path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE files (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT NOT NULL,
+                    file_name TEXT NOT NULL,
+                    file_hash TEXT,
+                    file_size INTEGER NOT NULL,
+                    chunk_count INTEGER DEFAULT 0,
+                    status TEXT DEFAULT 'pending',
+                    error_message TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    processed_at TIMESTAMP
+                );
+
+                CREATE VIRTUAL TABLE files_search_fts USING fts5(
+                    file_name,
+                    file_type,
+                    status,
+                    source,
+                    email_subject,
+                    email_sender,
+                    document_date,
+                    content='files',
+                    content_rowid='id'
+                );
+
+                CREATE TRIGGER files_search_fts_insert AFTER INSERT ON files BEGIN
+                    INSERT INTO files_search_fts(rowid, file_name, file_type, status, source, email_subject, email_sender, document_date)
+                    VALUES (new.id, new.file_name, new.file_type, new.status, new.source, new.email_subject, new.email_sender, new.document_date);
+                END;
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        migrate_add_files_search_fts(self.temp_db_path)
+
+        conn = sqlite3.connect(self.temp_db_path)
+        try:
+            conn.execute(
+                "INSERT INTO files (file_path, file_name, file_size, status) VALUES (?, ?, ?, ?)",
+                ("/tmp/recovered.txt", "recovered.txt", 10, "indexed"),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT rowid FROM files_search_fts WHERE files_search_fts MATCH ?",
+                ("recovered*",),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertIsNotNone(row)
 
     def test_init_db_creates_fork_columns_on_chat_sessions(self):
         """Fresh databases should include fork metadata without migrations."""

--- a/backend/tests/test_documents_auth.py
+++ b/backend/tests/test_documents_auth.py
@@ -74,7 +74,7 @@ from app.api.deps import (
 )
 from app.config import settings
 from app.main import app
-from app.services.auth_service import create_access_token, hash_password
+from app.services.auth_service import create_access_token
 
 
 class SimpleConnectionPool:
@@ -193,7 +193,9 @@ class TestDocumentAuthBase(unittest.TestCase):
             conn.execute("DELETE FROM vault_members")
             conn.execute("DELETE FROM users WHERE id != 0")
 
-            pw = hash_password("testpass")
+            # These route tests authenticate with JWTs; the stored password hash
+            # is never verified, so keep setup independent from bcrypt backends.
+            pw = "test-password-hash"
 
             # User 1: superadmin
             conn.execute(
@@ -504,6 +506,118 @@ class TestReadAccess(TestDocumentAuthBase):
         # Should succeed (200) or at least not 403
         self.assertNotEqual(response.status_code, 401)
         self.assertNotEqual(response.status_code, 403)
+
+    def test_document_search_matches_metadata_fields(self):
+        """Document list search matches metadata, not only filename."""
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                """
+                INSERT INTO files (
+                    id, file_name, file_path, file_size, file_type, status,
+                    chunk_count, vault_id, source, email_subject, email_sender,
+                    document_date
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    20,
+                    "budget.pdf",
+                    "/uploads/budget.pdf",
+                    100,
+                    "application/pdf",
+                    "indexed",
+                    1,
+                    2,
+                    "email",
+                    "Quarterly planning packet",
+                    "finance@example.com",
+                    "2026-05-13",
+                ),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.get(
+            "/api/documents?vault_id=2&search=quarterly",
+            headers=self._auth_headers(self._member_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        filenames = [doc["filename"] for doc in response.json()["documents"]]
+        self.assertEqual(filenames, ["budget.pdf"])
+
+    def test_document_search_preserves_filename_substring_matching(self):
+        """Filename search remains substring-based for existing UX expectations."""
+        response = self.client.get(
+            "/api/documents?vault_id=2&search=est_doc",
+            headers=self._auth_headers(self._member_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        filenames = [doc["filename"] for doc in response.json()["documents"]]
+        self.assertEqual(filenames, ["test_doc.txt"])
+
+    def test_document_search_non_token_query_still_matches_filenames(self):
+        """Punctuation-only searches keep the legacy filename substring behavior."""
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                """
+                INSERT INTO files (id, file_name, file_path, file_size, vault_id, status)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (997, "notes!!!.pdf", "/tmp/notes!!!.pdf", 128, 2, "indexed"),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.get(
+            "/api/documents?vault_id=2&search=!!!",
+            headers=self._auth_headers(self._member_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        filenames = [doc["filename"] for doc in response.json()["documents"]]
+        self.assertEqual(filenames, ["notes!!!.pdf"])
+
+    def test_document_search_fts_operator_text_is_escaped_to_tokens(self):
+        """FTS metacharacters are reduced to safe prefix tokens before MATCH."""
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                """
+                INSERT INTO files (
+                    id, file_name, file_path, file_size, vault_id, status,
+                    source, email_subject
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    998,
+                    "operator-report.pdf",
+                    "/tmp/operator-report.pdf",
+                    128,
+                    2,
+                    "indexed",
+                    "email",
+                    'OR file_name MATCH x NEAR("unsafe")',
+                ),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.get(
+            '/api/documents?vault_id=2&search=NEAR("unsafe")',
+            headers=self._auth_headers(self._member_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        filenames = [doc["filename"] for doc in response.json()["documents"]]
+        self.assertEqual(filenames, ["operator-report.pdf"])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_search_auth.py
+++ b/backend/tests/test_search_auth.py
@@ -12,6 +12,7 @@ Tests verify:
 Uses FastAPI TestClient with mocked embedding_service and vector_store.
 """
 
+import json
 import os
 import sys
 import tempfile
@@ -85,6 +86,7 @@ class FakeVectorStore:
 
     def __init__(self):
         self._initialized = False
+        self.chunk_records = []
 
     async def init_table(self, dimension: int):
         """Initialize the table with given dimension."""
@@ -104,6 +106,11 @@ class FakeVectorStore:
                 "_distance": 0.5,
             }
         ]
+
+    async def get_chunks_by_uid(self, chunk_uids: list[str]):
+        """Return fake chunks by UID."""
+        wanted = set(chunk_uids)
+        return [chunk for chunk in self.chunk_records if chunk.get("id") in wanted]
 
 
 class TestSearchAuth(unittest.TestCase):
@@ -146,10 +153,10 @@ class TestSearchAuth(unittest.TestCase):
         self.fake_embedding_service = FakeEmbeddingService()
         self.fake_vector_store = FakeVectorStore()
 
-        def get_fake_embedding_service(request):
+        def get_fake_embedding_service():
             return self.fake_embedding_service
 
-        def get_fake_vector_store(request):
+        def get_fake_vector_store():
             return self.fake_vector_store
 
         main_app.dependency_overrides[get_db] = get_test_db
@@ -485,6 +492,107 @@ class TestSearchAuth(unittest.TestCase):
         # Endpoint validates query is not empty/whitespace → returns 400
         # This is endpoint-level validation, not Pydantic validation
         self.assertIn(response.status_code, [400, 422])
+
+    def test_chunk_context_returns_parent_window_for_authorized_vault(self):
+        """GET /search/chunks/{id}/context returns stored parent-window text."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                """
+                INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (42, "db-handbook.md", "/uploads/db-handbook.md", 100, "indexed", 1, self.accessible_vault_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+        self.fake_vector_store.chunk_records = [
+            {
+                "id": "42_abc12345_default_0",
+                "text": "matched chunk",
+                "file_id": "42",
+                "vault_id": str(self.accessible_vault_id),
+                "chunk_index": 0,
+                "metadata": json.dumps(
+                    {
+                        "source_file": "handbook.md",
+                        "parent_window_text": "before matched chunk after",
+                        "raw_text": "matched chunk",
+                    }
+                ),
+            }
+        ]
+        token = self._create_jwt_token(self.member_user_id, "member_user", "member")
+
+        response = self.client.get(
+            "/api/search/chunks/42_abc12345_default_0/context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["id"], "42_abc12345_default_0")
+        self.assertEqual(data["context_text"], "before matched chunk after")
+        self.assertEqual(data["context_source"], "parent_window")
+        self.assertEqual(data["filename"], "db-handbook.md")
+        self.assertNotIn("metadata", data)
+
+    def test_chunk_context_hides_inaccessible_vault(self):
+        """Chunk context returns not found for inaccessible existing chunks."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                """
+                INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (99, "restricted.md", "/uploads/restricted.md", 100, "indexed", 1, self.restricted_vault_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+        self.fake_vector_store.chunk_records = [
+            {
+                "id": "99_0",
+                "text": "restricted chunk",
+                "file_id": "99",
+                "vault_id": str(self.restricted_vault_id),
+                "chunk_index": 0,
+                "metadata": "{}",
+            }
+        ]
+        token = self._create_jwt_token(self.member_user_id, "member_user", "member")
+
+        response = self.client.get(
+            "/api/search/chunks/99_0/context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 404, response.text)
+        inaccessible_body = response.json()
+
+        missing_response = self.client.get(
+            "/api/search/chunks/missing/context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(missing_response.status_code, 404, missing_response.text)
+        self.assertEqual(inaccessible_body, missing_response.json())
+
+    def test_chunk_context_missing_chunk_returns_same_not_found(self):
+        """Missing chunk and inaccessible chunk share the same response status."""
+        token = self._create_jwt_token(self.member_user_id, "member_user", "member")
+
+        response = self.client.get(
+            "/api/search/chunks/missing/context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(response.status_code, 404, response.text)
+        self.assertEqual(response.json(), {"detail": "Chunk not found"})
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/chat/RightPane.test.tsx
+++ b/frontend/src/components/chat/RightPane.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { RightPane } from "./RightPane";
 import * as useChatStoreModule from "@/stores/useChatStore";
 import * as useChatShellStoreModule from "@/stores/useChatStore";
+import { getChunkContext } from "@/lib/api";
 
 // Mock the stores
 vi.mock("@/stores/useChatStore", () => {
@@ -80,6 +81,18 @@ vi.mock("@/stores/useChatShellStore", () => ({
   })),
 }));
 
+vi.mock("@/lib/api", () => ({
+  getChunkContext: vi.fn().mockResolvedValue({
+    id: "src-1",
+    file_id: "1",
+    filename: "doc.pdf",
+    chunk_index: 0,
+    chunk_text: "Snippet content",
+    context_text: "Expanded source context",
+    context_source: "parent_window",
+  }),
+}));
+
 // Mock UI components with proper interactivity
 const mockOnValueChange = vi.fn();
 
@@ -152,6 +165,15 @@ describe("RightPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockOnValueChange.mockClear();
+    vi.mocked(getChunkContext).mockResolvedValue({
+      id: "src-1",
+      file_id: "1",
+      filename: "doc.pdf",
+      chunk_index: 0,
+      chunk_text: "Snippet content",
+      context_text: "Expanded source context",
+      context_source: "parent_window",
+    });
   });
 
   // =============================================================================
@@ -982,6 +1004,41 @@ print("hello")
       // After selection, preview tab would show source content
       await waitFor(() => {
         expect(screen.getByTestId("tab-preview")).toBeInTheDocument();
+      });
+    });
+
+    it("fetches expanded context only after selecting a source", async () => {
+      const sources = [
+        createMockSource({
+          id: "src-1",
+          filename: "doc.pdf",
+          snippet: "Short snippet",
+        }),
+      ];
+
+      mockUseChatStore.mockReturnValue({
+        messages: [
+          createMockMessage({ role: "user", content: "test" }),
+          createMockMessage({ role: "assistant", content: "response", sources }),
+        ],
+        expandedSources: new Set(),
+      });
+
+      render(<RightPane />);
+
+      expect(getChunkContext).not.toHaveBeenCalled();
+
+      const sourceButton = screen.getAllByRole("button").find(btn =>
+        btn.textContent?.includes("doc.pdf")
+      );
+      expect(sourceButton).toBeInTheDocument();
+      fireEvent.click(sourceButton!);
+
+      await waitFor(() => {
+        expect(getChunkContext).toHaveBeenCalledWith("src-1");
+      });
+      await waitFor(() => {
+        expect(screen.getByText("Expanded source context")).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/components/chat/RightPane.tsx
+++ b/frontend/src/components/chat/RightPane.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FileText, Table, Code, ExternalLink, BookOpen, Layers } from "lucide-react";
+import { FileText, Table, Code, ExternalLink, BookOpen, Layers, Loader2 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -16,7 +16,7 @@ import {
   parseCompletedAssistantIds,
 } from "@/stores/useChatStore";
 import { useChatShellStore } from "@/stores/useChatShellStore";
-import type { Source } from "@/lib/api";
+import { getChunkContext, type ChunkContextResponse, type Source } from "@/lib/api";
 import { WikiCards } from "./WikiCards";
 import { getRelevanceLabel, type ScoreType } from "@/lib/relevance";
 import { EmptyState } from "@/components/shared/EmptyState";
@@ -263,11 +263,40 @@ interface SourcePreviewProps {
 }
 
 function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
-  const content = source.snippet || "";
+  const [chunkContext, setChunkContext] = useState<ChunkContextResponse | null>(null);
+  const [isLoadingContext, setIsLoadingContext] = useState(false);
+  const [contextError, setContextError] = useState<string | null>(null);
+  const previewContent = chunkContext?.context_text || source.snippet || "";
   const highlightedContent = useMemo(
-    () => highlightQueryTerms(content, query),
-    [content, query]
+    () => highlightQueryTerms(previewContent, query),
+    [previewContent, query]
   );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setChunkContext(null);
+    setContextError(null);
+    if (!source.id) return;
+
+    setIsLoadingContext(true);
+    getChunkContext(source.id)
+      .then((context) => {
+        if (!cancelled) setChunkContext(context);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setContextError(err instanceof Error ? err.message : "Could not load source context");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingContext(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source.id]);
 
   return (
     <div className="flex flex-col h-full min-h-0 gap-4">
@@ -282,9 +311,27 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
         </Button>
       </div>
 
-      {source.snippet && (
-        <div className="text-xs text-muted-foreground italic truncate flex-shrink-0">
-          {source.snippet}
+      {(source.snippet || chunkContext?.context_source || isLoadingContext || contextError) && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground flex-shrink-0">
+          {isLoadingContext && (
+            <span className="inline-flex items-center gap-1">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Loading context
+            </span>
+          )}
+          {chunkContext?.context_source && (
+            <span className="rounded border border-border px-1.5 py-0.5">
+              {chunkContext.context_source === "parent_window" ? "Document context" : "Chunk context"}
+            </span>
+          )}
+          {contextError && (
+            <span className="text-warning-foreground">{contextError}</span>
+          )}
+          {source.snippet && (
+            <span className="min-w-0 flex-1 truncate italic">
+              {source.snippet}
+            </span>
+          )}
         </div>
       )}
 
@@ -299,7 +346,7 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
 
       <ScrollArea className="flex-1 min-h-0 rounded-md border p-4">
         <div className="text-sm leading-relaxed whitespace-pre-wrap">
-          {highlightedContent}
+          {previewContent ? highlightedContent : "No preview content available."}
         </div>
       </ScrollArea>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -581,6 +581,16 @@ export interface Source {
   score_type?: "distance" | "rerank" | "rrf";
 }
 
+export interface ChunkContextResponse {
+  id: string;
+  file_id: string;
+  filename: string;
+  chunk_index: number | string;
+  chunk_text: string;
+  context_text: string;
+  context_source: "parent_window" | "raw_text" | "chunk" | string;
+}
+
 /**
  * A memory the assistant referenced when generating a response.
  * Distinct from document sources: memories use the [M#] label space and
@@ -945,6 +955,13 @@ export async function deleteAllDocumentsInVault(vaultId: number): Promise<{ dele
 
 export async function getDocumentStats(vaultId?: number): Promise<DocumentStatsResponse> {
   const response = await apiClient.get<DocumentStatsResponse>("/documents/stats", vaultId != null ? { params: { vault_id: vaultId } } : undefined);
+  return response.data;
+}
+
+export async function getChunkContext(chunkId: string): Promise<ChunkContextResponse> {
+  const response = await apiClient.get<ChunkContextResponse>(
+    `/search/chunks/${encodeURIComponent(chunkId)}/context`
+  );
   return response.data;
 }
 

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@/lib/api', () => ({
     claims_count: 0,
     lint_count: 0,
   }),
-  compileDocumentWiki: vi.fn().mockResolvedValue({}),
+  compileDocumentWiki: vi.fn().mockResolvedValue({ job_id: 1, status: 'queued' }),
   getDocumentStats: vi.fn().mockResolvedValue({
     total_documents: 2,
     total_chunks: 15,
@@ -145,7 +145,12 @@ vi.mock('@/components/shared/DocumentCard', () => ({
 }));
 
 vi.mock('@/components/shared/EmptyState', () => ({
-  EmptyState: () => <div data-testid="empty-state" />,
+  EmptyState: ({ title, description }: { title: string; description?: string }) => (
+    <div data-testid="empty-state">
+      <h2>{title}</h2>
+      {description && <p>{description}</p>}
+    </div>
+  ),
 }));
 
 vi.mock('@/lib/formatters', () => ({
@@ -164,6 +169,19 @@ describe('DocumentsPage - Drag to Resize Filename Column', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listDocuments).mockResolvedValue({
+      documents: [
+        { id: '1', filename: 'test.pdf', size: 1024, created_at: '2024-01-01', metadata: { status: 'processed', chunk_count: 5 } },
+        { id: '2', filename: 'test2.pdf', size: 2048, created_at: '2024-01-02', metadata: { status: 'processed', chunk_count: 10 } },
+      ],
+      total: 2,
+    });
+    vi.mocked(getDocumentStats).mockResolvedValue({
+      total_documents: 2,
+      total_chunks: 15,
+      total_size_bytes: 3072,
+      documents_by_status: { processed: 2 },
+    });
     vi.mocked(useVaultStore).mockReturnValue({
       activeVaultId: null,
       vaults: [],
@@ -328,6 +346,98 @@ describe('DocumentsPage - Drag to Resize Filename Column', () => {
       expect(
         container.querySelector('input[aria-label="Select all documents"]')
       ).not.toBeDisabled();
+    });
+  });
+
+  describe('empty states', () => {
+    it('shows the no-documents state when the selected vault has no documents', async () => {
+      vi.mocked(useVaultStore).mockReturnValue({
+        activeVaultId: 2,
+        vaults: [{ id: 2, name: 'Writable Vault', current_user_permission: 'write' }],
+      } as ReturnType<typeof useVaultStore>);
+      vi.mocked(listDocuments).mockResolvedValueOnce({ documents: [], total: 0 });
+      vi.mocked(getDocumentStats).mockResolvedValueOnce({
+        total_documents: 0,
+        total_chunks: 0,
+        total_size_bytes: 0,
+        documents_by_status: {},
+      });
+
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('No documents yet')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Upload files to get started.')).toBeInTheDocument();
+    });
+
+    it('shows the no-search-matches state when a populated vault has no matching documents', async () => {
+      vi.mocked(useVaultStore).mockReturnValue({
+        activeVaultId: 2,
+        vaults: [{ id: 2, name: 'Admin Vault', current_user_permission: 'admin' }],
+      } as ReturnType<typeof useVaultStore>);
+      vi.mocked(listDocuments).mockResolvedValue({ documents: [], total: 0 });
+      vi.mocked(getDocumentStats).mockResolvedValueOnce({
+        total_documents: 2,
+        total_chunks: 10,
+        total_size_bytes: 2048,
+        documents_by_status: { indexed: 2 },
+      });
+
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('No documents yet')).toBeInTheDocument();
+      });
+
+      const searchInput = container.querySelector(
+        'input[placeholder="Search documents and metadata..."]'
+      ) as HTMLInputElement;
+      fireEvent.change(searchInput, { target: { value: 'quarterly' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('No documents match your search')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Search checks filename, type, status, source, sender, subject, and document date.')
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the no-documents state for active search while stats are unavailable', async () => {
+      vi.mocked(useVaultStore).mockReturnValue({
+        activeVaultId: 2,
+        vaults: [{ id: 2, name: 'Admin Vault', current_user_permission: 'admin' }],
+      } as ReturnType<typeof useVaultStore>);
+      vi.mocked(listDocuments).mockResolvedValue({ documents: [], total: 0 });
+      vi.mocked(getDocumentStats).mockRejectedValueOnce(new Error('stats unavailable'));
+
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('No documents yet')).toBeInTheDocument();
+      });
+
+      const searchInput = container.querySelector(
+        'input[placeholder="Search documents and metadata..."]'
+      ) as HTMLInputElement;
+      fireEvent.change(searchInput, { target: { value: 'quarterly' } });
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('No documents yet')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -542,6 +542,26 @@ export default function DocumentsPage() {
     () => documents?.filter((doc) => !optimisticallyDeletedIds.has(doc.id)) ?? [],
     [documents, optimisticallyDeletedIds]
   );
+  const hasActiveSearch = searchQuery.trim().length > 0;
+  const hasStats = stats !== null;
+  const totalVaultDocuments = stats?.total_documents ?? 0;
+  const isResolvingSearchEmptyState = hasSelectedVault && hasActiveSearch && !hasStats;
+  const emptyState = !hasSelectedVault
+    ? {
+        title: "Select a vault to view documents",
+        description: "Documents are scoped to the active vault.",
+      }
+    : hasActiveSearch && totalVaultDocuments > 0
+      ? {
+          title: "No documents match your search",
+          description: "Search checks filename, type, status, source, sender, subject, and document date.",
+        }
+      : {
+          title: "No documents yet",
+          description: canWriteActiveVault
+            ? "Upload files to get started."
+            : "Documents will appear here when this vault has indexed files.",
+        };
 
   const tableVirtualizer = useVirtualizer({
     count: filteredDocuments.length,
@@ -922,7 +942,7 @@ export default function DocumentsPage() {
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
-            placeholder="Search documents..."
+            placeholder="Search documents and metadata..."
             className="pl-10"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -1043,11 +1063,16 @@ export default function DocumentsPage() {
             ))}
           </div>
         </>
+      ) : isResolvingSearchEmptyState ? (
+        <div className="space-y-3" role="status" aria-live="polite">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-96 max-w-full" />
+        </div>
       ) : filteredDocuments.length === 0 ? (
         <EmptyState
           icon={FileText}
-          title={searchQuery ? "No documents match your search" : "No documents yet"}
-          description={searchQuery ? undefined : "Upload some files to get started."}
+          title={emptyState.title}
+          description={emptyState.description}
         />
       ) : (
         <>

--- a/frontend/src/pages/DocumentsPage.virtualization.test.tsx
+++ b/frontend/src/pages/DocumentsPage.virtualization.test.tsx
@@ -468,12 +468,12 @@ describe("DocumentsPage - Virtualization", () => {
       });
 
       await waitFor(() => {
-        const searchInput = container.querySelector('input[placeholder="Search documents..."]');
+        const searchInput = container.querySelector('input[placeholder="Search documents and metadata..."]');
         expect(searchInput).toBeTruthy();
       });
 
       // Type in search box
-      const searchInput = container.querySelector('input[placeholder="Search documents..."]') as HTMLInputElement;
+      const searchInput = container.querySelector('input[placeholder="Search documents and metadata..."]') as HTMLInputElement;
       await act(async () => {
         fireEvent.change(searchInput, { target: { value: "test" } });
       });


### PR DESCRIPTION
## Summary
- expand document search from filename-only matching to filename substring plus FTS-backed metadata fields
- add an auth-checked chunk context endpoint and lazy source preview expansion
- refine document empty states for no active vault, no documents, and no search matches

## Review follow-up
- restored non-token search fallback to filename substring matching and added punctuation-only coverage
- added FTS operator-token safety coverage and a stale legacy FTS trigger migration regression
- removed unused chunk/source metadata payload fields and asserted chunk-context 404 response parity
- shortened the search placeholder to neutral metadata wording and guarded unresolved active-search empty state rendering
- kept the literal password hash in document route tests with an explicit comment because these tests use JWT auth and local bcrypt hashing fails before route coverage runs

## Invariant audit
- commit-pr invariant source: not applicable -- `Test-Path AGENTS.md` returned `False`
- engineering invariant docs: not applicable -- `Test-Path docs/engineering-invariants.md` returned `False`
- release-please manifest: not applicable -- `Test-Path .release-please-manifest.json` returned `False`

## Test plan
- [x] `python -m pytest tests/test_schema_unification.py tests/test_database.py tests/test_search_auth.py tests/test_documents_auth.py::TestReadAccess::test_document_search_matches_metadata_fields tests/test_documents_auth.py::TestReadAccess::test_document_search_preserves_filename_substring_matching tests/test_documents_auth.py::TestReadAccess::test_document_search_non_token_query_still_matches_filenames tests/test_documents_auth.py::TestReadAccess::test_document_search_fts_operator_text_is_escaped_to_tokens` -- 47 passed, 4 slowapi deprecation warnings
- [x] `python -m pytest tests/test_database.py tests/test_documents_auth.py::TestReadAccess::test_document_search_matches_metadata_fields tests/test_documents_auth.py::TestReadAccess::test_document_search_preserves_filename_substring_matching tests/test_documents_auth.py::TestReadAccess::test_document_search_non_token_query_still_matches_filenames tests/test_documents_auth.py::TestReadAccess::test_document_search_fts_operator_text_is_escaped_to_tokens tests/test_search_auth.py::TestSearchAuth::test_chunk_context_returns_parent_window_for_authorized_vault tests/test_search_auth.py::TestSearchAuth::test_chunk_context_hides_inaccessible_vault tests/test_search_auth.py::TestSearchAuth::test_chunk_context_missing_chunk_returns_same_not_found` -- 13 passed, 4 slowapi deprecation warnings
- [x] `npm test -- DocumentsPage.test.tsx DocumentsPage.virtualization.test.tsx RightPane.test.tsx` -- 85 passed, existing React test warnings plus intentional stats-error log in the new unavailable-stats test
- [x] `npm run typecheck`
- [x] `npm run lint -- --max-warnings 0`
- [x] `python -m py_compile backend\app\api\routes\documents.py backend\app\api\routes\search.py backend\tests\test_database.py backend\tests\test_documents_auth.py backend\tests\test_search_auth.py`
- [x] `git diff --check` -- line-ending warnings only