### PR TITLE
feat(documents): add authenticated document preview

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -9,6 +9,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import mimetypes
 import os
 import re
 import sqlite3
@@ -27,6 +28,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.exceptions import RequestValidationError
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.api.deps import (
@@ -292,6 +294,24 @@ class DeleteAllVaultResponse(BaseModel):
 
     deleted_count: int
     vault_id: int
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _allowed_document_roots(settings_dep: Settings, vault_id: int) -> list[Path]:
+    return [
+        settings_dep.vault_uploads_dir(vault_id),
+        settings_dep.vault_documents_dir(vault_id),
+        settings_dep.uploads_dir,
+        settings_dep.documents_dir,
+        settings_dep.library_dir,
+    ]
 
 
 def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
@@ -624,6 +644,63 @@ async def get_document_status(
         wiki_phase=wiki_phase,
         wiki_job_id=wiki_job_id,
     )
+
+
+@router.get("/{file_id}/raw")
+async def get_document_raw(
+    file_id: int,
+    conn: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    evaluate: Callable = Depends(get_evaluate_policy),
+    settings_dep: Settings = Depends(get_settings),
+):
+    """Stream original document bytes for authenticated users with vault read access."""
+    cursor = await asyncio.to_thread(
+        conn.execute,
+        """
+        SELECT id, vault_id, file_name, file_path
+        FROM files
+        WHERE id = ?
+        """,
+        (file_id,),
+    )
+    row = await asyncio.to_thread(cursor.fetchone)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    vault_id = row["vault_id"]
+    if not await evaluate(user, "vault", vault_id, "read"):
+        raise HTTPException(status_code=403, detail="No read access to this vault")
+
+    try:
+        file_path = Path(row["file_path"]).resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        raise HTTPException(status_code=404, detail="Document file not found")
+
+    allowed_roots = [
+        root.resolve(strict=False) for root in _allowed_document_roots(settings_dep, vault_id)
+    ]
+    if not any(_path_is_within(file_path, root) for root in allowed_roots):
+        logger.warning(
+            "Refusing to serve document %s outside configured document roots: %s",
+            file_id,
+            file_path,
+        )
+        raise HTTPException(status_code=404, detail="Document file not found")
+
+    if not file_path.exists() or not file_path.is_file():
+        raise HTTPException(status_code=404, detail="Document file not found")
+
+    media_type = mimetypes.guess_type(row["file_name"])[0] or "application/octet-stream"
+    is_pdf = media_type == "application/pdf" or row["file_name"].lower().endswith(".pdf")
+    response = FileResponse(
+        path=file_path,
+        media_type=media_type,
+        filename=row["file_name"],
+        content_disposition_type="inline" if is_pdf else "attachment",
+    )
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    return response
 
 
 def _safe_get(row, key: str, default=None):

--- a/backend/app/services/document_retrieval.py
+++ b/backend/app/services/document_retrieval.py
@@ -558,6 +558,7 @@ class DocumentRetrievalService:
             "filename": filename,
             "section": section,
             "source_label": source_label,
+            "page_number": chunk.metadata.get("page_number"),
             "snippet": snippet,
             "score": chunk.score,
             "metadata": chunk.metadata,

--- a/backend/tests/test_documents_auth.py
+++ b/backend/tests/test_documents_auth.py
@@ -6,6 +6,7 @@ This test suite verifies:
 """
 
 import os
+import shutil
 import sys
 import tempfile
 import threading
@@ -72,6 +73,7 @@ from app.api.deps import (
     get_embedding_service,
     get_vector_store,
 )
+from app.api.routes.documents import _allowed_document_roots, _path_is_within
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
@@ -280,8 +282,6 @@ class TestDocumentAuthBase(unittest.TestCase):
         if hasattr(self, "_connection_pool"):
             self._connection_pool.close_all()
 
-        import shutil
-
         shutil.rmtree(self._temp_dir, ignore_errors=True)
 
     def _get_db_conn(self):
@@ -348,6 +348,11 @@ class TestAuthentication(TestDocumentAuthBase):
     def test_delete_documents_by_id_unauthenticated(self):
         """DELETE /documents/{id} without auth returns 401."""
         response = self.client.delete("/api/documents/1")
+        self.assertEqual(response.status_code, 401)
+
+    def test_get_document_raw_unauthenticated(self):
+        """GET /documents/{id}/raw without auth returns 401."""
+        response = self.client.get("/api/documents/1/raw")
         self.assertEqual(response.status_code, 401)
 
     def test_post_documents_batch_unauthenticated(self):
@@ -485,6 +490,44 @@ class TestRoleAdminRequired(TestDocumentAuthBase):
 class TestReadAccess(TestDocumentAuthBase):
     """Tests for read access - members with read access can list documents."""
 
+    def _seed_document_file(
+        self,
+        file_id: int,
+        vault_id: int,
+        filename: str,
+        content: bytes,
+    ) -> Path:
+        file_path = settings.vault_uploads_dir(vault_id) / filename
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(content)
+
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO files (
+                    id, file_name, file_path, file_size, file_type, status,
+                    chunk_count, vault_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    file_id,
+                    filename,
+                    str(file_path),
+                    len(content),
+                    Path(filename).suffix.lower(),
+                    "indexed",
+                    1,
+                    vault_id,
+                ),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        return file_path
+
     def test_member_with_read_access_can_list_documents(self):
         """Member with read access can GET /documents."""
         # member_readonly (user 4) has READ permission on vault 3
@@ -506,6 +549,160 @@ class TestReadAccess(TestDocumentAuthBase):
         # Should succeed (200) or at least not 403
         self.assertNotEqual(response.status_code, 401)
         self.assertNotEqual(response.status_code, 403)
+
+    def test_member_with_read_access_can_fetch_pdf_raw_bytes(self):
+        """Member with read access can fetch inline PDF bytes."""
+        pdf_bytes = b"%PDF-1.4\n% test pdf\n"
+        self._seed_document_file(30, 3, "readable.pdf", pdf_bytes)
+
+        response = self.client.get(
+            "/api/documents/30/raw",
+            headers=self._auth_headers(self._member_readonly_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, pdf_bytes)
+        self.assertIn("application/pdf", response.headers.get("content-type", ""))
+        self.assertIn("inline", response.headers.get("content-disposition", ""))
+        self.assertIn("readable.pdf", response.headers.get("content-disposition", ""))
+        self.assertEqual(response.headers.get("x-content-type-options"), "nosniff")
+
+    def test_member_with_read_access_can_fetch_non_pdf_raw_bytes(self):
+        """Non-PDF originals download instead of rendering active content inline."""
+        html_bytes = b"<script>window.opener.location='https://evil.example'</script>"
+        self._seed_document_file(34, 3, "preview.html", html_bytes)
+
+        response = self.client.get(
+            "/api/documents/34/raw",
+            headers=self._auth_headers(self._member_readonly_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, html_bytes)
+        self.assertIn("text/html", response.headers.get("content-type", ""))
+        self.assertIn("attachment", response.headers.get("content-disposition", ""))
+        self.assertIn("preview.html", response.headers.get("content-disposition", ""))
+        self.assertEqual(response.headers.get("x-content-type-options"), "nosniff")
+
+    def test_member_without_read_access_cannot_fetch_raw_bytes(self):
+        """A file in another vault returns 403 before serving bytes."""
+        self._seed_document_file(31, 2, "private.pdf", b"%PDF-1.4\nprivate\n")
+
+        response = self.client.get(
+            "/api/documents/31/raw",
+            headers=self._auth_headers(self._member_no_access_token()),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("No read access", response.text)
+
+    def test_document_raw_missing_row_returns_404(self):
+        """Missing document IDs return 404."""
+        response = self.client.get(
+            "/api/documents/404/raw",
+            headers=self._auth_headers(self._superadmin_token()),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_document_raw_missing_file_returns_404(self):
+        """Missing files on disk return a controlled 404."""
+        missing_path = settings.vault_uploads_dir(3) / "missing.pdf"
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO files (
+                    id, file_name, file_path, file_size, file_type, status,
+                    chunk_count, vault_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    32,
+                    "missing.pdf",
+                    str(missing_path),
+                    128,
+                    ".pdf",
+                    "indexed",
+                    1,
+                    3,
+                ),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.get(
+            "/api/documents/32/raw",
+            headers=self._auth_headers(self._member_readonly_token()),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_document_raw_rejects_paths_outside_document_roots(self):
+        """DB paths outside configured document roots are not served."""
+        outside_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        outside_path = outside_dir / "outside.pdf"
+        outside_path.write_bytes(b"%PDF-1.4\noutside\n")
+        resolved_outside_path = outside_path.resolve(strict=False)
+        allowed_roots = [
+            root.resolve(strict=False) for root in _allowed_document_roots(settings, 3)
+        ]
+        self.assertFalse(
+            any(_path_is_within(resolved_outside_path, root) for root in allowed_roots)
+        )
+
+        conn = self._get_db_conn()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO files (
+                    id, file_name, file_path, file_size, file_type, status,
+                    chunk_count, vault_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    33,
+                    "outside.pdf",
+                    str(outside_path),
+                    outside_path.stat().st_size,
+                    ".pdf",
+                    "indexed",
+                    1,
+                    3,
+                ),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.get(
+            "/api/documents/33/raw",
+            headers=self._auth_headers(self._member_readonly_token()),
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_document_raw_serves_unknown_extension_as_attachment(self):
+        """Unknown MIME types are still downloadable without inline rendering."""
+        original_bytes = b"opaque bytes"
+        self._seed_document_file(35, 3, "archive.unknownext", original_bytes)
+
+        response = self.client.get(
+            "/api/documents/35/raw",
+            headers=self._auth_headers(self._member_readonly_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, original_bytes)
+        self.assertIn(
+            "application/octet-stream", response.headers.get("content-type", "")
+        )
+        self.assertIn("attachment", response.headers.get("content-disposition", ""))
+        self.assertEqual(response.headers.get("x-content-type-options"), "nosniff")
 
     def test_document_search_matches_metadata_fields(self):
         """Document list search matches metadata, not only filename."""

--- a/docs/release.md
+++ b/docs/release.md
@@ -686,6 +686,29 @@ groups:
 
 ## Release Notes
 
+### Version 0.3.0 (PDF/document viewer - Issue #54)
+
+#### New Features
+
+- Added an authenticated raw-document endpoint for users with vault read access.
+- Added a code-split PDF preview panel that can open cited source documents at the referenced page.
+- Added a non-PDF fallback that downloads original files instead of rendering active content inline.
+
+#### Security
+
+- Raw document responses now validate stored file paths against configured document roots before serving bytes.
+- Non-PDF raw responses are served as attachments with `X-Content-Type-Options: nosniff`.
+
+#### Migration Steps
+
+No database or configuration migration is required.
+
+#### Breaking Changes
+
+None.
+
+---
+
 ### Version 0.2.1 (PR1 performance quick wins — Issue #20)
 
 #### Performance Improvements

--- a/frontend/src/components/chat/RightPane.tsx
+++ b/frontend/src/components/chat/RightPane.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { lazy, Suspense, useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { FileText, Table, Code, ExternalLink, BookOpen, Layers, Loader2 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -16,10 +16,12 @@ import {
   parseCompletedAssistantIds,
 } from "@/stores/useChatStore";
 import { useChatShellStore } from "@/stores/useChatShellStore";
-import { getChunkContext, type ChunkContextResponse, type Source } from "@/lib/api";
+import { getChunkContext, getDocumentRawBlob, type ChunkContextResponse, type Source } from "@/lib/api";
 import { WikiCards } from "./WikiCards";
 import { getRelevanceLabel, type ScoreType } from "@/lib/relevance";
 import { EmptyState } from "@/components/shared/EmptyState";
+
+const PdfPreview = lazy(() => import("@/components/preview/PdfPreview"));
 
 interface StructuredOutput {
   id: string;
@@ -266,11 +268,26 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
   const [chunkContext, setChunkContext] = useState<ChunkContextResponse | null>(null);
   const [isLoadingContext, setIsLoadingContext] = useState(false);
   const [contextError, setContextError] = useState<string | null>(null);
+  const [documentPreview, setDocumentPreview] = useState<{
+    url: string;
+    isPdf: boolean;
+    filename: string;
+  } | null>(null);
+  const [isLoadingDocument, setIsLoadingDocument] = useState(false);
+  const [documentError, setDocumentError] = useState<string | null>(null);
+  const documentAbortRef = useRef<AbortController | null>(null);
   const previewContent = chunkContext?.context_text || source.snippet || "";
   const highlightedContent = useMemo(
     () => highlightQueryTerms(previewContent, query),
     [previewContent, query]
   );
+  const sourceFileId = source.file_id;
+  const sourcePageNumber =
+    typeof source.page_number === "number"
+      ? source.page_number
+      : typeof source.metadata?.page_number === "number"
+        ? source.metadata.page_number
+        : null;
 
   useEffect(() => {
     let cancelled = false;
@@ -298,6 +315,57 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
     };
   }, [source.id]);
 
+  useEffect(() => {
+    setDocumentError(null);
+    setIsLoadingDocument(false);
+    documentAbortRef.current?.abort();
+    documentAbortRef.current = null;
+    setDocumentPreview((current) => {
+      if (current) URL.revokeObjectURL(current.url);
+      return null;
+    });
+  }, [source.id]);
+
+  useEffect(() => {
+    return () => {
+      documentAbortRef.current?.abort();
+      if (documentPreview) URL.revokeObjectURL(documentPreview.url);
+    };
+  }, [documentPreview]);
+
+  const handleOpenDocument = useCallback(async () => {
+    if (!sourceFileId) return;
+
+    documentAbortRef.current?.abort();
+    const controller = new AbortController();
+    documentAbortRef.current = controller;
+    setIsLoadingDocument(true);
+    setDocumentError(null);
+
+    try {
+      const blob = await getDocumentRawBlob(sourceFileId, controller.signal);
+      if (controller.signal.aborted || documentAbortRef.current !== controller) return;
+      const nextUrl = URL.createObjectURL(blob);
+      const contentType = blob.type.toLowerCase();
+      const isPdf =
+        contentType.includes("pdf") || source.filename.toLowerCase().endsWith(".pdf");
+      setDocumentPreview((current) => {
+        if (current) URL.revokeObjectURL(current.url);
+        return { url: nextUrl, isPdf, filename: source.filename };
+      });
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setDocumentError(
+        err instanceof Error ? err.message : "Could not open original document"
+      );
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoadingDocument(false);
+        documentAbortRef.current = null;
+      }
+    }
+  }, [source.filename, sourceFileId]);
+
   return (
     <div className="flex flex-col h-full min-h-0 gap-4">
       <div className="flex items-center justify-between flex-shrink-0">
@@ -305,13 +373,30 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
           <FileText className="h-4 w-4 text-primary" />
           <h3 className="font-semibold">{source.filename}</h3>
         </div>
-        <Button variant="ghost" size="sm" onClick={onJumpToAnswer}>
-          <ExternalLink className="h-3.5 w-3.5 mr-1" />
-          Jump to answer
-        </Button>
+        <div className="flex items-center gap-1">
+          {sourceFileId && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleOpenDocument}
+              disabled={isLoadingDocument}
+            >
+              {isLoadingDocument ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+              ) : (
+                <FileText className="h-3.5 w-3.5 mr-1" />
+              )}
+              Open document
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={onJumpToAnswer}>
+            <ExternalLink className="h-3.5 w-3.5 mr-1" />
+            Jump to answer
+          </Button>
+        </div>
       </div>
 
-      {(source.snippet || chunkContext?.context_source || isLoadingContext || contextError) && (
+      {(source.snippet || chunkContext?.context_source || isLoadingContext || contextError || documentError) && (
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground flex-shrink-0">
           {isLoadingContext && (
             <span className="inline-flex items-center gap-1">
@@ -326,6 +411,9 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
           )}
           {contextError && (
             <span className="text-warning-foreground">{contextError}</span>
+          )}
+          {documentError && (
+            <span className="text-warning-foreground">{documentError}</span>
           )}
           {source.snippet && (
             <span className="min-w-0 flex-1 truncate italic">
@@ -344,11 +432,31 @@ function SourcePreview({ source, query, onJumpToAnswer }: SourcePreviewProps) {
         </div>
       )}
 
-      <ScrollArea className="flex-1 min-h-0 rounded-md border p-4">
-        <div className="text-sm leading-relaxed whitespace-pre-wrap">
-          {previewContent ? highlightedContent : "No preview content available."}
+      {documentPreview ? (
+        <div className="flex-1 min-h-0">
+          <Suspense
+            fallback={
+              <div className="flex h-full items-center justify-center rounded-md border text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading viewer
+              </div>
+            }
+          >
+            <PdfPreview
+              blobUrl={documentPreview.url}
+              filename={documentPreview.filename}
+              isPdf={documentPreview.isPdf}
+              pageNumber={sourcePageNumber}
+            />
+          </Suspense>
         </div>
-      </ScrollArea>
+      ) : (
+        <ScrollArea className="flex-1 min-h-0 rounded-md border p-4">
+          <div className="text-sm leading-relaxed whitespace-pre-wrap">
+            {previewContent ? highlightedContent : "No preview content available."}
+          </div>
+        </ScrollArea>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/chat/RightPane.virtualization.test.tsx
+++ b/frontend/src/components/chat/RightPane.virtualization.test.tsx
@@ -2,10 +2,15 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { RightPane } from "./RightPane";
 import * as useChatStoreModule from "@/stores/useChatStore";
 import * as useChatShellStoreModule from "@/stores/useChatShellStore";
+
+const apiMocks = vi.hoisted(() => ({
+  getChunkContext: vi.fn(),
+  getDocumentRawBlob: vi.fn(),
+}));
 
 // Mock @tanstack/react-virtual
 vi.mock("@tanstack/react-virtual", () => ({
@@ -87,6 +92,11 @@ vi.mock("@/stores/useChatShellStore", () => ({
   useChatShellStore: vi.fn(),
 }));
 
+vi.mock("@/lib/api", () => ({
+  getChunkContext: (...args: unknown[]) => apiMocks.getChunkContext(...args),
+  getDocumentRawBlob: (...args: unknown[]) => apiMocks.getDocumentRawBlob(...args),
+}));
+
 // Mock UI components with proper interactivity
 const mockOnValueChange = vi.fn();
 
@@ -121,11 +131,16 @@ vi.mock("@/components/ui/scroll-area", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, onClick, variant, size, ...props }: any) => (
-    <button data-testid={props["data-testid"]} onClick={onClick} {...props}>
-      {children}
-    </button>
-  ),
+  Button: ({ children, onClick, variant, size, asChild, ...props }: any) => {
+    if (asChild) {
+      return children;
+    }
+    return (
+      <button data-testid={props["data-testid"]} onClick={onClick} {...props}>
+        {children}
+      </button>
+    );
+  },
 }));
 
 const mockUseChatStore = useChatStoreModule.useChatStore as unknown as ReturnType<
@@ -169,6 +184,12 @@ describe("RightPane virtualization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockOnValueChange.mockClear();
+    apiMocks.getChunkContext.mockRejectedValue(new Error("No context"));
+    apiMocks.getDocumentRawBlob.mockResolvedValue(
+      new Blob(["%PDF-1.4\n"], { type: "application/pdf" })
+    );
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:preview");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
 
     // Default store mocks
     mockUseChatStore.mockReturnValue({
@@ -579,6 +600,154 @@ describe("RightPane virtualization", () => {
 
       rerender(<RightPane />);
       expect(screen.getByLabelText("Sources list")).toBeInTheDocument();
+    });
+  });
+
+  describe("document preview", () => {
+    it("fetches document bytes through the authenticated API and targets the cited PDF page", async () => {
+      const source = createMockSource({
+        id: "src-pdf",
+        file_id: "42",
+        filename: "manual.pdf",
+        page_number: 5,
+      });
+      mockUseChatStore.mockReturnValue({
+        messages: [
+          createMockMessage({ role: "user", content: "manual" }),
+          createMockMessage({ role: "assistant", content: "response", sources: [source] }),
+        ],
+        expandedSources: new Set(),
+      });
+
+      render(<RightPane />);
+      fireEvent.click(screen.getByText("manual.pdf").closest("button")!);
+      fireEvent.click(await screen.findByRole("button", { name: /open document/i }));
+
+      await waitFor(() => {
+        expect(apiMocks.getDocumentRawBlob).toHaveBeenCalledWith(
+          "42",
+          expect.any(AbortSignal)
+        );
+      });
+      const frame = await screen.findByTitle("Preview of manual.pdf");
+      expect(frame).toHaveAttribute("src", "blob:preview#page=5");
+    });
+
+    it("uses metadata page numbers when source page_number is not flattened", async () => {
+      const source = createMockSource({
+        id: "src-metadata-page",
+        file_id: "45",
+        filename: "appendix.pdf",
+        metadata: { page_number: 9 },
+      });
+      mockUseChatStore.mockReturnValue({
+        messages: [
+          createMockMessage({ role: "user", content: "appendix" }),
+          createMockMessage({ role: "assistant", content: "response", sources: [source] }),
+        ],
+        expandedSources: new Set(),
+      });
+
+      render(<RightPane />);
+      fireEvent.click(screen.getByText("appendix.pdf").closest("button")!);
+      fireEvent.click(await screen.findByRole("button", { name: /open document/i }));
+
+      const frame = await screen.findByTitle("Preview of appendix.pdf");
+      expect(frame).toHaveAttribute("src", "blob:preview#page=9");
+    });
+
+    it("falls back to downloading the original for non-PDF sources", async () => {
+      apiMocks.getDocumentRawBlob.mockResolvedValueOnce(
+        new Blob(["<script>window.opener.location='https://evil.example'</script>"], {
+          type: "text/html",
+        })
+      );
+      const source = createMockSource({
+        id: "src-html",
+        file_id: "43",
+        filename: "preview.html",
+      });
+      mockUseChatStore.mockReturnValue({
+        messages: [
+          createMockMessage({ role: "user", content: "preview" }),
+          createMockMessage({ role: "assistant", content: "response", sources: [source] }),
+        ],
+        expandedSources: new Set(),
+      });
+
+      render(<RightPane />);
+      fireEvent.click(screen.getByText("preview.html").closest("button")!);
+      fireEvent.click(await screen.findByRole("button", { name: /open document/i }));
+
+      expect(await screen.findByText("Preview is available for PDF files.")).toBeInTheDocument();
+      const fallbackLink = screen.getByRole("link", { name: /download original/i });
+      expect(fallbackLink).toHaveAttribute("href", "blob:preview");
+      expect(fallbackLink).toHaveAttribute("download", "preview.html");
+      expect(fallbackLink).not.toHaveAttribute("target");
+    });
+
+    it("revokes object URLs when the preview unmounts", async () => {
+      const source = createMockSource({
+        id: "src-cleanup",
+        file_id: "44",
+        filename: "cleanup.pdf",
+      });
+      mockUseChatStore.mockReturnValue({
+        messages: [
+          createMockMessage({ role: "user", content: "cleanup" }),
+          createMockMessage({ role: "assistant", content: "response", sources: [source] }),
+        ],
+        expandedSources: new Set(),
+      });
+
+      const { unmount } = render(<RightPane />);
+      fireEvent.click(screen.getByText("cleanup.pdf").closest("button")!);
+      fireEvent.click(await screen.findByRole("button", { name: /open document/i }));
+
+      await screen.findByTitle("Preview of cleanup.pdf");
+      unmount();
+
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+    });
+
+    it("does not create a stale object URL when an aborted request resolves", async () => {
+      let resolveBlob!: (blob: Blob) => void;
+      apiMocks.getDocumentRawBlob.mockReturnValueOnce(
+        new Promise<Blob>((resolve) => {
+          resolveBlob = resolve;
+        })
+      );
+      const source = createMockSource({
+        id: "src-aborted",
+        file_id: "46",
+        filename: "aborted.pdf",
+      });
+      mockUseChatStore.mockReturnValue({
+        messages: [
+          createMockMessage({ role: "user", content: "abort" }),
+          createMockMessage({ role: "assistant", content: "response", sources: [source] }),
+        ],
+        expandedSources: new Set(),
+      });
+
+      const { unmount } = render(<RightPane />);
+      fireEvent.click(screen.getByText("aborted.pdf").closest("button")!);
+      fireEvent.click(await screen.findByRole("button", { name: /open document/i }));
+
+      await waitFor(() => {
+        expect(apiMocks.getDocumentRawBlob).toHaveBeenCalledWith(
+          "46",
+          expect.any(AbortSignal)
+        );
+      });
+      unmount();
+
+      await act(async () => {
+        resolveBlob(new Blob(["%PDF-1.4\n"], { type: "application/pdf" }));
+        await Promise.resolve();
+      });
+
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/preview/PdfPreview.test.tsx
+++ b/frontend/src/components/preview/PdfPreview.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PdfPreview from "./PdfPreview";
+
+describe("PdfPreview", () => {
+  it("renders non-PDF fallback as a real download link through Button asChild", () => {
+    render(
+      <PdfPreview
+        blobUrl="blob:preview"
+        filename="preview.html"
+        isPdf={false}
+      />
+    );
+
+    const link = screen.getByRole("link", { name: /download original/i });
+    expect(link).toHaveAttribute("href", "blob:preview");
+    expect(link).toHaveAttribute("download", "preview.html");
+    expect(link).not.toHaveAttribute("target");
+  });
+});

--- a/frontend/src/components/preview/PdfPreview.tsx
+++ b/frontend/src/components/preview/PdfPreview.tsx
@@ -1,0 +1,60 @@
+import { Download, ExternalLink, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface PdfPreviewProps {
+  blobUrl: string;
+  filename: string;
+  isPdf: boolean;
+  pageNumber?: number | null;
+}
+
+export default function PdfPreview({
+  blobUrl,
+  filename,
+  isPdf,
+  pageNumber,
+}: PdfPreviewProps) {
+  const pageTarget =
+    isPdf && pageNumber && pageNumber > 0 ? `${blobUrl}#page=${pageNumber}` : blobUrl;
+
+  if (!isPdf) {
+    return (
+      <div className="flex h-full min-h-[220px] flex-col items-center justify-center gap-3 rounded-md border bg-muted/20 p-6 text-center">
+        <FileText className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <p className="text-sm font-medium">{filename}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Preview is available for PDF files.
+          </p>
+        </div>
+        <Button size="sm" variant="outline" asChild>
+          <a href={blobUrl} download={filename}>
+            <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+            Download original
+          </a>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-[320px] flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span className="truncate">
+          {pageNumber && pageNumber > 0 ? `Page ${pageNumber}` : "PDF preview"}
+        </span>
+        <Button size="sm" variant="ghost" asChild>
+          <a href={pageTarget} target="_blank" rel="noreferrer">
+            <ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" />
+            Open
+          </a>
+        </Button>
+      </div>
+      <iframe
+        title={`Preview of ${filename}`}
+        src={pageTarget}
+        className="h-full min-h-[300px] w-full rounded-md border bg-background"
+      />
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -576,9 +576,11 @@ export interface Source {
   section?: string;
   source_label?: string;
   evidence_type?: "primary" | "supporting";
+  page_number?: number | null;
   snippet?: string;
   score?: number;
   score_type?: "distance" | "rerank" | "rrf";
+  metadata?: Record<string, unknown>;
 }
 
 export interface ChunkContextResponse {
@@ -935,6 +937,20 @@ export async function getDocumentStatus(
 ): Promise<DocumentStatusResponse> {
   const response = await apiClient.get<DocumentStatusResponse>(
     `/documents/${fileId}/status`
+  );
+  return response.data;
+}
+
+export async function getDocumentRawBlob(
+  fileId: string | number,
+  signal?: AbortSignal
+): Promise<Blob> {
+  const response = await apiClient.get<Blob>(
+    `/documents/${fileId}/raw`,
+    {
+      responseType: "blob",
+      signal,
+    }
   );
   return response.data;
 }


### PR DESCRIPTION
## Summary
- Adds an authenticated `/api/documents/{file_id}/raw` endpoint guarded by vault read access and document-root path validation.
- Adds a code-split document preview panel that fetches raw bytes through the authenticated API and targets cited PDF pages.
- Keeps non-PDF fallback safe by serving non-PDF originals as attachments with `nosniff` and downloading them from the UI instead of opening active blob content.

## Review follow-up
- Removed the unpopulated `chunk_bbox` API field instead of shipping dead public plumbing.
- Hardened the outside-root regression test with a separate temp directory and explicit non-containment assertion.
- Added real-Button coverage for the non-PDF download fallback and unknown-MIME attachment coverage.
- Addressed Copilot's stale async preview comment by ignoring aborted/stale document fetch resolutions before creating blob URLs.

## Invariant audit
1 (plugin initialization): not touched - changed files are backend document routes/retrieval/tests, frontend chat preview/API, and docs/release.md only.
2 (runtime portability): not touched - no runtime entrypoint or package manager changes; `npm run build` passed.
3 (subprocesses): not touched - `rg -n spawn\(|spawnSync\(|subprocess|Process\( <changed files>` returned no matches.
4 (workflow pinning): not touched - no `.github/workflows` files changed.
5 (document path safety): touched - raw endpoint validates resolved file paths against configured document roots; covered by `test_document_raw_rejects_paths_outside_document_roots`.
6 (test_runner safety): not touched - no OpenCode `test_runner` validation was used.
7 (test writing): touched - local writing-tests skill loaded for audit; new coverage uses this repo's pytest/vitest patterns and passes focused validation.
8 (authz): touched - raw endpoint requires auth and vault read access; covered by unauthenticated, allowed, forbidden, missing-row, and missing-file tests.
9 (active-content fallback): touched - HTML-capable non-PDF bytes are attachment-only with `X-Content-Type-Options: nosniff`; frontend fallback uses a download link without `target`.
10 (PDF code splitting): touched - `npm run build` passed and emitted a separate `PdfPreview-*.js` chunk.
11 (source page targeting): touched - source metadata carries `page_number`; frontend tests cover direct and metadata fallback page targeting.
12 (release notes): touched - added `docs/release.md` notes for version 0.3.0 covering behavior, security, migration, and breaking changes.

## Test plan
- [x] `python -m pytest tests/test_documents_auth.py -k raw -q`
- [x] `npm test -- src/components/chat/RightPane.virtualization.test.tsx src/components/preview/PdfPreview.test.tsx`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `python -m ruff check app tests/test_documents_auth.py`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `python -m pytest tests/test_documents_auth.py -q` (32 passed, 1 pre-existing failure documented below)

## Pre-existing failures
- `python -m pytest tests/test_documents_auth.py -q` still fails `TestRoleAdminRequired.test_regular_member_post_documents_batch_returns_403`: expected 403, got 422 because the test posts a raw JSON list to a route that validates an embedded `file_ids` body before role authorization. This same failure was confirmed on `origin/master` before this PR's final patch.

## Release notes
- Added `docs/release.md` entry for version 0.3.0.