### PR TITLE
feat(deployment): add path-prefixed deployment support (issue #117)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@
 # =============================================================================
 PORT=9090
 
+# Path prefix for reverse proxy subdirectory deployment (e.g., /knowledgevault)
+# Leave empty for root deployment. Must start with / and not end with /
+# Example: ROOT_PATH=/knowledgevault
+ROOT_PATH=
+
 # Data Directory Configuration
 # Host path for Docker volume mount - path on your host machine where data will be persisted
 HOST_DATA_DIR=./data
@@ -35,9 +40,17 @@ CSRF_TOKEN_TTL=900
 REDIS_URL=redis://localhost:6379/0
 
 # CORS allowed origins (comma-separated list)
-# For development: http://localhost:3000
-# For production: https://yourdomain.com
+# For path-prefixed deployment, use the origin without the path
+# Example: BACKEND_CORS_ORIGINS=https://yourdomain.com,https://app.yourdomain.com
 BACKEND_CORS_ORIGINS=http://localhost:3000
+
+# =============================================================================
+# FRONTEND CONFIGURATION
+# =============================================================================
+# Base path for frontend router and asset URLs when deployed behind a reverse proxy
+# Must match ROOT_PATH (without trailing slash). Leave empty for root deployment.
+# Example: VITE_APP_BASENAME=/knowledgevault
+VITE_APP_BASENAME=
 
 # =============================================================================
 # MULTI-USER AUTHENTICATION (JWT)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: Build Frontend
 FROM node:20-alpine AS frontend-builder
+ARG VITE_APP_BASENAME=""
+ENV VITE_APP_BASENAME=$VITE_APP_BASENAME
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci
@@ -34,6 +36,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy backend code
 COPY backend/app ./app
 
+# Copy and set up startup script
+COPY backend/start.sh ./start.sh
+RUN chmod +x ./start.sh
+
 # Copy built frontend
 COPY --from=frontend-builder /app/frontend/dist ./static
 
@@ -51,4 +57,4 @@ USER appuser
 
 EXPOSE 9090
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9090"]
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ On first launch, you'll be redirected to the **Setup Wizard** (`/setup`) to crea
 | `PORT` | 9090 | Web server port |
 | `HOST_DATA_DIR` | ./data | Host path for data persistence |
 | `DATA_DIR` | /app/data | Container data path |
+| `ROOT_PATH` | "" | Base path for backend router (e.g., `/knowledgevault` for subdirectory deployment) |
+| `VITE_APP_BASENAME` | "" | Base path for frontend router and asset URLs. Must match `ROOT_PATH` without trailing slash |
 | `OLLAMA_EMBEDDING_URL` | http://harrier-embed:8080/v1/embeddings | Embedding service endpoint (TEI) |
 | `OLLAMA_CHAT_URL` | http://host.docker.internal:11434 | Thinking chat endpoint |
 | `INSTANT_CHAT_URL` | http://host.docker.internal:1234 | Instant chat endpoint |
@@ -663,6 +665,84 @@ The chat interface provides a three-zone workspace layout:
 4. Click delete icon to remove
 5. Memories are automatically used in chat context
 
+## Subdirectory Deployment
+
+When deploying KnowledgeVault behind a reverse proxy at a subdirectory path (e.g., `https://example.com/knowledgevault/`), you need to configure both the backend and frontend base paths:
+
+### Backend Configuration
+
+Set `ROOT_PATH` in your `.env` file to match the subdirectory path (without trailing slash):
+
+```bash
+# .env
+ROOT_PATH=/knowledgevault
+```
+
+This tells FastAPI to generate URLs and handle requests relative to the base path.
+
+### Frontend Configuration
+
+Build the frontend Docker image with the `VITE_APP_BASENAME` build argument:
+
+```bash
+# Build with basename for subdirectory deployment
+docker compose build --build-arg VITE_APP_BASENAME=/knowledgevault
+
+# Or in docker-compose.yml, add:
+# args:
+#   VITE_APP_BASENAME: ${VITE_APP_BASENAME:-/knowledgevault}
+```
+
+The `VITE_APP_BASENAME` is used to:
+- Configure the React Router base path
+- Set the API base URL (`${VITE_APP_BASENAME}/api`)
+- Generate correct asset URLs for the built static files
+
+### Reverse Proxy Configuration
+
+**Nginx Example:**
+
+```nginx
+location /knowledgevault/ {
+    proxy_pass http://localhost:9090/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $host;
+    
+    # Required for WebSocket and proper URL handling
+    proxy_redirect http://localhost:9090/ /knowledgevault/;
+}
+```
+
+**Caddy Example:**
+
+```
+knowledgevault.example.com/knowledgevault {
+    handle_path /knowledgevault/* {
+        strip_prefix /knowledgevault
+        reverse_proxy localhost:9090
+    }
+}
+```
+
+### Environment Variable Coordination
+
+| Variable | Location | Purpose |
+|----------|----------|---------|
+| `ROOT_PATH` | Backend `.env` | FastAPI base path for URL generation |
+| `VITE_APP_BASENAME` | Docker build arg | Frontend router base path and API URL prefix |
+
+**Important:** Both values must match (without trailing slashes) for proper deployment.
+
+### Verifying Subdirectory Deployment
+
+After deployment, verify:
+1. Frontend loads at `https://yourdomain.com/knowledgevault/`
+2. API calls go to `https://yourdomain.com/knowledgevault/api/*`
+3. Static assets (JS, CSS) load from `https://yourdomain.com/knowledgevault/assets/*`
+4. Browser navigation uses the History API without 404 errors
+
 ## Development
 
 ### Backend Development
@@ -718,9 +798,30 @@ The three-zone chat workspace is built from these key components:
 ### Building Production Images
 
 ```bash
+# Build with optional basename for subdirectory deployment
+# Example: docker compose build --build-arg VITE_APP_BASENAME=/knowledgevault
 docker compose -f docker-compose.yml build
 docker compose -f docker-compose.yml up -d
 ```
+
+#### Docker Build Arguments
+
+The Docker build supports the `VITE_APP_BASENAME` argument for configuring the frontend router base path at build time:
+
+```bash
+# Build for root deployment (default)
+docker compose build
+
+# Build for subdirectory deployment
+docker compose build --build-arg VITE_APP_BASENAME=/knowledgevault
+```
+
+The `VITE_APP_BASENAME` value is injected into the frontend build and used to:
+- Configure the Vite router base path
+- Set the API base URL (`${VITE_APP_BASENAME}/api`)
+- Generate correct asset URLs for static files
+
+This configuration must match the `ROOT_PATH` setting in the backend `.env` file for proper reverse proxy deployment.
 
 ## Documentation
 
@@ -744,3 +845,26 @@ No license file present. Add LICENSE file or update this section as needed.
 - Issues: Create an issue in the repository
 - Admin Guide: See `docs/admin-guide.md`
 - Non-Technical Setup: See `docs/non-technical-setup.md`
+- Release Notes: See `docs/release.md` for version history and migration guides
+
+## Recent Changes (Phase 5)
+
+### Subdirectory Deployment Support
+
+**Fixed:** Frontend and backend base path configuration for reverse proxy subdirectory deployment.
+
+**Changes:**
+- Added `VITE_APP_BASENAME` build argument to Dockerfile for build-time frontend basename injection
+- Updated `docker-compose.yml` to pass `VITE_APP_BASENAME` as build argument
+- Fixed static file mounting to use `rstrip("/")` for consistent path handling
+- Updated `start.sh` to include `--proxy-headers --forwarded-allow-ips="*"` for proper reverse proxy support
+- Fixed cookie and CSRF token path generation to handle basename prefixes correctly
+- Updated frontend API client to incorporate `VITE_APP_BASENAME` in all API requests
+- Fixed Vue/React router base path to use normalized basename (trailing slash stripped)
+
+**Configuration:**
+- Set `ROOT_PATH` in backend `.env` (e.g., `/knowledgevault`)
+- Build Docker image with `VITE_APP_BASENAME` argument matching `ROOT_PATH`
+- Configure reverse proxy to strip the base path before forwarding to backend
+
+See the [Subdirectory Deployment](#subdirectory-deployment) section above for complete setup instructions.

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from app.api.deps import get_current_active_user, get_db
 from app.limiter import limiter
-from app.security import csrf_protect, get_csrf_manager, issue_csrf_token
+from app.security import SAFE_PREFIX_RE, csrf_protect, get_csrf_manager, issue_csrf_token
 from app.services.auth_service import (
     create_access_token,
     create_refresh_token,
@@ -32,6 +32,27 @@ def _is_secure_request(request: Request) -> bool:
     """Return True if the request came in over HTTPS or a trusted proxy header."""
     forwarded = request.headers.get("x-forwarded-proto", "")
     return request.url.scheme == "https" or forwarded.lower() == "https"
+
+
+def _get_cookie_path(request: Request, suffix: str) -> str:
+    """Return a cookie path that includes any reverse-proxy path prefix."""
+    # Prefer middleware-validated value (task 3.4)
+    if hasattr(request.state, "forwarded_prefix"):
+        prefix = request.state.forwarded_prefix
+        if not isinstance(prefix, str):
+            prefix = ""
+    else:
+        # Middleware not installed — read and validate raw header
+        prefix = request.headers.get("x-forwarded-prefix", "")
+        if not (prefix and SAFE_PREFIX_RE.match(prefix)):
+            prefix = ""
+
+    if prefix:
+        prefix = prefix.rstrip("/")
+        if not suffix.startswith("/"):
+            suffix = "/" + suffix
+        return f"{prefix}{suffix}"
+    return suffix
 
 
 class RegisterRequest(BaseModel):
@@ -125,7 +146,7 @@ async def register(
         secure=_is_secure_request(request),
         samesite="lax",
         max_age=REFRESH_TOKEN_MAX_AGE_DAYS * 24 * 60 * 60,
-        path="/api/auth/refresh",
+        path=_get_cookie_path(request, "/api/auth/refresh"),
     )
 
     return {
@@ -247,11 +268,11 @@ async def login(
         secure=_is_secure_request(request),
         samesite="lax",
         max_age=REFRESH_TOKEN_MAX_AGE_DAYS * 24 * 60 * 60,
-        path="/api/auth/refresh",
+        path=_get_cookie_path(request, "/api/auth/refresh"),
     )
 
     csrf_manager = get_csrf_manager(request)
-    issue_csrf_token(response, csrf_manager)
+    issue_csrf_token(response, csrf_manager, request)
 
     return {
         "access_token": access_token,
@@ -364,11 +385,11 @@ async def refresh(
         secure=_is_secure_request(request),
         samesite="lax",
         max_age=REFRESH_TOKEN_MAX_AGE_DAYS * 24 * 60 * 60,
-        path="/api/auth/refresh",
+        path=_get_cookie_path(request, "/api/auth/refresh"),
     )
 
     csrf_manager = get_csrf_manager(request)
-    issue_csrf_token(response, csrf_manager)
+    issue_csrf_token(response, csrf_manager, request)
 
     return {
         "access_token": access_token,
@@ -379,6 +400,7 @@ async def refresh(
 
 @router.post("/logout")
 async def logout(
+    request: Request,
     response: Response,
     refresh_token: Optional[str] = Cookie(None, alias=REFRESH_TOKEN_COOKIE_NAME),
     db=Depends(get_db),
@@ -396,7 +418,7 @@ async def logout(
             db.rollback()
             logger.error("Failed to delete session during logout", exc_info=True)
 
-    response.delete_cookie(key=REFRESH_TOKEN_COOKIE_NAME, path="/api/auth/refresh")
+    response.delete_cookie(key=REFRESH_TOKEN_COOKIE_NAME, path=_get_cookie_path(request, "/api/auth/refresh"))
     return {"message": "Logged out successfully"}
 
 
@@ -557,7 +579,7 @@ async def change_password(
         secure=_is_secure_request(request),
         samesite="lax",
         max_age=REFRESH_TOKEN_MAX_AGE_DAYS * 24 * 60 * 60,
-        path="/api/auth/refresh",
+        path=_get_cookie_path(request, "/api/auth/refresh"),
     )
 
     return {
@@ -700,7 +722,7 @@ async def revoke_all_sessions(
         secure=_is_secure_request(request),
         samesite="lax",
         max_age=REFRESH_TOKEN_MAX_AGE_DAYS * 24 * 60 * 60,
-        path="/api/auth/refresh",
+        path=_get_cookie_path(request, "/api/auth/refresh"),
     )
 
     return {

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -790,9 +790,10 @@ def put_settings(
 @router.get("/csrf-token")
 def get_csrf_token(
     response: Response,
+    request: Request,
     csrf_manager: CSRFManager = Depends(get_csrf_manager),
 ):
-    token = issue_csrf_token(response, csrf_manager)
+    token = issue_csrf_token(response, csrf_manager, request)
     return {"csrf_token": token}
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -457,6 +457,20 @@ class Settings(BaseSettings):
     # CORS settings
     backend_cors_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
 
+    @field_validator("backend_cors_origins", mode="before")
+    @classmethod
+    def parse_backend_cors_origins(cls, v):
+        """Parse backend_cors_origins from comma-separated string or pass through if already a list."""
+        if isinstance(v, list):
+            return v
+        if isinstance(v, str):
+            origins = [origin.strip() for origin in v.split(",")]
+            return [origin for origin in origins if origin]
+        return v
+
+    # Root path for reverse proxy subdirectory deployment (e.g., /knowledgevault)
+    root_path: str = ""
+
     # Helper validation functions (consolidated validators)
     @staticmethod
     def _validate_int_range(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.lifespan import lifespan
 from app.limiter import limiter
 from app.middleware.logging import LoggingMiddleware
 from app.middleware.maintenance import MaintenanceMiddleware
+from app.middleware.proxy_prefix import ProxyPrefixMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ app = FastAPI(
     version="0.1.0",
     description="Self-hosted RAG Knowledge Base API",
     lifespan=lifespan,
+    root_path=settings.root_path,
 )
 
 # Security check: warn if admin_secret_token is not set or using default value
@@ -93,6 +95,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# ProxyPrefixMiddleware — detect x-forwarded-prefix for reverse proxy path prefix
+app.add_middleware(ProxyPrefixMiddleware)
 
 # Security: warn if CORS origins contain wildcard when credentials are enabled
 if "*" in settings.backend_cors_origins:
@@ -140,8 +144,10 @@ logger.info(
 if static_dir.exists():
     try:
         # Mount assets only (without html=True to avoid catch-all behavior)
+        _root = settings.root_path.rstrip("/") if settings.root_path else ""
+        assets_mount_path = f"{_root}/assets" if _root else "/assets"
         app.mount(
-            "/assets",
+            assets_mount_path,
             StaticFiles(directory=str(static_dir / "assets"), html=False),
             name="assets",
         )
@@ -149,15 +155,17 @@ if static_dir.exists():
 
         # Catch-all route for SPA client-side routing
         # Serves index.html for any unmatched frontend routes (not API routes)
+        # Use assets_mount_path without leading slash for guard comparison
+        _assets_prefix = assets_mount_path.lstrip("/").lower()
         @app.get("/{full_path:path}")
         async def serve_spa(full_path: str):
             # Return 404 for API and assets paths to avoid shadowing (case-insensitive)
             normalized_path = full_path.lower()
             if (
                 normalized_path == "api"
-                or normalized_path == "assets"
+                or normalized_path == _assets_prefix
                 or normalized_path.startswith("api/")
-                or normalized_path.startswith("assets/")
+                or normalized_path.startswith(_assets_prefix + "/")
             ):
                 raise HTTPException(status_code=404, detail="Not found")
             return FileResponse(static_dir / "index.html")

--- a/backend/app/middleware/proxy_prefix.py
+++ b/backend/app/middleware/proxy_prefix.py
@@ -1,0 +1,19 @@
+"""Middleware to detect reverse-proxy path prefix from x-forwarded-prefix header."""
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+from app.security import SAFE_PREFIX_RE
+
+
+class ProxyPrefixMiddleware(BaseHTTPMiddleware):
+    """Read x-forwarded-prefix header and store it in request.state for downstream use."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+        prefix = request.headers.get("x-forwarded-prefix", "")
+        # Validate and store per-request (not in shared app.state)
+        if prefix and SAFE_PREFIX_RE.match(prefix):
+            request.state.forwarded_prefix = prefix
+        else:
+            request.state.forwarded_prefix = ""
+        return await call_next(request)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac
 import logging
+import re
 import secrets
 import threading
 import time
@@ -196,8 +197,27 @@ def csrf_protect(
     return x_csrf_token
 
 
-def issue_csrf_token(response: Response, csrf_manager: CSRFManager) -> str:
+SAFE_PREFIX_RE = re.compile(r"^(?!.*\.\.)[/A-Za-z0-9._~!$&'()*+:@%-]+$")
+
+
+def issue_csrf_token(response: Response, csrf_manager: CSRFManager, request: Request | None = None) -> str:
     token = csrf_manager.generate_token()
+    path = "/api"
+    if request:
+        # Prefer middleware-validated value (task 3.4)
+        if hasattr(request.state, "forwarded_prefix"):
+            prefix = request.state.forwarded_prefix
+        else:
+            # Middleware not installed — read and validate raw header
+            prefix = request.headers.get("x-forwarded-prefix", "")
+            if not (prefix and SAFE_PREFIX_RE.match(prefix)):
+                prefix = ""
+        if prefix:
+            prefix = prefix.strip("/")
+            if prefix:
+                path = f"/{prefix}/api"
+            else:
+                path = "/api"
     response.set_cookie(
         CSRF_COOKIE_NAME,
         token,
@@ -205,6 +225,7 @@ def issue_csrf_token(response: Response, csrf_manager: CSRFManager) -> str:
         samesite="lax",
         secure=settings.csrf_cookie_secure,
         httponly=False,
+        path=path,
     )
     return token
 

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec uvicorn app.main:app --host 0.0.0.0 --port 9090 --proxy-headers --forwarded-allow-ips="*"

--- a/backend/tests/test_auth_cookie_path.py
+++ b/backend/tests/test_auth_cookie_path.py
@@ -1,0 +1,115 @@
+"""
+Verification tests for _get_cookie_path helper in auth routes.
+
+Tests verify:
+1. No prefix header → returns suffix as-is
+2. Prefix `/knowledgevault` + suffix `/api/auth/refresh` → `/knowledgevault/api/auth/refresh`
+3. Prefix `/knowledgevault/` (trailing slash) → `/knowledgevault/api/auth/refresh`
+4. Prefix `''` (empty string) → returns suffix as-is
+"""
+
+import unittest
+from unittest.mock import MagicMock
+from starlette.requests import Request
+
+
+class TestGetCookiePath(unittest.TestCase):
+    """Tests for _get_cookie_path helper function."""
+
+    def _call_get_cookie_path(self, prefix_header_value: str, suffix: str):
+        """Helper to call _get_cookie_path with a mocked request."""
+        from app.api.routes.auth import _get_cookie_path
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers.get.return_value = prefix_header_value
+        # Use a plain object for state to avoid auto-creation of attributes
+        # that would make hasattr() return True incorrectly
+        mock_request.state = type('State', (), {})()
+        return _get_cookie_path(mock_request, suffix)
+
+    def test_no_prefix_returns_suffix_as_is(self):
+        """Case 1: No x-forwarded-prefix header → returns suffix as-is."""
+        result = self._call_get_cookie_path("", "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_prefix_without_trailing_slash(self):
+        """Case 2: Prefix `/knowledgevault` + suffix `/api/auth/refresh` → `/knowledgevault/api/auth/refresh`."""
+        result = self._call_get_cookie_path("/knowledgevault", "/api/auth/refresh")
+        self.assertEqual(result, "/knowledgevault/api/auth/refresh")
+
+    def test_prefix_with_trailing_slash(self):
+        """Case 3: Prefix `/knowledgevault/` (trailing slash) → `/knowledgevault/api/auth/refresh`."""
+        result = self._call_get_cookie_path("/knowledgevault/", "/api/auth/refresh")
+        self.assertEqual(result, "/knowledgevault/api/auth/refresh")
+
+    def test_empty_string_prefix_returns_suffix_as_is(self):
+        """Case 4: Prefix `''` (empty string) → returns suffix as-is."""
+        result = self._call_get_cookie_path("", "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_suffix_without_leading_slash_gets_added(self):
+        """Suffix without leading slash gets `/` prepended."""
+        result = self._call_get_cookie_path("/knowledgevault", "api/auth/refresh")
+        self.assertEqual(result, "/knowledgevault/api/auth/refresh")
+
+    def test_none_prefix_returns_suffix_as_is(self):
+        """x-forwarded-prefix header returning None (not set) returns suffix as-is."""
+        result = self._call_get_cookie_path(None, "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_invalid_prefix_with_semicolon_falls_back_to_suffix(self):
+        """Invalid prefix containing ';' (cookie injection attempt) → falls back to suffix only."""
+        result = self._call_get_cookie_path("/knowledge;vault", "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_invalid_prefix_with_semicolon_at_start(self):
+        """Invalid prefix starting with ';' → falls back to suffix only."""
+        result = self._call_get_cookie_path(";knowledgevault", "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_various_injection_chars_all_rejected(self):
+        """Various cookie-injection characters are rejected."""
+        # Test various injection characters individually
+        # Note: single quote (') is allowed by SAFE_PREFIX_RE: r"^(?!.*\.\.)[/A-Za-z0-9._~!$&'()*+:@%-]+$"
+        injection_chars = [";", '"', "<", ">", " ", "\n", "\r"]
+        for char in injection_chars:
+            prefix_with_char = f"/knowledge{char}vault"
+            result = self._call_get_cookie_path(prefix_with_char, "/api/auth/refresh")
+            self.assertEqual(
+                result,
+                "/api/auth/refresh",
+                f"Prefix with char '{repr(char)}' should be rejected",
+            )
+
+    def test_invalid_prefix_with_equals_sign_falls_back_to_suffix(self):
+        """Invalid prefix containing '=' (cookie injection attempt) → falls back to suffix only."""
+        result = self._call_get_cookie_path("/knowledge=vault", "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_non_string_forwarded_prefix_in_state_falls_back(self):
+        """Non-string forwarded_prefix in request.state (e.g., integer) → falls back to suffix."""
+        from app.api.routes.auth import _get_cookie_path
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers.get.return_value = ""  # No header prefix
+        # Use a plain object for state to avoid auto-creation issues
+        mock_request.state = type('State', (), {})()
+        # Set forwarded_prefix to a non-string type (int)
+        mock_request.state.forwarded_prefix = 123
+        result = _get_cookie_path(mock_request, "/api/auth/refresh")
+        self.assertEqual(result, "/api/auth/refresh")
+
+    def test_forwarded_prefix_from_state_valid_string(self):
+        """Valid forwarded_prefix from request.state (string) → uses it as prefix."""
+        from app.api.routes.auth import _get_cookie_path
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers.get.return_value = ""  # No header prefix
+        mock_request.state = type('State', (), {})()
+        mock_request.state.forwarded_prefix = "/knowledgevault"
+        result = _get_cookie_path(mock_request, "/api/auth/refresh")
+        self.assertEqual(result, "/knowledgevault/api/auth/refresh")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_cors_origin_handling.py
+++ b/backend/tests/test_cors_origin_handling.py
@@ -1,0 +1,80 @@
+"""
+Tests for CORS origin handling in Settings.
+
+Tests cover task 4.2:
+- Validator handles comma-separated string input correctly
+- Validator trims whitespace from origins
+- Validator filters out empty strings
+- Validator passes through list input unchanged
+- docker-compose adds BACKEND_CORS_ORIGINS with correct default
+"""
+
+import pytest
+
+from app.config import Settings
+
+
+class TestParseBackendCorsOrigins:
+    """Tests for the parse_backend_cors_origins field validator."""
+
+    def test_comma_separated_string_parsed_correctly(self):
+        """Comma-separated string should be split into list of origins."""
+        settings = Settings(backend_cors_origins="http://localhost:5173,http://localhost:3000")
+        assert settings.backend_cors_origins == ["http://localhost:5173", "http://localhost:3000"]
+
+    def test_comma_separated_string_with_extra_whitespace_parsed(self):
+        """Comma-separated string with extra whitespace should have whitespace trimmed."""
+        settings = Settings(backend_cors_origins="  http://localhost:5173  ,  http://localhost:3000  ")
+        assert settings.backend_cors_origins == ["http://localhost:5173", "http://localhost:3000"]
+
+    def test_empty_strings_filtered_out(self):
+        """Empty strings between commas should be filtered out."""
+        settings = Settings(backend_cors_origins="http://localhost:5173,,http://localhost:3000")
+        assert settings.backend_cors_origins == ["http://localhost:5173", "http://localhost:3000"]
+
+    def test_trailing_comma_creates_empty_string_filtered(self):
+        """Trailing comma should not create an empty string entry."""
+        settings = Settings(backend_cors_origins="http://localhost:5173,http://localhost:3000,")
+        assert settings.backend_cors_origins == ["http://localhost:5173", "http://localhost:3000"]
+
+    def test_leading_comma_creates_empty_string_filtered(self):
+        """Leading comma should not create an empty string entry."""
+        settings = Settings(backend_cors_origins=",http://localhost:5173,http://localhost:3000")
+        assert settings.backend_cors_origins == ["http://localhost:5173", "http://localhost:3000"]
+
+    def test_list_input_passed_through_unchanged(self):
+        """List input should be returned unchanged."""
+        original_list = ["http://localhost:5173", "http://localhost:3000"]
+        settings = Settings(backend_cors_origins=original_list)
+        assert settings.backend_cors_origins == original_list
+
+    def test_list_input_with_extra_whitespace_not_stripped(self):
+        """List input should NOT have whitespace stripped (pass-through behavior)."""
+        original_list = ["  http://localhost:5173  ", "http://localhost:3000"]
+        settings = Settings(backend_cors_origins=original_list)
+        assert settings.backend_cors_origins == original_list
+
+    def test_single_origin_string_parsed(self):
+        """Single origin without comma should still work."""
+        settings = Settings(backend_cors_origins="http://localhost:5173")
+        assert settings.backend_cors_origins == ["http://localhost:5173"]
+
+    def test_multiple_origins_with_different_schemes(self):
+        """Origins with different schemes (http, https) should be preserved."""
+        settings = Settings(backend_cors_origins="http://localhost:5173,https://example.com,http://localhost:3000")
+        assert settings.backend_cors_origins == ["http://localhost:5173", "https://example.com", "http://localhost:3000"]
+
+    def test_origins_with_ports_preserved(self):
+        """Origins with non-standard ports should be preserved."""
+        settings = Settings(backend_cors_origins="http://localhost:8080,http://localhost:3000,https://example.com:8443")
+        assert settings.backend_cors_origins == ["http://localhost:8080", "http://localhost:3000", "https://example.com:8443"]
+
+    def test_only_empty_strings_becomes_empty_list(self):
+        """String that resolves to only empty strings should become empty list."""
+        settings = Settings(backend_cors_origins=",,")
+        assert settings.backend_cors_origins == []
+
+    def test_whitespace_only_string_becomes_empty_list(self):
+        """Whitespace-only string should become empty list after filtering."""
+        settings = Settings(backend_cors_origins="   ,   ,   ")
+        assert settings.backend_cors_origins == []

--- a/backend/tests/test_csrf_token_path_prefix.py
+++ b/backend/tests/test_csrf_token_path_prefix.py
@@ -1,0 +1,162 @@
+"""
+Verification tests for issue_csrf_token path prefix awareness.
+
+Tests verify:
+1. issue_csrf_token sets path=/api when no prefix
+2. issue_csrf_token sets path=/knowledgevault/api when x-forwarded-prefix=/knowledgevault
+3. All callers pass request parameter
+4. Regex validates prefix safely
+"""
+
+import unittest
+
+from app.security import SAFE_PREFIX_RE
+
+
+def _compute_csrf_path(request_headers_prefix: str | None, request: object | None) -> str:
+    """
+    Replicates the path-computation logic from issue_csrf_token.
+
+    Returns:
+        - "/api" when request is None or x-forwarded-prefix is empty/invalid
+        - "{prefix}/api" when prefix is valid
+    """
+    path = "/api"
+    if request is not None:
+        prefix = request_headers_prefix or ""
+        if prefix and SAFE_PREFIX_RE.match(prefix):
+            prefix = prefix.rstrip("/")
+            path = f"{prefix}/api"
+    return path
+
+
+class TestCsrfPathComputationLogic(unittest.TestCase):
+    """Tests for the path computation logic in issue_csrf_token."""
+
+    def test_no_request_returns_api(self):
+        """Verify 1: path=/api when request is None."""
+        result = _compute_csrf_path("", None)
+        self.assertEqual(result, "/api")
+
+    def test_empty_prefix_returns_api(self):
+        """Verify 1: path=/api when x-forwarded-prefix is empty string."""
+        result = _compute_csrf_path("", object())
+        self.assertEqual(result, "/api")
+
+    def test_no_prefix_header_returns_api(self):
+        """Verify 1: path=/api when x-forwarded-prefix header is not set (None)."""
+        result = _compute_csrf_path(None, object())
+        self.assertEqual(result, "/api")
+
+    def test_knowledgevault_prefix_returns_knowledgevault_api(self):
+        """Verify 2: path=/knowledgevault/api when x-forwarded-prefix=/knowledgevault."""
+        result = _compute_csrf_path("/knowledgevault", object())
+        self.assertEqual(result, "/knowledgevault/api")
+
+    def test_prefix_with_trailing_slash_normalized(self):
+        """Prefix /knowledgevault/ should normalize to /knowledgevault/api."""
+        result = _compute_csrf_path("/knowledgevault/", object())
+        self.assertEqual(result, "/knowledgevault/api")
+
+    def test_deep_prefix_normalized(self):
+        """Prefix /a/b/c should result in /a/b/c/api."""
+        result = _compute_csrf_path("/a/b/c", object())
+        self.assertEqual(result, "/a/b/c/api")
+
+
+class TestCsrfPathSafeRegex(unittest.TestCase):
+    """Tests for _CSRF_PATH_SAFE_RE regex validation."""
+
+    def test_valid_prefixes_pass_regex(self):
+        """Verify 4: Valid prefixes should pass the regex."""
+        valid_prefixes = [
+            "/",
+            "/api",
+            "/knowledgevault",
+            "/knowledge-vault",
+            "/knowledge_vault",
+            "/knowledge.vault",
+            "/knowledge~vault",
+            "/knowledge!vault",
+            "/knowledge$vault",
+            "/knowledge&vault",
+            "/knowledge(vault)",
+            "/knowledge*vault",
+            "/knowledge+vault",
+            "/knowledge:vault",
+            "/knowledge@vault",
+            "/knowledge.vault",
+            "/knowledge_vault",
+            "/a1",
+            "/a.b.c",
+            "/a/b/c",
+            "/abc123",
+            "/ABC123",
+            "/my-app",
+            "/app.v2",
+        ]
+        for prefix in valid_prefixes:
+            self.assertIsNotNone(
+                SAFE_PREFIX_RE.match(prefix),
+                f"Prefix '{prefix}' should be accepted by regex",
+            )
+
+    def test_invalid_prefixes_fail_regex(self):
+        """Verify 4: Invalid/malicious prefixes should fail the regex."""
+        invalid_prefixes = [
+            "/knowledge;vault",      # semicolon - cookie injection
+            "/knowledge=vault",      # equals - cookie injection
+            "/knowledge\"vault",     # quote - cookie injection
+            "/knowledge<vault",     # less than - HTML injection
+            "/knowledge>vault",     # greater than - HTML injection
+            "/knowledge vault",     # space - invalid path char
+            "/knowledge\nvault",    # newline - header injection
+            "/knowledge\rvault",    # carriage return - header injection
+            "/knowledge\tvault",    # tab - invalid path char
+            "/; rm -rf /",         # command injection attempt
+        ]
+        for prefix in invalid_prefixes:
+            result = SAFE_PREFIX_RE.match(prefix)
+            self.assertIsNone(
+                result,
+                f"Malicious prefix '{repr(prefix)}' should be rejected by regex",
+            )
+
+    def test_empty_string_fails_regex(self):
+        """Empty string should not match the regex (must start with /)."""
+        result = SAFE_PREFIX_RE.match("")
+        self.assertIsNone(result)
+
+
+class TestCallersPassRequestParameter(unittest.TestCase):
+    """Verify all callers of issue_csrf_token pass the request parameter."""
+
+    def test_auth_login_passes_request(self):
+        """auth.py login() should call issue_csrf_token with request."""
+        # Read source file directly to avoid import chain that hits the re bug
+        import os
+        source_path = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "auth.py")
+        with open(source_path, "r") as f:
+            source = f.read()
+        # Verify the call includes request as the third argument
+        self.assertIn("issue_csrf_token(response, csrf_manager, request)", source)
+
+    def test_auth_refresh_passes_request(self):
+        """auth.py refresh() should call issue_csrf_token with request."""
+        import os
+        source_path = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "auth.py")
+        with open(source_path, "r") as f:
+            source = f.read()
+        self.assertIn("issue_csrf_token(response, csrf_manager, request)", source)
+
+    def test_settings_csrf_token_passes_request(self):
+        """settings.py get_csrf_token() should call issue_csrf_token with request."""
+        import os
+        source_path = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "settings.py")
+        with open(source_path, "r") as f:
+            source = f.read()
+        self.assertIn("issue_csrf_token(response, csrf_manager, request)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_main_catchall.py
+++ b/backend/tests/test_main_catchall.py
@@ -88,9 +88,9 @@ class TestMainCatchAllRoute(unittest.TestCase):
             content = f.read()
 
         # Check for case-insensitive assets blocking
-        self.assertIn('normalized_path == "assets"', content,
+        self.assertIn('normalized_path == _assets_prefix', content,
                       "Assets path check not found")
-        self.assertIn('normalized_path.startswith("assets/")', content,
+        self.assertIn('normalized_path.startswith(_assets_prefix + "/")', content,
                       "Assets prefix check not found")
 
     def test_assets_mount_configured(self):
@@ -100,7 +100,7 @@ class TestMainCatchAllRoute(unittest.TestCase):
             content = f.read()
 
         # Check for assets mount configuration
-        self.assertIn('app.mount("/assets"', content,
+        self.assertIn('app.mount(\n            assets_mount_path', content,
                       "Assets mount not found")
         self.assertIn('StaticFiles(directory=str(static_dir / "assets")', content,
                       "Assets directory configuration not found")

--- a/backend/tests/test_proxy_prefix_middleware.py
+++ b/backend/tests/test_proxy_prefix_middleware.py
@@ -1,0 +1,285 @@
+"""
+Verification tests for ProxyPrefixMiddleware (task 3.4).
+
+Tests verify:
+1. Middleware validates and stores forwarded_prefix in request.state
+2. auth.py _get_cookie_path uses request.state first, raw header fallback only if middleware absent
+3. security.py issue_csrf_token uses request.state first
+4. `..` is rejected by SAFE_PREFIX_RE (path traversal prevention)
+
+NOTE: These tests specifically verify request.state (per-request), NOT app.state (shared).
+"""
+
+import re
+import unittest
+from unittest.mock import MagicMock
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.security import SAFE_PREFIX_RE
+
+
+class TestSAFE_PREFIX_RejectsPathTraversal(unittest.TestCase):
+    """Verify `..` is rejected by SAFE_PREFIX_RE (requirement 4)."""
+
+    def test_double_dot_rejected(self):
+        """`..` path traversal must be rejected."""
+        result = SAFE_PREFIX_RE.match("/../etc/passwd")
+        self.assertIsNone(result)
+
+    def test_double_dot_in_middle_rejected(self):
+        """/foo/bar/../baz must be rejected."""
+        result = SAFE_PREFIX_RE.match("/foo/bar/../baz")
+        self.assertIsNone(result)
+
+    def test_double_dot_at_start_rejected(self):
+        """/../foo must be rejected."""
+        result = SAFE_PREFIX_RE.match("/../foo")
+        self.assertIsNone(result)
+
+    def test_double_dot_with_special_chars_rejected(self):
+        """/foo/../bar must be rejected."""
+        result = SAFE_PREFIX_RE.match("/foo/../bar")
+        self.assertIsNone(result)
+
+    def test_valid_prefix_no_double_dot_passes(self):
+        """Valid prefixes without `..` should pass."""
+        valid_prefixes = [
+            "/",
+            "/api",
+            "/knowledgevault",
+            "/a/b/c",
+            "/foo.bar",
+            "/foo_bar",
+            "/foo-bar",
+            "/a1",
+        ]
+        for prefix in valid_prefixes:
+            self.assertIsNotNone(
+                SAFE_PREFIX_RE.match(prefix),
+                f"Prefix '{prefix}' should be accepted",
+            )
+
+
+class TestProxyPrefixMiddlewareValidation(unittest.TestCase):
+    """Test ProxyPrefixMiddleware validates and stores in request.state (requirement 1)."""
+
+    def _make_mock_request(self, x_forwarded_prefix: str | None = None) -> MagicMock:
+        """Create a mock request with x-forwarded-prefix header."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers.get.return_value = x_forwarded_prefix
+        return mock_request
+
+    def test_middleware_stores_valid_prefix_in_request_state(self):
+        """Valid prefix should be stored in request.state.forwarded_prefix."""
+        from app.middleware.proxy_prefix import ProxyPrefixMiddleware
+
+        middleware = ProxyPrefixMiddleware(app=MagicMock())
+        mock_request = self._make_mock_request("/knowledgevault")
+
+        captured_state = {}
+
+        async def mock_call_next(request):
+            captured_state["forwarded_prefix"] = request.state.forwarded_prefix
+            return Response("ok")
+
+        # Run middleware dispatch
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            middleware.dispatch(mock_request, mock_call_next)
+        )
+
+        self.assertEqual(captured_state["forwarded_prefix"], "/knowledgevault")
+
+    def test_middleware_stores_empty_string_for_invalid_prefix(self):
+        """Invalid prefix should result in empty string in request.state.forwarded_prefix."""
+        from app.middleware.proxy_prefix import ProxyPrefixMiddleware
+
+        middleware = ProxyPrefixMiddleware(app=MagicMock())
+        mock_request = self._make_mock_request("/knowledge;vault")
+
+        captured_state = {}
+
+        async def mock_call_next(request):
+            captured_state["forwarded_prefix"] = request.state.forwarded_prefix
+            return Response("ok")
+
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            middleware.dispatch(mock_request, mock_call_next)
+        )
+
+        self.assertEqual(captured_state["forwarded_prefix"], "")
+
+    def test_middleware_stores_empty_string_for_double_dot(self):
+        """/../etc/passwd should be rejected and result in empty string."""
+        from app.middleware.proxy_prefix import ProxyPrefixMiddleware
+
+        middleware = ProxyPrefixMiddleware(app=MagicMock())
+        mock_request = self._make_mock_request("/../etc/passwd")
+
+        captured_state = {}
+
+        async def mock_call_next(request):
+            captured_state["forwarded_prefix"] = request.state.forwarded_prefix
+            return Response("ok")
+
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            middleware.dispatch(mock_request, mock_call_next)
+        )
+
+        self.assertEqual(captured_state["forwarded_prefix"], "")
+
+    def test_middleware_stores_empty_string_when_no_header(self):
+        """No x-forwarded-prefix header should result in empty string."""
+        from app.middleware.proxy_prefix import ProxyPrefixMiddleware
+
+        middleware = ProxyPrefixMiddleware(app=MagicMock())
+        mock_request = self._make_mock_request(None)
+
+        captured_state = {}
+
+        async def mock_call_next(request):
+            captured_state["forwarded_prefix"] = request.state.forwarded_prefix
+            return Response("ok")
+
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            middleware.dispatch(mock_request, mock_call_next)
+        )
+
+        self.assertEqual(captured_state["forwarded_prefix"], "")
+
+
+class TestAuthCookiePathUsesRequestStateFirst(unittest.TestCase):
+    """Test auth.py _get_cookie_path uses request.state first (requirement 2).
+
+    The fallback to raw header should ONLY occur when middleware is absent
+    (i.e., when request.state doesn't have forwarded_prefix attribute).
+    """
+
+    def _call_get_cookie_path(self, mock_request: MagicMock, suffix: str):
+        """Helper to call _get_cookie_path."""
+        from app.api.routes.auth import _get_cookie_path
+        return _get_cookie_path(mock_request, suffix)
+
+    def _make_request_with_state(self, forwarded_prefix_value: str | None, header_value: str) -> MagicMock:
+        """Create mock request with request.state.forwarded_prefix explicitly set or deleted."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers.get.return_value = header_value
+        if forwarded_prefix_value is not None:
+            # Middleware ran and set the value
+            mock_request.state.forwarded_prefix = forwarded_prefix_value
+        else:
+            # Middleware absent - delete the attribute so hasattr returns False
+            del mock_request.state.forwarded_prefix
+        return mock_request
+
+    def test_request_state_takes_priority_over_header(self):
+        """"When request.state.forwarded_prefix exists, it must be used even if header has different value."""
+        mock_request = self._make_request_with_state("/state-prefix", "/header-prefix")
+
+        result = self._call_get_cookie_path(mock_request, "/api/auth/refresh")
+
+        # Should use request.state, NOT header
+        self.assertEqual(result, "/state-prefix/api/auth/refresh")
+
+    def test_fallback_to_header_when_middleware_absent(self):
+        """When middleware absent (no forwarded_prefix in request.state), fall back to raw header."""
+        mock_request = self._make_request_with_state(None, "/valid-header")
+
+        result = self._call_get_cookie_path(mock_request, "/api/auth/refresh")
+
+        # Should use header value since middleware didn't run
+        self.assertEqual(result, "/valid-header/api/auth/refresh")
+
+    def test_fallback_validates_raw_header(self):
+        """Raw header fallback should still be validated against SAFE_PREFIX_RE."""
+        mock_request = self._make_request_with_state(None, "/valid-header")
+
+        result = self._call_get_cookie_path(mock_request, "/api/auth/refresh")
+
+        self.assertEqual(result, "/valid-header/api/auth/refresh")
+
+    def test_fallback_rejects_invalid_raw_header(self):
+        """Raw header fallback should reject invalid prefixes (e.g., with semicolon)."""
+        mock_request = self._make_request_with_state(None, "/invalid;header")
+
+        result = self._call_get_cookie_path(mock_request, "/api/auth/refresh")
+
+        # Should fall back to suffix only since header is invalid
+        self.assertEqual(result, "/api/auth/refresh")
+
+
+class TestSecurityIssueCsrfTokenUsesRequestStateFirst(unittest.TestCase):
+    """Test security.py issue_csrf_token uses request.state first (requirement 3).
+
+    The fallback to raw header should ONLY occur when middleware is absent.
+
+    NOTE: We cannot use spec=Request because Starlette Request is falsy when empty,
+    which would cause the outer `if request:` check to fail.
+    """
+
+    def _make_request_with_state(self, forwarded_prefix_value: str | None, header_value: str) -> MagicMock:
+        """Create mock request with request.state.forwarded_prefix explicitly set or deleted."""
+        # Don't use spec=Request because it makes the mock falsy
+        mock_request = MagicMock()
+        mock_request.headers.get.return_value = header_value
+        if forwarded_prefix_value is not None:
+            # Middleware ran and set the value
+            mock_request.state.forwarded_prefix = forwarded_prefix_value
+        else:
+            # Middleware absent - delete the attribute so hasattr returns False
+            del mock_request.state.forwarded_prefix
+        return mock_request
+
+    def test_request_state_takes_priority(self):
+        """When request.state.forwarded_prefix exists, it must be used for CSRF cookie path."""
+        mock_request = self._make_request_with_state("/state-prefix", "/header-prefix")
+        mock_response = MagicMock()
+
+        from app.security import issue_csrf_token, CSRFManager
+        mock_manager = MagicMock(spec=CSRFManager)
+        mock_manager.generate_token.return_value = "test-token"
+
+        issue_csrf_token(mock_response, mock_manager, mock_request)
+
+        # Check the path used in set_cookie call
+        call_kwargs = mock_response.set_cookie.call_args
+        # set_cookie is called with (key, value, **kwargs)
+        self.assertEqual(call_kwargs[1]["path"], "/state-prefix/api")
+
+    def test_fallback_to_header_when_middleware_absent(self):
+        """When middleware absent (no forwarded_prefix in request.state), fall back to raw header."""
+        mock_request = self._make_request_with_state(None, "/header-prefix")
+        mock_response = MagicMock()
+
+        from app.security import issue_csrf_token, CSRFManager
+        mock_manager = MagicMock(spec=CSRFManager)
+        mock_manager.generate_token.return_value = "test-token"
+
+        issue_csrf_token(mock_response, mock_manager, mock_request)
+
+        # Check the path used in set_cookie call
+        call_kwargs = mock_response.set_cookie.call_args
+        self.assertEqual(call_kwargs[1]["path"], "/header-prefix/api")
+
+    def test_no_prefix_returns_api_path(self):
+        """No prefix should result in path=/api."""
+        mock_request = self._make_request_with_state(None, "")
+        mock_response = MagicMock()
+
+        from app.security import issue_csrf_token, CSRFManager
+        mock_manager = MagicMock(spec=CSRFManager)
+        mock_manager.generate_token.return_value = "test-token"
+
+        issue_csrf_token(mock_response, mock_manager, mock_request)
+
+        call_kwargs = mock_response.set_cookie.call_args
+        self.assertEqual(call_kwargs[1]["path"], "/api")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_static_mount_path_prefix_3_2.py
+++ b/backend/tests/test_static_mount_path_prefix_3_2.py
@@ -1,0 +1,81 @@
+"""
+Verification tests for task 3.2 — Static mount path is prefix-aware.
+Tests that assets_mount_path correctly incorporates root_path prefix.
+
+Expected behavior:
+- root_path="" → mount path = "/assets"
+- root_path="/knowledgevault" → mount path = "/knowledgevault/assets"
+"""
+
+import sys
+import os
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.config import Settings
+
+
+class TestStaticMountPathPrefixAware:
+    """Test that static mount path respects root_path prefix."""
+
+    def test_root_path_empty_mount_path_is_assets(self):
+        """root_path='' should result in mount path '/assets'."""
+        with patch.dict("os.environ", {"ROOT_PATH": ""}):
+            settings = Settings()
+            # Compute mount path using the same logic as main.py
+            assets_mount_path = f"{settings.root_path}/assets" if settings.root_path else "/assets"
+            assert assets_mount_path == "/assets"
+
+    def test_root_path_knowledgevault_mount_path_includes_prefix(self):
+        """root_path='/knowledgevault' should result in mount path '/knowledgevault/assets'."""
+        with patch.dict("os.environ", {"ROOT_PATH": "/knowledgevault"}):
+            settings = Settings()
+            # Compute mount path using the same logic as main.py
+            assets_mount_path = f"{settings.root_path}/assets" if settings.root_path else "/assets"
+            assert assets_mount_path == "/knowledgevault/assets"
+
+    def test_root_path_with_trailing_slash(self):
+        """root_path='/kv/' should result in mount path '/kv/assets' (trailing slash stripped)."""
+        with patch.dict("os.environ", {"ROOT_PATH": "/kv/"}):
+            settings = Settings()
+            # The implementation strips trailing slashes from root_path
+            _root = settings.root_path.rstrip("/") if settings.root_path else ""
+            assets_mount_path = f"{_root}/assets" if _root else "/assets"
+            assert assets_mount_path == "/kv/assets"
+
+    def test_root_path_only_slash(self):
+        """root_path='/' should result in mount path '/assets' (stripped to empty, then falsy)."""
+        with patch.dict("os.environ", {"ROOT_PATH": "/"}):
+            settings = Settings()
+            _root = settings.root_path.rstrip("/") if settings.root_path else ""
+            assets_mount_path = f"{_root}/assets" if _root else "/assets"
+            assert assets_mount_path == "/assets"
+
+
+class TestMountPathLogicDirectly:
+    """Direct tests of the mount path logic from main.py line 144."""
+
+    def test_logic_root_path_empty_string_is_falsy(self):
+        """Empty string root_path is falsy in Python, so should use '/assets'."""
+        root_path = ""
+        assets_mount_path = f"{root_path}/assets" if root_path else "/assets"
+        assert assets_mount_path == "/assets"
+
+    def test_logic_root_path_with_value_is_truthy(self):
+        """Non-empty root_path is truthy, so prefix is applied."""
+        root_path = "/knowledgevault"
+        assets_mount_path = f"{root_path}/assets" if root_path else "/assets"
+        assert assets_mount_path == "/knowledgevault/assets"
+
+    def test_logic_root_path_none_is_falsy(self):
+        """None root_path is falsy, so should use '/assets'."""
+        root_path = None
+        # Using conditional expression
+        assets_mount_path = f"{root_path}/assets" if root_path else "/assets"
+        assert assets_mount_path == "/assets"
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        VITE_APP_BASENAME: ${VITE_APP_BASENAME:-}
     container_name: knowledgevault
     restart: unless-stopped
     ports:
@@ -123,6 +125,8 @@ services:
       - CHUNK_ENRICHMENT_ENABLED=${CHUNK_ENRICHMENT_ENABLED:-false}
       - MULTI_SCALE_INDEXING_ENABLED=${MULTI_SCALE_INDEXING_ENABLED:-true}
       - MULTI_SCALE_CHUNK_SIZES=${MULTI_SCALE_CHUNK_SIZES:-768,1536}
+      - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS:-http://localhost:5173,http://localhost:3000}
+      - ROOT_PATH=${ROOT_PATH:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,12 @@
+# Frontend environment variables
+# Copy to frontend/.env and customize
+
+# Base path for the frontend when deployed behind a reverse proxy subdirectory
+# Must match ROOT_PATH (without trailing slash). Leave empty for root deployment.
+# Example: VITE_APP_BASENAME=/knowledgevault
+
+# Optional: Override the API base URL (default is auto-derived from VITE_APP_BASENAME)
+# If not set, API calls go to ${VITE_APP_BASENAME}/api
+# VITE_API_URL=http://localhost:9090/api
+
+VITE_APP_BASENAME=

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,7 +115,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <BrowserRouter basename={import.meta.env.VITE_APP_BASENAME || ''} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Suspense fallback={<PageLoader />}>
           <Routes>
               <Route path="/setup" element={<SetupPage />} />

--- a/frontend/src/components/chat/WikiCards.tsx
+++ b/frontend/src/components/chat/WikiCards.tsx
@@ -17,7 +17,8 @@ function WikiCard({ wikiRef }: WikiCardProps) {
 
   const handleNavigate = () => {
     if (wikiRef.slug) {
-      window.open(`/wiki?page=${encodeURIComponent(wikiRef.slug)}`, "_blank", "noopener");
+      const basename = (import.meta.env.VITE_APP_BASENAME || "").replace(/\/$/, "");
+      window.open(`${basename}/wiki?page=${encodeURIComponent(wikiRef.slug)}`, "_blank", "noopener");
     }
   };
 

--- a/frontend/src/lib/api.redirect_basename.test.ts
+++ b/frontend/src/lib/api.redirect_basename.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="vitest" />
+import { describe, test, expect } from 'vitest'
+
+// Test the login path construction logic from api.ts 401 interceptor
+// Replicates actual implementation: lines 250-251 in api.ts
+
+describe('401 redirect basename-aware login path', () => {
+  // Replicates the EXACT logic from api.ts lines 250-251
+  const getLoginPath = (basename: string | undefined): string => {
+    const base = (basename || '').replace(/\/$/, '')
+    return base ? `${base}/login` : '/login'
+  }
+
+  describe('loginPath construction', () => {
+    test('Root-level deployment: empty basename yields /login', () => {
+      expect(getLoginPath('')).toBe('/login')
+    })
+
+    test('Root-level deployment: undefined basename yields /login', () => {
+      expect(getLoginPath(undefined)).toBe('/login')
+    })
+
+    test('Root-level deployment: "/" basename yields /login', () => {
+      expect(getLoginPath('/')).toBe('/login')
+    })
+
+    test('Path-prefixed deployment: /knowledgevault yields /knowledgevault/login', () => {
+      expect(getLoginPath('/knowledgevault')).toBe('/knowledgevault/login')
+    })
+
+    test('Path-prefixed deployment: /knowledgevault/ (trailing slash) yields /knowledgevault/login', () => {
+      expect(getLoginPath('/knowledgevault/')).toBe('/knowledgevault/login')
+    })
+
+    test('Path-prefixed deployment: /myapp yields /myapp/login', () => {
+      expect(getLoginPath('/myapp')).toBe('/myapp/login')
+    })
+
+    test('Path-prefixed deployment: /myapp/ (trailing slash) yields /myapp/login', () => {
+      expect(getLoginPath('/myapp/')).toBe('/myapp/login')
+    })
+
+    test('Path-prefixed deployment: /api/admin yields /api/admin/login', () => {
+      expect(getLoginPath('/api/admin')).toBe('/api/admin/login')
+    })
+
+    test('Path-prefixed deployment: /api/admin/ (trailing slash) yields /api/admin/login', () => {
+      expect(getLoginPath('/api/admin/')).toBe('/api/admin/login')
+    })
+
+  })
+
+  describe('window.location assignment guard', () => {
+    // Test that we don't redirect if already on login page
+    const willRedirect = (currentPath: string, loginPath: string): boolean => {
+      return currentPath !== loginPath
+    }
+
+    test('Redirects when on /dashboard and login is /login', () => {
+      expect(willRedirect('/dashboard', '/login')).toBe(true)
+    })
+
+    test('Redirects when on /knowledgevault/dashboard and login is /knowledgevault/login', () => {
+      expect(willRedirect('/knowledgevault/dashboard', '/knowledgevault/login')).toBe(true)
+    })
+
+    test('Redirects when on /knowledgevault/ (with trailing slash) and login is /knowledgevault/login', () => {
+      expect(willRedirect('/knowledgevault/', '/knowledgevault/login')).toBe(true)
+    })
+
+    test('Does NOT redirect when already on /login', () => {
+      expect(willRedirect('/login', '/login')).toBe(false)
+    })
+
+    test('Does NOT redirect when already on /knowledgevault/login', () => {
+      expect(willRedirect('/knowledgevault/login', '/knowledgevault/login')).toBe(false)
+    })
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosRequestHeaders } from "axios";
 import { setChatHistory as storageSetChatHistory, getChatHistory as storageGetChatHistory } from "./storage";
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || "/api";
+const basename = (import.meta.env.VITE_APP_BASENAME || "").replace(/\/$/, "");
+const API_BASE_URL = import.meta.env.VITE_API_URL || (basename ? `${basename}/api` : "/api");
 
 // Module-level JWT token holder - persisted via useAuthStore persist middleware
 let _jwtAccessToken: string | null = null;
@@ -247,8 +248,10 @@ apiClient.interceptors.response.use(
 
       // Clear auth state and redirect to login
       _jwtAccessToken = null;
-      if (window.location.pathname !== "/login") {
-        window.location.href = "/login";
+      const basename = (import.meta.env.VITE_APP_BASENAME || '').replace(/\/$/, '')
+      const loginPath = basename ? `${basename}/login` : '/login'
+      if (window.location.pathname !== loginPath) {
+        window.location.href = loginPath
       }
     }
 

--- a/frontend/src/pages/WikiPage.tsx
+++ b/frontend/src/pages/WikiPage.tsx
@@ -53,7 +53,8 @@ export default function WikiPage() {
     // jsdom (vitest) does not provide EventSource. Skip cleanly so unit tests
     // that don't exercise the live stream still mount the page.
     if (typeof EventSource === "undefined") return;
-    const apiBase = import.meta.env.VITE_API_URL || "/api";
+    const basename = (import.meta.env.VITE_APP_BASENAME || "").replace(/\/$/, "");
+    const apiBase = import.meta.env.VITE_API_URL || (basename ? `${basename}/api` : "/api");
     const url = `${apiBase}/wiki/events?vault_id=${activeVaultId}`;
     const es = new EventSource(url, { withCredentials: true });
     eventSourceRef.current = es;

--- a/frontend/src/stores/useAuthStore.ts
+++ b/frontend/src/stores/useAuthStore.ts
@@ -46,7 +46,8 @@ interface AuthState {
   _setLoading: (loading: boolean) => void;
 }
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || "/api";
+const basename = (import.meta.env.VITE_APP_BASENAME || "").replace(/\/$/, "");
+const API_BASE_URL = import.meta.env.VITE_API_URL || (basename ? `${basename}/api` : "/api");
 
 // Create a separate axios instance for auth calls to avoid interceptor loops
 const authClient = axios.create({

--- a/frontend/src/test/vite_config_basename.test.ts
+++ b/frontend/src/test/vite_config_basename.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="vitest" />
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// We need to test the appBasename logic without importing the actual config
+// since it reads process.env at module load time. Instead, we test the
+// equivalent logic directly.
+
+describe('VITE_APP_BASENAME configuration logic', () => {
+  const originalEnv = process.env.VITE_APP_BASENAME
+
+  afterEach(() => {
+    // Restore original env
+    if (originalEnv === undefined) {
+      delete process.env.VITE_APP_BASENAME
+    } else {
+      process.env.VITE_APP_BASENAME = originalEnv
+    }
+  })
+
+  // Simulates: export const appBasename = process.env.VITE_APP_BASENAME || ''
+  const getAppBasename = () => process.env.VITE_APP_BASENAME || ''
+
+  // Simulates: base: appBasename || '/'
+  const getBase = (appBasename: string) => appBasename || '/'
+
+  test('base falls back to "/" when VITE_APP_BASENAME is not set', () => {
+    delete process.env.VITE_APP_BASENAME
+    const appBasename = getAppBasename()
+    const base = getBase(appBasename)
+    expect(base).toBe('/')
+  })
+
+  test('base uses env var value when VITE_APP_BASENAME is set to a path', () => {
+    process.env.VITE_APP_BASENAME = '/myapp'
+    const appBasename = getAppBasename()
+    const base = getBase(appBasename)
+    expect(base).toBe('/myapp')
+  })
+
+  test('base uses env var value when VITE_APP_BASENAME is set to root', () => {
+    process.env.VITE_APP_BASENAME = '/'
+    const appBasename = getAppBasename()
+    const base = getBase(appBasename)
+    expect(base).toBe('/')
+  })
+
+  test('base falls back to "/" when VITE_APP_BASENAME is set to empty string', () => {
+    process.env.VITE_APP_BASENAME = ''
+    const appBasename = getAppBasename()
+    const base = getBase(appBasename)
+    expect(base).toBe('/')
+  })
+
+  test('appBasename is exported as a string', () => {
+    process.env.VITE_APP_BASENAME = '/test'
+    const appBasename = getAppBasename()
+    expect(typeof appBasename).toBe('string')
+  })
+})

--- a/frontend/src/vite-config-proxy.test.ts
+++ b/frontend/src/vite-config-proxy.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'bun:test'
+
+// Replicate the normalization logic from vite.config.ts
+function normalizeBasename(appBasename: string): string {
+  return appBasename.replace(/\/+$/, '')
+}
+
+function computeProxyConfig(appBasename: string): { key: string; rewrite: ((path: string) => string) | undefined } {
+  const normalizedBasename = normalizeBasename(appBasename)
+  const key = normalizedBasename ? `${normalizedBasename}/api` : '/api'
+  const rewrite = normalizedBasename
+    ? (path: string) => path.replace(new RegExp(`^${normalizedBasename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), '')
+    : undefined
+  return { key, rewrite }
+}
+
+describe('1.5: Proxy rewrite with regex escape', () => {
+
+  test('1. appBasename="" → normalizedBasename="", key="/api", no rewrite', () => {
+    const { key, rewrite } = computeProxyConfig('')
+    expect(normalizeBasename('')).toBe('')
+    expect(key).toBe('/api')
+    expect(rewrite).toBeUndefined()
+  })
+
+  test('2. appBasename="/knowledgevault" → normalizedBasename="/knowledgevault", key="/knowledgevault/api", rewrite strips basename', () => {
+    const { key, rewrite } = computeProxyConfig('/knowledgevault')
+    expect(normalizeBasename('/knowledgevault')).toBe('/knowledgevault')
+    expect(key).toBe('/knowledgevault/api')
+    expect(rewrite).toBeDefined()
+    expect(rewrite!('/knowledgevault/api/users')).toBe('/api/users')
+    expect(rewrite!('/knowledgevault/api')).toBe('/api')
+  })
+
+  test('3. appBasename="/knowledgevault/" → normalizedBasename="/knowledgevault", key="/knowledgevault/api"', () => {
+    const { key, rewrite } = computeProxyConfig('/knowledgevault/')
+    expect(normalizeBasename('/knowledgevault/')).toBe('/knowledgevault')
+    expect(key).toBe('/knowledgevault/api')
+    expect(rewrite).toBeDefined()
+    expect(rewrite!('/knowledgevault/api/users')).toBe('/api/users')
+  })
+
+  test('4. appBasename="/" → normalizedBasename="", key="/api"', () => {
+    const { key, rewrite } = computeProxyConfig('/')
+    expect(normalizeBasename('/')).toBe('')
+    expect(key).toBe('/api')
+    expect(rewrite).toBeUndefined()
+  })
+
+  test('5. appBasename="/app.v2" → regex properly escapes the dot', () => {
+    const { key, rewrite } = computeProxyConfig('/app.v2')
+    expect(normalizeBasename('/app.v2')).toBe('/app.v2')
+    expect(key).toBe('/app.v2/api')
+    expect(rewrite).toBeDefined()
+    // The dot must be escaped - /app.v2/api should NOT match /appX2/api
+    expect(rewrite!('/app.v2/api/users')).toBe('/api/users')
+    // Verify it doesn't incorrectly match similar paths
+    expect(rewrite!('/appX2/api')).toBe('/appX2/api') // not matched, dot is escaped
+    expect(rewrite!('/app.v2/api')).toBe('/api')
+  })
+
+  test('Edge: multiple trailing slashes are stripped', () => {
+    expect(normalizeBasename('///')).toBe('')
+  })
+
+  test('Edge: path with no match remains unchanged', () => {
+    const { rewrite } = computeProxyConfig('/app')
+    expect(rewrite!('/other/api')).toBe('/other/api')
+  })
+})

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_BASENAME: string
+}

--- a/frontend/src/vite.config.test.ts
+++ b/frontend/src/vite.config.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { appBasename } from '../vite.config'
+
+describe('vite.config.ts', () => {
+  it('exports appBasename as a string', () => {
+    expect(typeof appBasename).toBe('string')
+  })
+
+  it('appBasename defaults to empty string when VITE_APP_BASENAME is not set', () => {
+    // appBasename is captured at module load time.
+    // This test verifies the default when the env var was unset at test startup.
+    expect(appBasename).toBe('')
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,12 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// VITE_APP_BASENAME: Build-time path prefix for asset URLs. Application code reads this via import.meta.env.VITE_APP_BASENAME at runtime.
+export const appBasename = process.env.VITE_APP_BASENAME || ''
+const normalizedBasename = appBasename.replace(/\/+$/, '')
+
 export default defineConfig({
+  base: normalizedBasename || '/',
   plugins: [react()],
   resolve: {
     alias: {
@@ -25,9 +30,12 @@ export default defineConfig({
     port: 3000,
     host: true,
     proxy: {
-      '/api': {
+      [normalizedBasename ? `${normalizedBasename}/api` : '/api']: {
         target: 'http://localhost:9090',
         changeOrigin: true,
+        rewrite: normalizedBasename
+          ? (path) => path.replace(new RegExp(`^${normalizedBasename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), '')
+          : undefined,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Add full-stack support for deploying behind a reverse proxy subdirectory path (e.g., /knowledgevault)
- Frontend basename awareness via VITE_APP_BASENAME build-time variable with Docker ARG support
- Backend oot_path handling with ProxyPrefixMiddleware for x-forwarded-prefix detection
- Cookie and CSRF path prefixing, static asset mount prefixing, and API base URL awareness

## Test plan
- [x] python -m pytest tests/test_auth_cookie_path.py tests/test_csrf_token_path_prefix.py tests/test_proxy_prefix_middleware.py tests/test_static_mount_path_prefix_3_2.py tests/test_main_catchall.py -v -- 57 passed
- [x] 
pm test -- src/test/vite_config_basename.test.ts src/lib/api.redirect_basename.test.ts --run -- 19 passed
- [x] python -m py_compile app/api/routes/auth.py app/config.py app/main.py app/security.py app/middleware/proxy_prefix.py -- all clean
- [x] git diff --check -- no whitespace issues

## Deployment notes
- Set VITE_APP_BASENAME=/your-prefix and ROOT_PATH=/your-prefix in .env
- Rebuild Docker image to bake the basename into the frontend bundle
- Uvicorn runs with --proxy-headers --forwarded-allow-ips='*' (restrict to proxy IPs in production)