### PR TITLE
fix(ingestion): add safe concurrent ingestion controls

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -94,6 +94,8 @@ class Settings(BaseSettings):
     """Number of chunks between optimize() calls when optimize_mode is 'periodic'."""
     embedding_concurrent_batches: int = 4
     """Maximum number of embedding batches to process concurrently (1-16). Set to 1 for sequential behavior."""
+    embedding_global_concurrent_batches: int = 4
+    """Global cap for concurrent embedding batch API calls across all simultaneous documents (1-16)."""
     optimize_on_shutdown: bool = True
     """When True, BackgroundProcessor.stop() calls VectorStore.flush_optimize() during graceful shutdown."""
 
@@ -582,6 +584,12 @@ class Settings(BaseSettings):
     def validate_embedding_concurrent_batches(cls, v: int) -> int:
         """Validate embedding concurrent batches is in range 1..16."""
         return cls._validate_int_range(v, 1, 16, "embedding_concurrent_batches")
+
+    @field_validator("embedding_global_concurrent_batches", mode="after")
+    @classmethod
+    def validate_embedding_global_concurrent_batches(cls, v: int) -> int:
+        """Validate global embedding concurrent batches is in range 1..16."""
+        return cls._validate_int_range(v, 1, 16, "embedding_global_concurrent_batches")
 
     @field_validator("embedding_batch_size", mode="after")
     @classmethod

--- a/backend/app/services/background_tasks.py
+++ b/backend/app/services/background_tasks.py
@@ -197,19 +197,22 @@ class BackgroundProcessor:
         self._running = True
         self.shutdown_event.clear()
         await self._recover_stranded_pending_rows()
-        # Spawn N workers based on configuration
-        self._worker_tasks = []
-        for i in range(settings.ingestion_worker_count):
-            task = asyncio.create_task(self._worker_loop(), name=f"worker-{i}")
-            self._worker_tasks.append(task)
-        logger.info(f"Background processor started with {settings.ingestion_worker_count} worker(s)")
 
-        # Create write semaphore for SQLite contention when running multiple workers
-        if settings.ingestion_worker_count > 1:
+        worker_count = settings.ingestion_worker_count
+        # Create write semaphore before workers can consume queued/recovered items.
+        if worker_count > 1:
             self._write_semaphore = asyncio.Semaphore(1)
             self.processor._write_semaphore = self._write_semaphore
         else:
             self._write_semaphore = None
+            self.processor._write_semaphore = None
+
+        # Spawn N workers based on configuration
+        self._worker_tasks = []
+        for i in range(worker_count):
+            task = asyncio.create_task(self._worker_loop(), name=f"worker-{i}")
+            self._worker_tasks.append(task)
+        logger.info(f"Background processor started with {worker_count} worker(s)")
 
     async def _recover_stranded_pending_rows(self) -> None:
         """Re-enqueue any `files` rows left at status='pending' from a prior process.

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import sqlite3
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,6 +40,35 @@ from .schema_parser import SchemaParser
 from .vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
+
+_STAGE_TIMING_FIELDS = (
+    "parse_ms",
+    "chunk_ms",
+    "contextual_ms",
+    "parent_window_ms",
+    "enrichment_ms",
+    "embedding_ms",
+    "vector_write_ms",
+    "optimize_ms",
+    "sqlite_finalize_ms",
+)
+
+
+def _new_stage_timings() -> dict[str, float]:
+    return {field: 0.0 for field in _STAGE_TIMING_FIELDS}
+
+
+def _add_elapsed_ms(timings: dict[str, float], field: str, started_at: float) -> None:
+    timings[field] += (time.monotonic() - started_at) * 1000
+
+
+def _merge_vector_timings(
+    timings: dict[str, float], vector_timings: Optional[dict[str, float]]
+) -> None:
+    if not vector_timings:
+        return
+    timings["vector_write_ms"] += vector_timings.get("vector_write_ms", 0.0)
+    timings["optimize_ms"] += vector_timings.get("optimize_ms", 0.0)
 
 
 @dataclass
@@ -968,7 +998,10 @@ class DocumentProcessor:
         return processed_chunks
 
     async def _process_document_file(
-        self, file_path: str, file_id: Optional[int] = None
+        self,
+        file_path: str,
+        file_id: Optional[int] = None,
+        stage_timings: Optional[dict[str, float]] = None,
     ) -> Tuple[List[ProcessedChunk], str]:
         """
         Process a document file using DocumentParser and SemanticChunker.
@@ -980,6 +1013,7 @@ class DocumentProcessor:
         Returns:
             Tuple of (List of ProcessedChunk objects, document text as string)
         """
+        parse_started_at = time.monotonic()
         try:
             elements = await asyncio.wait_for(
                 asyncio.to_thread(self.parser.parse, file_path),
@@ -989,10 +1023,14 @@ class DocumentProcessor:
             raise DocumentProcessingError(
                 f"Document parsing timed out after {settings.document_parse_timeout}s: {file_path}"
             )
+        finally:
+            if stage_timings is not None:
+                _add_elapsed_ms(stage_timings, "parse_ms", parse_started_at)
         # Join all element texts for use as context in contextual chunking
         document_text = "\n".join([str(e) for e in elements])
 
         # Check if multi-scale indexing is enabled
+        chunk_started_at = time.monotonic()
         if settings.multi_scale_indexing_enabled:
             # Parse chunk sizes from settings
             scale_strs = settings.multi_scale_chunk_sizes.split(",")
@@ -1028,12 +1066,16 @@ class DocumentProcessor:
                 scale_list,
             )
 
+            if stage_timings is not None:
+                _add_elapsed_ms(stage_timings, "chunk_ms", chunk_started_at)
             return all_chunks, document_text
         else:
             # Existing single-scale behavior — use the live-settings chunker so
             # chunk_size_chars / chunk_overlap_chars changes apply per-document.
             active_chunker = self._get_chunker()
             chunks = await asyncio.to_thread(active_chunker.chunk_elements, elements)
+            if stage_timings is not None:
+                _add_elapsed_ms(stage_timings, "chunk_ms", chunk_started_at)
             return chunks, document_text
 
     async def process_file(
@@ -1072,6 +1114,7 @@ class DocumentProcessor:
 
         # Compute file hash
         file_hash = compute_file_hash(file_path)
+        stage_timings = _new_stage_timings()
 
         # Phase 1: Quick DB operations - get connection, do quick ops, release
         if self._write_semaphore:
@@ -1118,7 +1161,9 @@ class DocumentProcessor:
         try:
             # Process the file based on type
             if self._is_schema_file(file_path):
+                stage_started_at = time.monotonic()
                 chunks = await self._process_schema_file(file_path)
+                _add_elapsed_ms(stage_timings, "parse_ms", stage_started_at)
                 document_text = ""
             elif self._is_spreadsheet_file(file_path):
                 set_phase(
@@ -1127,11 +1172,13 @@ class DocumentProcessor:
                     phase=PHASE_PARSING,
                     message="Parsing spreadsheet (large spreadsheets can take several minutes)",
                 )
+                stage_started_at = time.monotonic()
                 chunks = await self._process_spreadsheet_file(file_path)
+                _add_elapsed_ms(stage_timings, "parse_ms", stage_started_at)
                 document_text = " ".join(c.text for c in chunks)
             else:
                 chunks, document_text = await self._process_document_file(
-                    file_path, file_id
+                    file_path, file_id, stage_timings
                 )
 
             set_phase(
@@ -1154,6 +1201,7 @@ class DocumentProcessor:
                         len(chunks),
                         source_filename,
                     )
+                    stage_started_at = time.monotonic()
                     try:
                         await chunker.contextualize_chunks(
                             document_text=document_text,
@@ -1171,6 +1219,8 @@ class DocumentProcessor:
                             source_filename,
                             str(e),
                         )
+                    finally:
+                        _add_elapsed_ms(stage_timings, "contextual_ms", stage_started_at)
                 # else: _get_contextual_chunker already logged a warning if needed
 
             # Compute parent window offsets for small-to-big retrieval (Issue #12)
@@ -1183,6 +1233,7 @@ class DocumentProcessor:
                     Path(file_path).name,
                 )
             if document_text and chunks:
+                stage_started_at = time.monotonic()
                 try:
                     compute_parent_windows(
                         chunks,
@@ -1195,6 +1246,8 @@ class DocumentProcessor:
                         Path(file_path).name,
                         e,
                     )
+                finally:
+                    _add_elapsed_ms(stage_timings, "parent_window_ms", stage_started_at)
 
             if not chunks:
                 raise DocumentProcessingError(
@@ -1216,6 +1269,7 @@ class DocumentProcessor:
             # Chunk enrichment: generate auxiliary metadata (summary, questions, entities)
             enrichment_service = self._get_chunk_enrichment_service()
             if enrichment_service is not None:
+                stage_started_at = time.monotonic()
                 try:
                     chunk_dicts = [
                         {
@@ -1241,6 +1295,8 @@ class DocumentProcessor:
                         source_filename,
                         str(e),
                     )
+                finally:
+                    _add_elapsed_ms(stage_timings, "enrichment_ms", stage_started_at)
 
             # Generate embeddings and store in vector store
             if self.embedding_service is not None and self.vector_store is not None:
@@ -1275,9 +1331,11 @@ class DocumentProcessor:
                         percent=0.0,
                     )
                     # Generate dense embeddings (Harrier dense-only)
+                    stage_started_at = time.monotonic()
                     embeddings_result = await self.embedding_service.embed_batch(
                         texts, fail_fast=False
                     )
+                    _add_elapsed_ms(stage_timings, "embedding_ms", stage_started_at)
                     batch_embeddings, failed_batch_indices = embeddings_result
 
                     # Handle partial embedding failures
@@ -1434,17 +1492,22 @@ class DocumentProcessor:
 
                     # Initialize vector table with embedding dimension and add chunks
                     embedding_dim = len(embeddings[0])
+                    stage_started_at = time.monotonic()
                     await self.vector_store.init_table(embedding_dim)
+                    _add_elapsed_ms(stage_timings, "vector_write_ms", stage_started_at)
 
                     if settings.reupload_safe_order:
                         # Safe re-upload: insert new generation first, then delete old (Issue #13)
                         # Step 1+2: Insert new-generation chunks (hash-prefixed IDs)
-                        await self.vector_store.add_chunks(records)
+                        vector_timings = await self.vector_store.add_chunks(records)
+                        _merge_vector_timings(stage_timings, vector_timings)
                         # Step 3: Delete old-generation chunks for this file
                         # (chunks whose IDs don't start with the new hash prefix)
+                        stage_started_at = time.monotonic()
                         deleted = await self.vector_store.delete_old_generation_by_file(
                             str(file_id), file_hash[:8]
                         )
+                        _add_elapsed_ms(stage_timings, "vector_write_ms", stage_started_at)
                         if deleted > 0:
                             logger.info(
                                 "Safe re-upload: deleted %d old-generation chunks for file_id=%s",
@@ -1453,8 +1516,11 @@ class DocumentProcessor:
                             )
                     else:
                         # Legacy: delete-then-insert (not crash-safe, kept for compat)
+                        stage_started_at = time.monotonic()
                         await self.vector_store.delete_by_file(str(file_id))
-                        await self.vector_store.add_chunks(records)
+                        _add_elapsed_ms(stage_timings, "vector_write_ms", stage_started_at)
+                        vector_timings = await self.vector_store.add_chunks(records)
+                        _merge_vector_timings(stage_timings, vector_timings)
 
                     await self._verify_vector_rows_visible(file_id)
         except Exception as e:
@@ -1482,6 +1548,7 @@ class DocumentProcessor:
             raise
 
         # Phase 3: Final DB operations - update status to indexed
+        stage_started_at = time.monotonic()
         if self._write_semaphore:
             await self._write_semaphore.acquire()
         conn = self.pool.get_connection()
@@ -1536,6 +1603,24 @@ class DocumentProcessor:
         # Clear transient progress fields and pin phase=indexed so polls show
         # a clean "ready" snapshot rather than stale embedding counters.
         clear_progress(self.pool, file_id)
+        _add_elapsed_ms(stage_timings, "sqlite_finalize_ms", stage_started_at)
+
+        logger.info(
+            "Ingestion stage timings file_id=%s file_name=%s parse_ms=%.1f chunk_ms=%.1f "
+            "contextual_ms=%.1f parent_window_ms=%.1f enrichment_ms=%.1f "
+            "embedding_ms=%.1f vector_write_ms=%.1f optimize_ms=%.1f sqlite_finalize_ms=%.1f",
+            file_id,
+            Path(file_path).name,
+            stage_timings["parse_ms"],
+            stage_timings["chunk_ms"],
+            stage_timings["contextual_ms"],
+            stage_timings["parent_window_ms"],
+            stage_timings["enrichment_ms"],
+            stage_timings["embedding_ms"],
+            stage_timings["vector_write_ms"],
+            stage_timings["optimize_ms"],
+            stage_timings["sqlite_finalize_ms"],
+        )
 
         return ProcessedDocument(file_id=file_id, chunks=chunks)
 
@@ -1631,10 +1716,13 @@ class DocumentProcessor:
         # identical to the synchronous path. We re-derive file_hash here for
         # the safe-reupload chunk-id prefix logic; this is cheap I/O.
         file_hash = compute_file_hash(file_path)
+        stage_timings = _new_stage_timings()
 
         try:
             if self._is_schema_file(file_path):
+                stage_started_at = time.monotonic()
                 chunks = await self._process_schema_file(file_path)
+                _add_elapsed_ms(stage_timings, "parse_ms", stage_started_at)
                 document_text = ""
             elif self._is_spreadsheet_file(file_path):
                 set_phase(
@@ -1643,11 +1731,13 @@ class DocumentProcessor:
                     phase=PHASE_PARSING,
                     message="Parsing spreadsheet (large spreadsheets can take several minutes)",
                 )
+                stage_started_at = time.monotonic()
                 chunks = await self._process_spreadsheet_file(file_path)
+                _add_elapsed_ms(stage_timings, "parse_ms", stage_started_at)
                 document_text = " ".join(c.text for c in chunks)
             else:
                 chunks, document_text = await self._process_document_file(
-                    file_path, file_id
+                    file_path, file_id, stage_timings
                 )
 
             set_phase(
@@ -1662,6 +1752,7 @@ class DocumentProcessor:
             if settings.contextual_chunking_enabled and chunks and document_text:
                 chunker = self._get_contextual_chunker()
                 if chunker is not None:
+                    stage_started_at = time.monotonic()
                     try:
                         await chunker.contextualize_chunks(
                             document_text=document_text,
@@ -1674,8 +1765,11 @@ class DocumentProcessor:
                             source_filename,
                             str(e),
                         )
+                    finally:
+                        _add_elapsed_ms(stage_timings, "contextual_ms", stage_started_at)
 
             if document_text and chunks:
+                stage_started_at = time.monotonic()
                 try:
                     compute_parent_windows(
                         chunks,
@@ -1688,6 +1782,8 @@ class DocumentProcessor:
                         Path(file_path).name,
                         e,
                     )
+                finally:
+                    _add_elapsed_ms(stage_timings, "parent_window_ms", stage_started_at)
 
             if not chunks:
                 raise DocumentProcessingError(
@@ -1708,6 +1804,7 @@ class DocumentProcessor:
 
             enrichment_service = self._get_chunk_enrichment_service()
             if enrichment_service is not None:
+                stage_started_at = time.monotonic()
                 try:
                     chunk_dicts = [
                         {
@@ -1728,6 +1825,8 @@ class DocumentProcessor:
                         source_filename,
                         str(e),
                     )
+                finally:
+                    _add_elapsed_ms(stage_timings, "enrichment_ms", stage_started_at)
 
             if self.embedding_service is not None and self.vector_store is not None:
                 if chunks:
@@ -1751,9 +1850,11 @@ class DocumentProcessor:
                         unit="chunks",
                         percent=0.0,
                     )
+                    stage_started_at = time.monotonic()
                     embeddings_result = await self.embedding_service.embed_batch(
                         texts, fail_fast=False
                     )
+                    _add_elapsed_ms(stage_timings, "embedding_ms", stage_started_at)
                     batch_embeddings, failed_batch_indices = embeddings_result
 
                     # Handle partial embedding failures
@@ -1892,13 +1993,18 @@ class DocumentProcessor:
                     )
 
                     embedding_dim = len(embeddings[0])
+                    stage_started_at = time.monotonic()
                     await self.vector_store.init_table(embedding_dim)
+                    _add_elapsed_ms(stage_timings, "vector_write_ms", stage_started_at)
 
                     if settings.reupload_safe_order:
-                        await self.vector_store.add_chunks(records)
+                        vector_timings = await self.vector_store.add_chunks(records)
+                        _merge_vector_timings(stage_timings, vector_timings)
+                        stage_started_at = time.monotonic()
                         deleted = await self.vector_store.delete_old_generation_by_file(
                             str(file_id), file_hash[:8]
                         )
+                        _add_elapsed_ms(stage_timings, "vector_write_ms", stage_started_at)
                         if deleted > 0:
                             logger.info(
                                 "Safe re-upload: deleted %d old-generation chunks for file_id=%s",
@@ -1906,8 +2012,11 @@ class DocumentProcessor:
                                 file_id,
                             )
                     else:
+                        stage_started_at = time.monotonic()
                         await self.vector_store.delete_by_file(str(file_id))
-                        await self.vector_store.add_chunks(records)
+                        _add_elapsed_ms(stage_timings, "vector_write_ms", stage_started_at)
+                        vector_timings = await self.vector_store.add_chunks(records)
+                        _merge_vector_timings(stage_timings, vector_timings)
 
                     await self._verify_vector_rows_visible(file_id)
         except Exception as e:
@@ -1931,6 +2040,7 @@ class DocumentProcessor:
             raise
 
         # Mark indexed
+        stage_started_at = time.monotonic()
         if self._write_semaphore:
             await self._write_semaphore.acquire()
         conn = self.pool.get_connection()
@@ -1980,5 +2090,23 @@ class DocumentProcessor:
             set_wiki_pending(self.pool, file_id, False)
 
         clear_progress(self.pool, file_id)
+        _add_elapsed_ms(stage_timings, "sqlite_finalize_ms", stage_started_at)
+
+        logger.info(
+            "Ingestion stage timings file_id=%s file_name=%s parse_ms=%.1f chunk_ms=%.1f "
+            "contextual_ms=%.1f parent_window_ms=%.1f enrichment_ms=%.1f "
+            "embedding_ms=%.1f vector_write_ms=%.1f optimize_ms=%.1f sqlite_finalize_ms=%.1f",
+            file_id,
+            Path(file_path).name,
+            stage_timings["parse_ms"],
+            stage_timings["chunk_ms"],
+            stage_timings["contextual_ms"],
+            stage_timings["parent_window_ms"],
+            stage_timings["enrichment_ms"],
+            stage_timings["embedding_ms"],
+            stage_timings["vector_write_ms"],
+            stage_timings["optimize_ms"],
+            stage_timings["sqlite_finalize_ms"],
+        )
 
         return ProcessedDocument(file_id=file_id, chunks=chunks)

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -113,6 +113,9 @@ class EmbeddingService:
         "Instruct: Retrieve relevant technical documentation passages.\n"
         "Query: "
     )
+    _global_batch_semaphore: asyncio.Semaphore | None = None
+    _global_batch_semaphore_limit: int | None = None
+    _global_batch_semaphore_loop: asyncio.AbstractEventLoop | None = None
 
     def __init__(self):
         """Initialize the embedding service with HTTP client and provider detection.
@@ -144,6 +147,22 @@ class EmbeddingService:
         # LRU cache. Cache keys include the live model/url/prefix fingerprints,
         # so a settings change naturally invalidates cached entries.
         self._embed_cache = LRUCache(maxsize=1000)
+
+    def _get_global_batch_semaphore(self) -> asyncio.Semaphore:
+        """Return the process-wide embedding batch semaphore for the current loop."""
+        limit = getattr(settings, "embedding_global_concurrent_batches", None)
+        if not isinstance(limit, int):
+            limit = settings.embedding_concurrent_batches
+        loop = asyncio.get_running_loop()
+        if (
+            self.__class__._global_batch_semaphore is None
+            or self.__class__._global_batch_semaphore_limit != limit
+            or self.__class__._global_batch_semaphore_loop is not loop
+        ):
+            self.__class__._global_batch_semaphore = asyncio.Semaphore(limit)
+            self.__class__._global_batch_semaphore_limit = limit
+            self.__class__._global_batch_semaphore_loop = loop
+        return self.__class__._global_batch_semaphore
 
     @property
     def embedding_model(self) -> str:
@@ -489,13 +508,14 @@ class EmbeddingService:
             else:
                 texts_to_embed.append(text)
 
-        # Process batches concurrently using asyncio.gather + semaphore
+        # Process batches concurrently using both per-call and process-wide caps.
         all_embeddings: List[List[float]] = []
         sem = asyncio.Semaphore(settings.embedding_concurrent_batches)
 
         async def _process_batch(batch_texts: List[str]) -> List[List[float]]:
             async with sem:
-                return await self._embed_batch_api(batch_texts)
+                async with self._get_global_batch_semaphore():
+                    return await self._embed_batch_api(batch_texts)
 
         batch_tasks = []
         for i in range(0, len(texts_to_embed), batch_size):

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -83,6 +83,8 @@ class VectorStore:
         self._last_index_build_generation: int = 0
         # Track chunk count between optimize calls when mode is 'periodic'
         self._optimize_counter: int = 0
+        # Serialize LanceDB table mutations, including deferred index creation that
+        # may run before search, when callers share one VectorStore instance.
         self._write_lock = asyncio.Lock()
         # Shared semaphore limiting concurrent LanceDB search operations across all callers.
         # Lazily initialised on first use to avoid event-loop binding issues.
@@ -109,6 +111,10 @@ class VectorStore:
         return self
 
     async def init_table(self, embedding_dim: int) -> "VectorStore":
+        async with self._write_lock:
+            return await self._init_table_unlocked(embedding_dim)
+
+    async def _init_table_unlocked(self, embedding_dim: int) -> "VectorStore":
         """
         Initialize or open the 'chunks' table.
 
@@ -464,12 +470,12 @@ class VectorStore:
                 current_rows,
             )
 
-    async def add_chunks(self, records: List[Dict[str, Any]]) -> None:
+    async def add_chunks(self, records: List[Dict[str, Any]]) -> Dict[str, float]:
         """Serialize chunk writes and related LanceDB maintenance."""
         async with self._write_lock:
             return await self._add_chunks_unlocked(records)
 
-    async def _add_chunks_unlocked(self, records: List[Dict[str, Any]]) -> None:
+    async def _add_chunks_unlocked(self, records: List[Dict[str, Any]]) -> Dict[str, float]:
         """
         Add chunk records to the vector store.
 
@@ -485,8 +491,9 @@ class VectorStore:
             raise RuntimeError("Table not initialized. Call init_table() first.")
 
         # Handle empty records
+        timings = {"vector_write_ms": 0.0, "optimize_ms": 0.0}
         if not records:
-            return
+            return timings
 
         # Get expected embedding dimension from table schema
         expected_dim = await self._get_expected_embedding_dim()
@@ -552,21 +559,27 @@ class VectorStore:
                     )
             processed_records.append(processed_record)
 
+        t0 = time.monotonic()
         await self.table.add(processed_records)
         self._index_mutation_generation += 1
+        timings["vector_write_ms"] += (time.monotonic() - t0) * 1000
 
         # Compact the table per configured optimize_mode
         optimize_mode = settings.optimize_mode
         if optimize_mode == "after_every_write":
             try:
+                t0 = time.monotonic()
                 await self.table.optimize()
+                timings["optimize_ms"] += (time.monotonic() - t0) * 1000
             except Exception as e:
                 logger.warning("table.optimize() after add_chunks failed (non-fatal): %s", e)
         elif optimize_mode == "periodic":
             self._optimize_counter += len(processed_records)
             if self._optimize_counter >= settings.optimize_interval_chunks:
                 try:
+                    t0 = time.monotonic()
                     await self.table.optimize()
+                    timings["optimize_ms"] += (time.monotonic() - t0) * 1000
                     self._optimize_counter = 0
                 except Exception as e:
                     logger.warning(
@@ -577,6 +590,7 @@ class VectorStore:
 
         # Check if we should create the vector index after adding chunks
         await self._maybe_create_vector_index()
+        return timings
 
     async def flush_optimize(self) -> None:
         """Serialize an explicit LanceDB optimize call."""

--- a/backend/tests/test_safe_concurrent_ingestion.py
+++ b/backend/tests/test_safe_concurrent_ingestion.py
@@ -1,0 +1,231 @@
+import asyncio
+import logging
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_background_processor_start_assigns_write_semaphore_before_workers():
+    from app.services.background_tasks import BackgroundProcessor
+
+    processor = BackgroundProcessor()
+    processor.processor = MagicMock()
+    processor.processor.pool = None
+    created_workers = []
+
+    def fake_create_task(coro, name=None):
+        assert processor._write_semaphore is not None
+        assert processor.processor._write_semaphore is processor._write_semaphore
+        coro.close()
+        created_workers.append(name)
+        return MagicMock()
+
+    with patch("app.services.background_tasks.settings") as mock_settings:
+        mock_settings.ingestion_worker_count = 2
+        with patch("app.services.background_tasks.asyncio.create_task", side_effect=fake_create_task):
+            await processor.start()
+
+    assert created_workers == ["worker-0", "worker-1"]
+
+
+@pytest.mark.asyncio
+async def test_worker_count_two_vector_store_mutations_are_serialized():
+    from app.services.background_tasks import BackgroundProcessor
+    from app.services.vector_store import VectorStore
+
+    store = VectorStore()
+    active = 0
+    max_active = 0
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def guarded_operation(*_args):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        if not first_entered.is_set():
+            first_entered.set()
+            await release_first.wait()
+        active -= 1
+        return {"vector_write_ms": 0.0, "optimize_ms": 0.0}
+
+    async def guarded_delete(*_args):
+        await guarded_operation()
+        return 0
+
+    store._add_chunks_unlocked = guarded_operation
+    store._delete_by_file_unlocked = guarded_delete
+
+    processor = BackgroundProcessor()
+    processor.processor = MagicMock()
+    processor.processor.pool = None
+
+    async def process_existing_file(file_id, file_path, vault_id):
+        if file_id == 1:
+            await store.add_chunks([{"id": "1"}])
+        else:
+            await store.delete_by_file("1")
+
+    processor.processor.process_existing_file = AsyncMock(side_effect=process_existing_file)
+
+    with patch("app.services.background_tasks.settings") as mock_settings:
+        mock_settings.ingestion_worker_count = 2
+        await processor.enqueue("first.txt", vault_id=1, file_id=1)
+        await processor.enqueue("second.txt", vault_id=1, file_id=2)
+        await processor.start()
+
+        await first_entered.wait()
+        await asyncio.sleep(0)
+        assert active == 1
+
+        release_first.set()
+        await processor.queue.join()
+        processor.shutdown_event.set()
+        await asyncio.wait_for(
+            asyncio.gather(*processor._worker_tasks, return_exceptions=True),
+            timeout=2,
+        )
+        processor._running = False
+
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_global_semaphore_limits_batches_across_documents():
+    from app.services.embeddings import EmbeddingService
+
+    active = 0
+    max_active = 0
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def fake_embed_batch_api(self, texts):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        if not first_entered.is_set():
+            first_entered.set()
+            await release_first.wait()
+        active -= 1
+        return [[1.0, 2.0] for _ in texts]
+
+    EmbeddingService._global_batch_semaphore = None
+    EmbeddingService._global_batch_semaphore_limit = None
+    EmbeddingService._global_batch_semaphore_loop = None
+
+    with patch("app.services.embeddings.settings") as mock_settings:
+        mock_settings.ollama_embedding_url = "http://localhost:8080/v1/embeddings"
+        mock_settings.embedding_model = "test-model"
+        mock_settings.embedding_doc_prefix = ""
+        mock_settings.embedding_query_prefix = ""
+        mock_settings.embedding_batch_size = 1
+        mock_settings.embedding_batch_max_retries = 3
+        mock_settings.embedding_batch_min_sub_size = 1
+        mock_settings.embedding_concurrent_batches = 4
+        mock_settings.embedding_global_concurrent_batches = 1
+
+        service_a = EmbeddingService()
+        service_b = EmbeddingService()
+        with patch.object(EmbeddingService, "_embed_batch_api", fake_embed_batch_api):
+            task_a = asyncio.create_task(service_a.embed_batch(["a1", "a2"], batch_size=1))
+            task_b = asyncio.create_task(service_b.embed_batch(["b1", "b2"], batch_size=1))
+            await first_entered.wait()
+            await asyncio.sleep(0)
+            assert active == 1
+
+            release_first.set()
+            await asyncio.gather(task_a, task_b)
+
+    assert max_active == 1
+    EmbeddingService._global_batch_semaphore = None
+    EmbeddingService._global_batch_semaphore_limit = None
+    EmbeddingService._global_batch_semaphore_loop = None
+
+
+@pytest.mark.asyncio
+async def test_process_file_emits_one_stage_timing_log(tmp_path, caplog):
+    from app.services.chunking import ProcessedChunk
+    from app.services.document_processor import DocumentProcessor
+
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello world", encoding="utf-8")
+
+    pool = MagicMock()
+    conn = MagicMock()
+    pool.get_connection.return_value = conn
+
+    embedding_service = MagicMock()
+    embedding_service.embed_batch = AsyncMock(return_value=([[0.1, 0.2]], []))
+    vector_store = MagicMock()
+    vector_store.init_table = AsyncMock()
+    vector_store.delete_by_file = AsyncMock(return_value=0)
+    vector_store.add_chunks = AsyncMock(
+        return_value={"vector_write_ms": 1.0, "optimize_ms": 2.0}
+    )
+    vector_store.count_by_file = AsyncMock(return_value=1)
+
+    processor = DocumentProcessor(
+        pool=pool,
+        embedding_service=embedding_service,
+        vector_store=vector_store,
+    )
+    chunk = ProcessedChunk(text="hello world", metadata={}, chunk_index=0)
+
+    with patch("app.services.document_processor.settings") as mock_settings:
+        mock_settings.contextual_chunking_enabled = False
+        mock_settings.parent_retrieval_enabled = True
+        mock_settings.parent_window_chars = 20
+        mock_settings.reupload_safe_order = False
+        mock_settings.embedding_batch_size = 64
+        with patch.object(processor, "_check_duplicate", return_value=None), \
+            patch.object(processor, "_insert_or_get_file_record", return_value=123), \
+            patch.object(processor, "_update_status"), \
+            patch.object(processor, "_validate_chunk_sizes"), \
+            patch.object(processor, "_is_schema_file", return_value=False), \
+            patch.object(processor, "_is_spreadsheet_file", return_value=False), \
+            patch.object(
+                processor,
+                "_process_document_file",
+                new=AsyncMock(return_value=([chunk], "hello world")),
+            ), \
+            patch.object(processor, "_get_chunk_enrichment_service", return_value=None), \
+            patch("app.services.document_processor.compute_file_hash", return_value="abc12345"), \
+            patch("app.services.document_processor.set_phase"), \
+            patch("app.services.document_processor.clear_progress"), \
+            patch("app.services.document_processor.set_wiki_pending"), \
+            patch("app.services.wiki_store.WikiStore") as mock_wiki_store:
+            mock_wiki_store.return_value.create_job.return_value = None
+            caplog.set_level(logging.INFO, logger="app.services.document_processor")
+            await processor.process_file(str(file_path), vault_id=1)
+
+    timing_logs = [
+        record
+        for record in caplog.records
+        if record.message.startswith("Ingestion stage timings")
+    ]
+    assert len(timing_logs) == 1
+    message = timing_logs[0].message
+    timing_values = {
+        match.group("field"): float(match.group("value"))
+        for match in re.finditer(
+            r"(?P<field>[a-z_]+_ms)=(?P<value>\d+(?:\.\d+)?)", message
+        )
+    }
+    for field in (
+        "parse_ms",
+        "chunk_ms",
+        "contextual_ms",
+        "parent_window_ms",
+        "enrichment_ms",
+        "embedding_ms",
+        "vector_write_ms",
+        "optimize_ms",
+        "sqlite_finalize_ms",
+    ):
+        assert field in timing_values
+        assert timing_values[field] >= 0.0
+
+    assert timing_values["vector_write_ms"] >= 1.0
+    assert timing_values["optimize_ms"] == 2.0


### PR DESCRIPTION
## Summary
- Move ingestion SQLite write semaphore setup ahead of worker startup so recovered or queued work cannot race unguarded writes.
- Add process-wide embedding batch throttling and serialize shared LanceDB write/optimize/delete operations while keeping parse and embedding work parallel.
- Emit per-file ingestion stage timing logs and cover the concurrency behavior with focused regressions.

## Test plan
- [x] git diff --check -- passed with non-blocking CRLF normalization warnings
- [x] python -m py_compile backend\app\services\vector_store.py backend\tests\test_safe_concurrent_ingestion.py -- passed
- [x] python -m pytest backend\tests\test_safe_concurrent_ingestion.py -q -- passed, 4 tests
- [x] python -m pytest backend\tests\test_safe_concurrent_ingestion.py backend\tests\test_bottleneck_fixes.py::TestProcessorStartStop backend\tests\test_vector_store_async.py::TestVectorStoreAddChunks backend\tests\test_vector_store_async.py::TestVectorStoreDelete -q -- passed, 27 tests; existing async unittest deprecation/runtime warnings remain in test_vector_store_async.py

## Review follow-up
- Accepted F-002: clarified the VectorStore write-lock comment so it covers deferred index creation before search, not only ingestion add/delete/optimize calls.
- Accepted F-003: strengthened the timing-log regression to parse numeric fields and assert propagated vector_write_ms/optimize_ms values.
- Rejected F-001 for this PR: keeping SQLite writes binary-serialized is the safer concurrency boundary without runtime evidence that wider write concurrency is safe.
- Deferred F-004: the startup-order test is intentionally static, and the two-worker test exercises real worker execution separately.

## Notes
- Rebased onto latest origin/master and preserved the LanceDB index visibility checks from #91.