### PR TITLE
chore(index): add lancedb sqlite reconciliation tooling

### DIFF
--- a/backend/scripts/reconcile_lancedb_sqlite.py
+++ b/backend/scripts/reconcile_lancedb_sqlite.py
@@ -1,0 +1,526 @@
+"""Reconcile indexed SQLite files with LanceDB chunk rows.
+
+The script is safe by default: it reports corpus disagreements and only deletes
+LanceDB rows when a deletion flag is paired with --confirm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import lancedb
+from lancedb.index import IvfPq
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CHUNK_SCALE = "default"
+LANCEDB_RECONCILE_COLUMNS = ("id", "file_id", "vault_id", "chunk_scale")
+LANCEDB_SCAN_BATCH_SIZE = 10_000
+VECTOR_INDEX_MIN_ROWS = 256
+DEFAULT_EMBEDDING_DIM = 1024
+DEFAULT_VECTOR_METRIC = "cosine"
+
+
+def _lance_escape(value: Any) -> str:
+    return str(value).replace("'", "''")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _default_data_dir() -> Path:
+    raw = os.getenv("DATA_DIR")
+    return Path(raw) if raw else BACKEND_ROOT / "data"
+
+
+@dataclass(frozen=True)
+class IndexedFile:
+    file_id: str
+    vault_id: str
+    file_name: str
+    chunk_count: int
+
+
+@dataclass(frozen=True)
+class ChunkRow:
+    id: str
+    file_id: str
+    vault_id: str
+    chunk_scale: str
+
+
+@dataclass(frozen=True)
+class CleanupPlan:
+    orphan_file_ids: tuple[str, ...]
+    orphan_vault_id: str | None
+    stale_multiscale: bool
+
+
+def _as_count_dict(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items(), key=lambda item: item[0]))
+
+
+def _stringify(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _load_indexed_files(sqlite_path: Path) -> dict[str, IndexedFile]:
+    if not sqlite_path.exists():
+        raise FileNotFoundError(f"SQLite database not found: {sqlite_path}")
+
+    with sqlite3.connect(sqlite_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT id, vault_id, file_name, COALESCE(chunk_count, 0) AS chunk_count
+            FROM files
+            WHERE status = 'indexed'
+            ORDER BY vault_id, id
+            """
+        ).fetchall()
+
+    return {
+        str(row["id"]): IndexedFile(
+            file_id=str(row["id"]),
+            vault_id=str(row["vault_id"]),
+            file_name=str(row["file_name"]),
+            chunk_count=int(row["chunk_count"] or 0),
+        )
+        for row in rows
+    }
+
+
+async def _open_chunks_table(lancedb_path: Path) -> Any | None:
+    db = await lancedb.connect_async(str(lancedb_path))
+    table_names = await db.table_names()
+    if "chunks" not in table_names:
+        return None
+    return await db.open_table("chunks")
+
+
+async def _load_lancedb_chunks(table: Any | None) -> list[ChunkRow]:
+    if table is None:
+        return []
+
+    chunks: list[ChunkRow] = []
+    if hasattr(table, "query"):
+        query = table.query().select(list(LANCEDB_RECONCILE_COLUMNS))
+        if hasattr(query, "to_batches"):
+            reader = await query.to_batches(max_batch_length=LANCEDB_SCAN_BATCH_SIZE)
+            async for batch in reader:
+                chunks.extend(_chunk_rows_from_raw_rows(_raw_rows_from_arrowish(batch)))
+            return chunks
+        raw_table = await query.to_arrow()
+    else:
+        raw_table = await table.to_arrow()
+
+    chunks.extend(_chunk_rows_from_raw_rows(_raw_rows_from_arrowish(raw_table)))
+    return chunks
+
+
+def _raw_rows_from_arrowish(raw_table: Any) -> list[Any]:
+    if hasattr(raw_table, "to_pylist"):
+        return raw_table.to_pylist()
+    if hasattr(raw_table, "to_pandas"):
+        return raw_table.to_pandas().to_dict(orient="records")
+    return list(raw_table)
+
+
+def _chunk_rows_from_raw_rows(raw_rows: list[Any]) -> list[ChunkRow]:
+    chunks: list[ChunkRow] = []
+    for row in raw_rows:
+        chunk_scale = _stringify(row.get("chunk_scale")) or DEFAULT_CHUNK_SCALE
+        chunks.append(
+            ChunkRow(
+                id=_stringify(row.get("id")),
+                file_id=_stringify(row.get("file_id")),
+                vault_id=_stringify(row.get("vault_id")),
+                chunk_scale=chunk_scale,
+            )
+        )
+    return chunks
+
+
+def build_report(
+    indexed_files: dict[str, IndexedFile],
+    chunks: list[ChunkRow],
+    *,
+    multi_scale_indexing_enabled: bool,
+) -> dict[str, Any]:
+    sqlite_by_vault: Counter[str] = Counter(
+        indexed_file.vault_id for indexed_file in indexed_files.values()
+    )
+    lancedb_by_vault: Counter[str] = Counter(chunk.vault_id for chunk in chunks)
+    lancedb_by_file: Counter[str] = Counter(chunk.file_id for chunk in chunks)
+    lancedb_by_scale: Counter[str] = Counter(chunk.chunk_scale for chunk in chunks)
+
+    orphan_file_ids = sorted(
+        file_id for file_id in lancedb_by_file if file_id not in indexed_files
+    )
+    orphan_vault_ids = {
+        vault_id: lancedb_by_vault[vault_id]
+        for vault_id in sorted(lancedb_by_vault)
+        if vault_id not in sqlite_by_vault
+    }
+    indexed_files_missing_lancedb_rows = {
+        file_id: {
+            "vault_id": indexed_file.vault_id,
+            "file_name": indexed_file.file_name,
+            "sqlite_chunk_count": indexed_file.chunk_count,
+        }
+        for file_id, indexed_file in sorted(indexed_files.items())
+        if indexed_file.chunk_count > 0 and lancedb_by_file.get(file_id, 0) == 0
+    }
+
+    mismatches_by_file: dict[str, dict[str, Any]] = {}
+    for file_id, indexed_file in indexed_files.items():
+        observed_vaults = sorted(
+            {chunk.vault_id for chunk in chunks if chunk.file_id == file_id}
+        )
+        mismatched_vaults = [
+            vault_id
+            for vault_id in observed_vaults
+            if vault_id != indexed_file.vault_id
+        ]
+        if mismatched_vaults:
+            mismatches_by_file[file_id] = {
+                "sqlite_vault_id": indexed_file.vault_id,
+                "lancedb_vault_ids": observed_vaults,
+                "mismatched_lancedb_vault_ids": mismatched_vaults,
+                "row_count": sum(
+                    1
+                    for chunk in chunks
+                    if chunk.file_id == file_id
+                    and chunk.vault_id in mismatched_vaults
+                ),
+            }
+
+    stale_multiscale_rows = [
+        chunk
+        for chunk in chunks
+        if not multi_scale_indexing_enabled and chunk.chunk_scale != DEFAULT_CHUNK_SCALE
+    ]
+    stale_multiscale_by_scale: Counter[str] = Counter(
+        chunk.chunk_scale for chunk in stale_multiscale_rows
+    )
+
+    return {
+        "sqlite_indexed_files_by_vault_id": _as_count_dict(sqlite_by_vault),
+        "lancedb_chunks_by_vault_id": _as_count_dict(lancedb_by_vault),
+        "lancedb_chunks_by_file_id": _as_count_dict(lancedb_by_file),
+        "lancedb_chunks_by_chunk_scale": _as_count_dict(lancedb_by_scale),
+        "file_ids_present_in_lancedb_but_not_sqlite_indexed": orphan_file_ids,
+        "vault_ids_present_in_lancedb_but_not_sqlite_indexed": orphan_vault_ids,
+        "indexed_sqlite_files_missing_lancedb_rows": indexed_files_missing_lancedb_rows,
+        "vault_id_mismatches_between_sqlite_files_and_lancedb_chunks": dict(
+            sorted(mismatches_by_file.items(), key=lambda item: item[0])
+        ),
+        "stale_multiscale_rows_when_disabled": {
+            "multi_scale_indexing_enabled": multi_scale_indexing_enabled,
+            "row_count": len(stale_multiscale_rows),
+            "by_chunk_scale": _as_count_dict(stale_multiscale_by_scale),
+        },
+        "totals": {
+            "sqlite_indexed_files": len(indexed_files),
+            "lancedb_chunks": len(chunks),
+            "orphan_file_ids": len(orphan_file_ids),
+            "orphan_vault_ids": len(orphan_vault_ids),
+            "indexed_files_missing_lancedb_rows": len(
+                indexed_files_missing_lancedb_rows
+            ),
+            "vault_mismatched_files": len(mismatches_by_file),
+            "stale_multiscale_rows": len(stale_multiscale_rows),
+        },
+    }
+
+
+def _delete_filter_for_file_ids(file_ids: list[str]) -> str:
+    quoted = ", ".join(f"'{_lance_escape(file_id)}'" for file_id in file_ids)
+    return f"file_id IN ({quoted})"
+
+
+async def _delete_with_count(table: Any, filter_expr: str) -> tuple[int, int | None]:
+    count = await table.count_rows(filter_expr)
+    if count > 0:
+        await table.delete(filter_expr)
+    try:
+        remaining = await table.count_rows(filter_expr)
+    except Exception:
+        remaining = None
+    return int(count), None if remaining is None else int(remaining)
+
+
+async def apply_cleanup(table: Any, plan: CleanupPlan) -> dict[str, dict[str, int | None]]:
+    deleted: dict[str, int] = {}
+    remaining: dict[str, int | None] = {}
+
+    if plan.orphan_file_ids:
+        filter_expr = _delete_filter_for_file_ids(list(plan.orphan_file_ids))
+        deleted["orphan_file_id_rows"], remaining["orphan_file_id_rows"] = (
+            await _delete_with_count(table, filter_expr)
+        )
+
+    if plan.orphan_vault_id is not None:
+        safe_vault_id = _lance_escape(plan.orphan_vault_id)
+        filter_expr = f"vault_id = '{safe_vault_id}'"
+        deleted["orphan_vault_rows"], remaining["orphan_vault_rows"] = (
+            await _delete_with_count(table, filter_expr)
+        )
+
+    if plan.stale_multiscale:
+        filter_expr = f"chunk_scale != '{DEFAULT_CHUNK_SCALE}'"
+        deleted["stale_multiscale_rows"], remaining["stale_multiscale_rows"] = (
+            await _delete_with_count(table, filter_expr)
+        )
+
+    return {
+        "deleted_counts": deleted,
+        "remaining_after_delete_counts": remaining,
+    }
+
+
+async def optimize_after_cleanup(table: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {"optimized": False, "index_action": "none"}
+
+    if hasattr(table, "optimize"):
+        try:
+            optimize_stats = await table.optimize()
+            result["optimized"] = True
+            result["optimize_stats"] = repr(optimize_stats)
+        except Exception as exc:
+            result["optimize_error"] = str(exc)
+
+    try:
+        row_count = await table.count_rows()
+    except Exception as exc:
+        result["index_action"] = "index_maintenance_skipped"
+        result["index_error"] = f"count_rows failed: {exc}"
+        return result
+
+    try:
+        indices = await table.list_indices() if hasattr(table, "list_indices") else []
+    except Exception as exc:
+        result["index_action"] = "index_maintenance_skipped"
+        result["index_error"] = f"list_indices failed: {exc}"
+        return result
+    has_embedding_idx = any(
+        getattr(index, "name", "") == "embedding_idx" for index in indices
+    )
+
+    if has_embedding_idx and row_count < VECTOR_INDEX_MIN_ROWS:
+        if hasattr(table, "drop_index"):
+            try:
+                await table.drop_index("embedding_idx")
+                result["index_action"] = "dropped_embedding_idx_below_threshold"
+            except Exception as exc:
+                result["index_action"] = "drop_embedding_idx_failed"
+                result["index_error"] = str(exc)
+        return result
+
+    if row_count >= VECTOR_INDEX_MIN_ROWS:
+        try:
+            embedding_dim = int(os.getenv("EMBEDDING_DIM", str(DEFAULT_EMBEDDING_DIM)))
+            vector_metric = os.getenv("VECTOR_METRIC", DEFAULT_VECTOR_METRIC)
+            await table.create_index(
+                column="embedding",
+                config=IvfPq(
+                    distance_type=vector_metric,
+                    num_partitions=256,
+                    num_sub_vectors=embedding_dim // 8,
+                ),
+                replace=True,
+            )
+            result["index_action"] = "rebuilt_embedding_idx"
+            if hasattr(table, "wait_for_index"):
+                await table.wait_for_index(["embedding_idx"])
+                result["waited_for_index"] = True
+        except Exception as exc:
+            result["index_action"] = "rebuild_embedding_idx_failed"
+            result["index_error"] = str(exc)
+
+    return result
+
+
+def _cleanup_plan_from_report(args: argparse.Namespace, report: dict[str, Any]) -> CleanupPlan:
+    orphan_file_ids: tuple[str, ...] = ()
+    if args.delete_orphan_file_ids:
+        orphan_file_ids = tuple(
+            report["file_ids_present_in_lancedb_but_not_sqlite_indexed"]
+        )
+
+    return CleanupPlan(
+        orphan_file_ids=orphan_file_ids,
+        orphan_vault_id=str(args.delete_orphan_vault)
+        if args.delete_orphan_vault is not None
+        else None,
+        stale_multiscale=bool(
+            args.delete_stale_multiscale
+            and report["stale_multiscale_rows_when_disabled"]["row_count"] > 0
+        ),
+    )
+
+
+def _planned_delete_counts(report: dict[str, Any], plan: CleanupPlan) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    if plan.orphan_file_ids:
+        rows_by_file = report["lancedb_chunks_by_file_id"]
+        counts["orphan_file_id_rows"] = sum(
+            int(rows_by_file.get(file_id, 0)) for file_id in plan.orphan_file_ids
+        )
+    if plan.orphan_vault_id is not None:
+        rows_by_vault = report["lancedb_chunks_by_vault_id"]
+        counts["orphan_vault_rows"] = int(rows_by_vault.get(plan.orphan_vault_id, 0))
+    if plan.stale_multiscale:
+        counts["stale_multiscale_rows"] = int(
+            report["stale_multiscale_rows_when_disabled"]["row_count"]
+        )
+    return counts
+
+
+def _resolve_multi_scale_indexing_enabled(value: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return _env_bool("MULTI_SCALE_INDEXING_ENABLED", False)
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    sqlite_path = Path(args.sqlite_path)
+    lancedb_path = Path(args.lancedb_path)
+
+    indexed_files = _load_indexed_files(sqlite_path)
+    table = await _open_chunks_table(lancedb_path)
+    chunks = await _load_lancedb_chunks(table)
+
+    multi_scale_enabled = _resolve_multi_scale_indexing_enabled(
+        args.multi_scale_indexing_enabled
+    )
+    report = build_report(
+        indexed_files,
+        chunks,
+        multi_scale_indexing_enabled=multi_scale_enabled,
+    )
+
+    plan = _cleanup_plan_from_report(args, report)
+    planned_delete_counts = _planned_delete_counts(report, plan)
+    mutating_flags_requested = bool(planned_delete_counts) or bool(
+        args.optimize_after_cleanup
+    )
+    report["cleanup_plan"] = {
+        "dry_run": args.dry_run or not args.confirm,
+        "requires_confirm": mutating_flags_requested
+        and (args.dry_run or not args.confirm),
+        "planned_delete_counts": planned_delete_counts,
+    }
+
+    if mutating_flags_requested and (args.dry_run or not args.confirm):
+        return report
+
+    if planned_delete_counts:
+        if table is None:
+            report["cleanup_result"] = {
+                "deleted_counts": {},
+                "remaining_after_delete_counts": {},
+            }
+        else:
+            report["cleanup_result"] = await apply_cleanup(table, plan)
+
+    if args.optimize_after_cleanup:
+        if table is None:
+            report["optimize_after_cleanup"] = {"optimized": False, "reason": "no chunks table"}
+        else:
+            report["optimize_after_cleanup"] = await optimize_after_cleanup(table)
+
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Report and optionally clean LanceDB rows that disagree with indexed SQLite files.",
+        epilog=(
+            "Exit codes: 0 report completed; 1 unrecoverable error; "
+            "2 destructive or optimize action requested without --confirm."
+        ),
+    )
+    parser.add_argument(
+        "--sqlite-path",
+        default=str(_default_data_dir() / "app.db"),
+        help="Path to SQLite app.db (default: DATA_DIR/app.db or backend/data/app.db)",
+    )
+    parser.add_argument(
+        "--lancedb-path",
+        default=str(_default_data_dir() / "lancedb"),
+        help="Path to LanceDB directory (default: DATA_DIR/lancedb or backend/data/lancedb)",
+    )
+    parser.add_argument(
+        "--multi-scale-indexing-enabled",
+        choices=("auto", "true", "false"),
+        default="auto",
+        help="Whether non-default chunk_scale rows are current. auto reads MULTI_SCALE_INDEXING_ENABLED, default false.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report only. This is the default unless --confirm is supplied.",
+    )
+    parser.add_argument(
+        "--delete-orphan-file-ids",
+        action="store_true",
+        help="Delete LanceDB rows whose file_id is not an indexed SQLite file.",
+    )
+    parser.add_argument(
+        "--delete-orphan-vault",
+        help="Delete LanceDB rows for this vault_id.",
+    )
+    parser.add_argument(
+        "--delete-stale-multiscale",
+        action="store_true",
+        help="Delete chunk_scale != default rows reported stale when multi-scale indexing is disabled.",
+    )
+    parser.add_argument(
+        "--optimize-after-cleanup",
+        action="store_true",
+        help="Run LanceDB optimize and refresh/drop embedding_idx after cleanup.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Required for any destructive deletion flag.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        report = asyncio.run(_run(args))
+        print(json.dumps(report, indent=2, sort_keys=True))
+        if report["cleanup_plan"]["requires_confirm"]:
+            print(
+                "Destructive cleanup was not run. Re-run with --confirm after reviewing row counts.",
+                file=sys.stderr,
+            )
+            return 2
+    except Exception as exc:
+        print(f"reconciliation failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_reconcile_lancedb_sqlite.py
+++ b/backend/tests/test_reconcile_lancedb_sqlite.py
@@ -1,0 +1,838 @@
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "reconcile_lancedb_sqlite.py"
+SPEC = importlib.util.spec_from_file_location("reconcile_lancedb_sqlite", SCRIPT_PATH)
+reconcile = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = reconcile
+SPEC.loader.exec_module(reconcile)
+
+
+class FakeArrowTable:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def to_pylist(self):
+        return list(self._rows)
+
+
+class FakePandasRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def to_dict(self, orient):
+        assert orient == "records"
+        return list(self._rows)
+
+
+class FakePandasArrowTable:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def to_pandas(self):
+        return FakePandasRows(self._rows)
+
+
+class FakeIterableArrowTable:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class FakeBatchReader:
+    def __init__(self, batches):
+        self._batches = list(batches)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._batches:
+            raise StopAsyncIteration
+        return self._batches.pop(0)
+
+
+class FakeQuery:
+    def __init__(self, batches):
+        self.batches = batches
+        self.selected_columns = None
+
+    def select(self, columns):
+        self.selected_columns = columns
+        return self
+
+    async def to_batches(self, max_batch_length=None):
+        assert max_batch_length == reconcile.LANCEDB_SCAN_BATCH_SIZE
+        return FakeBatchReader(self.batches)
+
+
+class FakeQueryTable:
+    def __init__(self, batches):
+        self.query_obj = FakeQuery(batches)
+
+    def query(self):
+        return self.query_obj
+
+    async def to_arrow(self):
+        raise AssertionError("query projection path should be used")
+
+
+class FakeTable:
+    def __init__(
+        self,
+        rows,
+        indices=None,
+        create_index_error=None,
+        count_rows_error=None,
+        list_indices_error=None,
+    ):
+        self.rows = list(rows)
+        self.indices = list(indices or [])
+        self.create_index_error = create_index_error
+        self.count_rows_error = count_rows_error
+        self.list_indices_error = list_indices_error
+        self.deleted_filters = []
+        self.optimized = False
+        self.dropped_indices = []
+        self.created_indices = []
+        self.waited_indices = []
+
+    async def to_arrow(self):
+        return FakeArrowTable(self.rows)
+
+    async def count_rows(self, filter_expr=None):
+        if self.count_rows_error and not filter_expr:
+            raise self.count_rows_error
+        if not filter_expr:
+            return len(self.rows)
+        return sum(1 for row in self.rows if self._matches(row, filter_expr))
+
+    async def delete(self, filter_expr):
+        self.deleted_filters.append(filter_expr)
+        self.rows = [row for row in self.rows if not self._matches(row, filter_expr)]
+
+    async def optimize(self):
+        self.optimized = True
+        return {"optimized": True}
+
+    async def list_indices(self):
+        if self.list_indices_error:
+            raise self.list_indices_error
+        return self.indices
+
+    async def drop_index(self, name):
+        self.dropped_indices.append(name)
+        self.indices = [index for index in self.indices if index.name != name]
+
+    async def create_index(self, **kwargs):
+        if self.create_index_error:
+            raise self.create_index_error
+        self.created_indices.append(kwargs)
+
+    async def wait_for_index(self, index_names):
+        self.waited_indices.append(list(index_names))
+
+    def _matches(self, row, filter_expr):
+        if filter_expr.startswith("vault_id = "):
+            return row["vault_id"] == filter_expr.split("'", 2)[1]
+        if filter_expr.startswith("chunk_scale != "):
+            return row["chunk_scale"] != filter_expr.split("'", 2)[1]
+        if filter_expr.startswith("file_id IN ("):
+            raw_values = filter_expr.removeprefix("file_id IN (").removesuffix(")")
+            values = {value.strip().strip("'") for value in raw_values.split(",")}
+            return row["file_id"] in values
+        raise AssertionError(f"unexpected filter: {filter_expr}")
+
+
+def create_sqlite_db(tmp_path, rows):
+    db_path = tmp_path / "app.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE files (
+                id INTEGER PRIMARY KEY,
+                vault_id INTEGER NOT NULL,
+                file_name TEXT NOT NULL,
+                chunk_count INTEGER DEFAULT 0,
+                status TEXT NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO files (id, vault_id, file_name, chunk_count, status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+    return db_path
+
+
+def run_main(monkeypatch, tmp_path, sqlite_rows, lancedb_rows, argv):
+    db_path = create_sqlite_db(tmp_path, sqlite_rows)
+    table = FakeTable(lancedb_rows)
+
+    async def open_chunks_table(lancedb_path):
+        assert lancedb_path == tmp_path / "lancedb"
+        return table
+
+    monkeypatch.setattr(reconcile, "_open_chunks_table", open_chunks_table)
+    exit_code = reconcile.main(
+        [
+            "--sqlite-path",
+            str(db_path),
+            "--lancedb-path",
+            str(tmp_path / "lancedb"),
+            *argv,
+        ]
+    )
+    return exit_code, table
+
+
+def run_main_with_table(monkeypatch, tmp_path, sqlite_rows, table, argv):
+    db_path = create_sqlite_db(tmp_path, sqlite_rows)
+
+    async def open_chunks_table(lancedb_path):
+        assert lancedb_path == tmp_path / "lancedb"
+        return table
+
+    monkeypatch.setattr(reconcile, "_open_chunks_table", open_chunks_table)
+    exit_code = reconcile.main(
+        [
+            "--sqlite-path",
+            str(db_path),
+            "--lancedb-path",
+            str(tmp_path / "lancedb"),
+            *argv,
+        ]
+    )
+    return exit_code, table
+
+
+def parse_report(capsys):
+    output = capsys.readouterr()
+    return json.loads(output.out), output
+
+
+class FakeIndex:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeIvfPq:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_dry_run_reports_vault_mismatch(capsys, monkeypatch, tmp_path):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 2, "indexed")],
+        lancedb_rows=[
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "10_1",
+                "file_id": "10",
+                "vault_id": "5",
+                "chunk_scale": "default",
+            },
+        ],
+        argv=["--dry-run"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.deleted_filters == []
+    assert report["sqlite_indexed_files_by_vault_id"] == {"10": 1}
+    assert report["lancedb_chunks_by_vault_id"] == {"10": 1, "5": 1}
+    assert report["vault_ids_present_in_lancedb_but_not_sqlite_indexed"] == {"5": 1}
+    assert report["vault_id_mismatches_between_sqlite_files_and_lancedb_chunks"] == {
+        "10": {
+            "sqlite_vault_id": "10",
+            "lancedb_vault_ids": ["10", "5"],
+            "mismatched_lancedb_vault_ids": ["5"],
+            "row_count": 1,
+        }
+    }
+
+
+def test_dry_run_reports_indexed_sqlite_file_missing_lancedb_rows(
+    capsys, monkeypatch, tmp_path
+):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[
+            (10, 10, "missing.txt", 3, "indexed"),
+            (11, 10, "zero.txt", 0, "indexed"),
+        ],
+        lancedb_rows=[],
+        argv=["--dry-run"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.deleted_filters == []
+    assert report["indexed_sqlite_files_missing_lancedb_rows"] == {
+        "10": {
+            "vault_id": "10",
+            "file_name": "missing.txt",
+            "sqlite_chunk_count": 3,
+        }
+    }
+    assert report["totals"]["indexed_files_missing_lancedb_rows"] == 1
+
+
+def test_dry_run_reports_empty_corpus(capsys, monkeypatch, tmp_path):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[],
+        lancedb_rows=[],
+        argv=["--dry-run"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.deleted_filters == []
+    assert report["sqlite_indexed_files_by_vault_id"] == {}
+    assert report["lancedb_chunks_by_vault_id"] == {}
+    assert report["file_ids_present_in_lancedb_but_not_sqlite_indexed"] == []
+    assert report["vault_ids_present_in_lancedb_but_not_sqlite_indexed"] == {}
+    assert report["totals"] == {
+        "indexed_files_missing_lancedb_rows": 0,
+        "lancedb_chunks": 0,
+        "orphan_file_ids": 0,
+        "orphan_vault_ids": 0,
+        "sqlite_indexed_files": 0,
+        "stale_multiscale_rows": 0,
+        "vault_mismatched_files": 0,
+    }
+
+
+def test_missing_sqlite_path_returns_error(capsys, tmp_path):
+    exit_code = reconcile.main(
+        [
+            "--sqlite-path",
+            str(tmp_path / "missing.db"),
+            "--lancedb-path",
+            str(tmp_path / "lancedb"),
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "SQLite database not found" in output.err
+    assert output.out == ""
+
+
+def test_delete_orphan_vault_requires_confirm(capsys, monkeypatch, tmp_path):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 2, "indexed")],
+        lancedb_rows=[
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "10_1",
+                "file_id": "10",
+                "vault_id": "5",
+                "chunk_scale": "default",
+            },
+        ],
+        argv=["--delete-orphan-vault", "5"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 2
+    assert "Re-run with --confirm" in output.err
+    assert table.deleted_filters == []
+    assert report["cleanup_plan"]["requires_confirm"] is True
+    assert report["cleanup_plan"]["planned_delete_counts"] == {"orphan_vault_rows": 1}
+
+
+def test_delete_orphan_vault_with_confirm_removes_only_requested_vault(
+    capsys, monkeypatch, tmp_path
+):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 2, "indexed")],
+        lancedb_rows=[
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "10_1",
+                "file_id": "10",
+                "vault_id": "5",
+                "chunk_scale": "default",
+            },
+        ],
+        argv=["--delete-orphan-vault", "5", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.deleted_filters == ["vault_id = '5'"]
+    assert table.rows == [
+        {
+            "id": "10_0",
+            "file_id": "10",
+            "vault_id": "10",
+            "chunk_scale": "default",
+        }
+    ]
+    assert report["cleanup_result"]["deleted_counts"] == {"orphan_vault_rows": 1}
+    assert report["cleanup_result"]["remaining_after_delete_counts"] == {
+        "orphan_vault_rows": 0
+    }
+
+
+def test_delete_stale_multiscale_only_when_requested_and_confirmed(
+    capsys, monkeypatch, tmp_path
+):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 2, "indexed")],
+        lancedb_rows=[
+            {
+                "id": "10_default_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "10_512_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "512",
+            },
+        ],
+        argv=[
+            "--multi-scale-indexing-enabled",
+            "false",
+            "--delete-stale-multiscale",
+            "--confirm",
+        ],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.deleted_filters == ["chunk_scale != 'default'"]
+    assert table.rows == [
+        {
+            "id": "10_default_0",
+            "file_id": "10",
+            "vault_id": "10",
+            "chunk_scale": "default",
+        }
+    ]
+    assert report["stale_multiscale_rows_when_disabled"] == {
+        "multi_scale_indexing_enabled": False,
+        "row_count": 1,
+        "by_chunk_scale": {"512": 1},
+    }
+    assert report["cleanup_result"]["deleted_counts"] == {
+        "stale_multiscale_rows": 1
+    }
+    assert report["cleanup_result"]["remaining_after_delete_counts"] == {
+        "stale_multiscale_rows": 0
+    }
+
+
+def test_delete_orphan_file_ids_removes_only_rows_without_indexed_sqlite_file(
+    capsys, monkeypatch, tmp_path
+):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[
+            (10, 10, "valid.txt", 1, "indexed"),
+            (11, 10, "pending.txt", 0, "pending"),
+        ],
+        lancedb_rows=[
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "11_0",
+                "file_id": "11",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "99_0",
+                "file_id": "99",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+        ],
+        argv=["--delete-orphan-file-ids", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert report["file_ids_present_in_lancedb_but_not_sqlite_indexed"] == [
+        "11",
+        "99",
+    ]
+    assert report["cleanup_result"]["deleted_counts"] == {
+        "orphan_file_id_rows": 2
+    }
+    assert report["cleanup_result"]["remaining_after_delete_counts"] == {
+        "orphan_file_id_rows": 0
+    }
+    assert [row["file_id"] for row in table.rows] == ["10"]
+
+
+def test_delete_stale_multiscale_is_noop_when_multiscale_enabled(
+    capsys, monkeypatch, tmp_path
+):
+    exit_code, table = run_main(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 2, "indexed")],
+        lancedb_rows=[
+            {
+                "id": "10_default_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            },
+            {
+                "id": "10_512_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "512",
+            },
+        ],
+        argv=[
+            "--multi-scale-indexing-enabled",
+            "true",
+            "--delete-stale-multiscale",
+            "--confirm",
+        ],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.deleted_filters == []
+    assert [row["chunk_scale"] for row in table.rows] == ["default", "512"]
+    assert report["stale_multiscale_rows_when_disabled"] == {
+        "multi_scale_indexing_enabled": True,
+        "row_count": 0,
+        "by_chunk_scale": {},
+    }
+    assert "cleanup_result" not in report
+
+
+def test_optimize_after_cleanup_drops_embedding_index_below_threshold(
+    capsys, monkeypatch, tmp_path
+):
+    table = FakeTable(
+        [
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            }
+        ],
+        indices=[FakeIndex("embedding_idx")],
+    )
+
+    exit_code, table = run_main_with_table(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 1, "indexed")],
+        table=table,
+        argv=["--optimize-after-cleanup", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.optimized is True
+    assert table.dropped_indices == ["embedding_idx"]
+    assert table.created_indices == []
+    assert report["optimize_after_cleanup"]["index_action"] == (
+        "dropped_embedding_idx_below_threshold"
+    )
+
+
+def test_optimize_after_cleanup_rebuilds_and_waits_for_large_table(
+    capsys, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(reconcile, "IvfPq", FakeIvfPq)
+    rows = [
+        {
+            "id": f"10_{index}",
+            "file_id": "10",
+            "vault_id": "10",
+            "chunk_scale": "default",
+        }
+        for index in range(reconcile.VECTOR_INDEX_MIN_ROWS)
+    ]
+    table = FakeTable(rows)
+
+    exit_code, table = run_main_with_table(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", len(rows), "indexed")],
+        table=table,
+        argv=["--optimize-after-cleanup", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.optimized is True
+    assert len(table.created_indices) == 1
+    assert table.created_indices[0]["column"] == "embedding"
+    assert table.created_indices[0]["replace"] is True
+    assert table.waited_indices == [["embedding_idx"]]
+    assert report["optimize_after_cleanup"]["index_action"] == "rebuilt_embedding_idx"
+    assert report["optimize_after_cleanup"]["waited_for_index"] is True
+
+
+def test_optimize_after_cleanup_requires_confirm(capsys, monkeypatch, tmp_path):
+    table = FakeTable(
+        [
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            }
+        ]
+    )
+
+    exit_code, table = run_main_with_table(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 1, "indexed")],
+        table=table,
+        argv=["--optimize-after-cleanup"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 2
+    assert "Re-run with --confirm" in output.err
+    assert table.optimized is False
+    assert "optimize_after_cleanup" not in report
+    assert report["cleanup_plan"]["requires_confirm"] is True
+
+
+def test_optimize_after_cleanup_reports_index_rebuild_failure(
+    capsys, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(reconcile, "IvfPq", FakeIvfPq)
+    rows = [
+        {
+            "id": f"10_{index}",
+            "file_id": "10",
+            "vault_id": "10",
+            "chunk_scale": "default",
+        }
+        for index in range(reconcile.VECTOR_INDEX_MIN_ROWS)
+    ]
+    table = FakeTable(rows, create_index_error=RuntimeError("training failed"))
+
+    exit_code, table = run_main_with_table(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", len(rows), "indexed")],
+        table=table,
+        argv=["--optimize-after-cleanup", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.optimized is True
+    assert table.waited_indices == []
+    assert report["optimize_after_cleanup"]["index_action"] == (
+        "rebuild_embedding_idx_failed"
+    )
+    assert report["optimize_after_cleanup"]["index_error"] == "training failed"
+
+
+def test_optimize_after_cleanup_reports_count_rows_probe_failure(
+    capsys, monkeypatch, tmp_path
+):
+    table = FakeTable(
+        [
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            }
+        ],
+        count_rows_error=RuntimeError("count failed"),
+    )
+
+    exit_code, table = run_main_with_table(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 1, "indexed")],
+        table=table,
+        argv=["--optimize-after-cleanup", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.optimized is True
+    assert report["optimize_after_cleanup"]["index_action"] == (
+        "index_maintenance_skipped"
+    )
+    assert report["optimize_after_cleanup"]["index_error"] == (
+        "count_rows failed: count failed"
+    )
+
+
+def test_optimize_after_cleanup_reports_list_indices_probe_failure(
+    capsys, monkeypatch, tmp_path
+):
+    table = FakeTable(
+        [
+            {
+                "id": "10_0",
+                "file_id": "10",
+                "vault_id": "10",
+                "chunk_scale": "default",
+            }
+        ],
+        list_indices_error=RuntimeError("index listing failed"),
+    )
+
+    exit_code, table = run_main_with_table(
+        monkeypatch,
+        tmp_path,
+        sqlite_rows=[(10, 10, "valid.txt", 1, "indexed")],
+        table=table,
+        argv=["--optimize-after-cleanup", "--confirm"],
+    )
+
+    report, output = parse_report(capsys)
+
+    assert exit_code == 0, output.err
+    assert table.optimized is True
+    assert report["optimize_after_cleanup"]["index_action"] == (
+        "index_maintenance_skipped"
+    )
+    assert report["optimize_after_cleanup"]["index_error"] == (
+        "list_indices failed: index listing failed"
+    )
+
+
+async def test_load_lancedb_chunks_uses_projected_batches():
+    table = FakeQueryTable(
+        [
+            FakeArrowTable(
+                [
+                    {
+                        "id": "10_0",
+                        "file_id": "10",
+                        "vault_id": "10",
+                        "chunk_scale": "default",
+                        "embedding": [1, 2, 3],
+                    }
+                ]
+            ),
+            FakeArrowTable(
+                [
+                    {
+                        "id": "11_0",
+                        "file_id": "11",
+                        "vault_id": "11",
+                        "chunk_scale": None,
+                        "text": "not needed",
+                    }
+                ]
+            ),
+        ]
+    )
+
+    chunks = await reconcile._load_lancedb_chunks(table)
+
+    assert table.query_obj.selected_columns == list(reconcile.LANCEDB_RECONCILE_COLUMNS)
+    assert chunks == [
+        reconcile.ChunkRow("10_0", "10", "10", "default"),
+        reconcile.ChunkRow("11_0", "11", "11", "default"),
+    ]
+
+
+async def test_load_lancedb_chunks_supports_pandas_fallback():
+    class PandasTable:
+        async def to_arrow(self):
+            return FakePandasArrowTable(
+                [
+                    {
+                        "id": "10_0",
+                        "file_id": "10",
+                        "vault_id": "10",
+                        "chunk_scale": "512",
+                    }
+                ]
+            )
+
+    chunks = await reconcile._load_lancedb_chunks(PandasTable())
+
+    assert chunks == [reconcile.ChunkRow("10_0", "10", "10", "512")]
+
+
+async def test_load_lancedb_chunks_supports_iterable_fallback():
+    class IterableTable:
+        async def to_arrow(self):
+            return FakeIterableArrowTable(
+                [
+                    {
+                        "id": "10_0",
+                        "file_id": "10",
+                        "vault_id": "10",
+                        "chunk_scale": "",
+                    }
+                ]
+            )
+
+    chunks = await reconcile._load_lancedb_chunks(IterableTable())
+
+    assert chunks == [reconcile.ChunkRow("10_0", "10", "10", "default")]


### PR DESCRIPTION
## Summary
- Add a safe-by-default LanceDB/SQLite reconciliation script for indexed file and chunk corpus hygiene.
- Report orphan LanceDB file IDs, orphan vault IDs, vault mismatches, stale multiscale rows, and indexed SQLite files missing LanceDB chunks.
- Gate destructive cleanup and optimize/index maintenance behind --confirm, with pre-delete counts, post-delete remaining counts, and nonfatal maintenance error reporting.

## Test plan
- [x] `python -m ruff check scripts/reconcile_lancedb_sqlite.py tests/test_reconcile_lancedb_sqlite.py` -- passed
- [x] `python -m pytest tests/test_reconcile_lancedb_sqlite.py -q` -- 18 passed
- [x] `python -m py_compile scripts/reconcile_lancedb_sqlite.py tests/test_reconcile_lancedb_sqlite.py` -- passed
- [x] `python scripts/reconcile_lancedb_sqlite.py --help` -- passed
- [x] `git diff --cached --check` -- passed before amend

## Review follow-up
- Accepted: added explicit `vault_ids_present_in_lancedb_but_not_sqlite_indexed` reporting for orphan vault detection.
- Accepted: changed LanceDB scanning to query only reconciliation columns and read batches instead of materializing full rows with text/embedding payloads.
- Accepted: added `remaining_after_delete_counts` so cleanup reports expose post-delete state and make concurrent changes visible.
- Accepted: added coverage for missing SQLite path, empty corpus, projected batch scans, `to_pandas` fallback, iterable fallback, and updated cleanup result assertions.
- Accepted: documented CLI exit codes in help output.
- Rejected: kept exit code 0 for reported nonfatal optimize/index maintenance failures; unrecoverable command failures still return 1 and unconfirmed mutations return 2.