### PR TITLE
feat(kms): Phase 1 Knowledge Management System for vault docs (#119)

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -67,6 +67,7 @@ _MAGIC_BYTES: dict[str, bytes] = {
     ".pdf": b"%PDF",
     ".docx": b"PK\x03\x04",
     ".xlsx": b"PK\x03\x04",
+    ".pptx": b"PK\x03\x04",
     ".xls": b"\xd0\xcf\x11\xe0",  # OLE Compound File
 }
 
@@ -140,6 +141,73 @@ def _record_document_action(
         """,
         (file_id, action, status, user_id, digest),
     )
+
+
+def _user_id_str(user: dict | None) -> str:
+    if user and user.get("id"):
+        return str(user["id"])
+    return "unknown"
+
+
+async def _safe_record_action(
+    file_id: int,
+    action: str,
+    status: str,
+    user: dict | None,
+    secret_manager: Optional[SecretManager],
+    conn: sqlite3.Connection,
+) -> None:
+    """Best-effort HMAC audit log against the request connection (DD-C010).
+
+    Never raises — auditing must not break the user-facing operation. No-op when
+    ``secret_manager`` is unavailable (e.g. before lifespan startup).
+    """
+    if secret_manager is None:
+        return
+    try:
+        await asyncio.to_thread(
+            _record_document_action,
+            file_id,
+            action,
+            status,
+            _user_id_str(user),
+            secret_manager,
+            conn,
+        )
+        await asyncio.to_thread(conn.commit)
+    except Exception as exc:  # noqa: BLE001 — audit failures must not propagate
+        logger.warning(
+            "Audit logging failed (%s/%s) for file_id=%s: %s", action, status, file_id, exc
+        )
+
+
+async def _record_upload_audit(
+    file_id: int,
+    user: dict | None,
+    secret_manager: Optional[SecretManager],
+    db_pool: "SQLiteConnectionPool",
+) -> None:
+    """Best-effort upload audit. Uploads use the pool (no request conn), so this
+    borrows a pooled connection for the single INSERT (DD-C010).
+
+    No-op when ``secret_manager`` is unavailable (e.g. before lifespan startup)."""
+    if secret_manager is None:
+        return
+
+    def _write() -> None:
+        conn = db_pool.get_connection()
+        try:
+            _record_document_action(
+                file_id, "upload", "success", _user_id_str(user), secret_manager, conn
+            )
+            conn.commit()
+        finally:
+            db_pool.release_connection(conn)
+
+    try:
+        await asyncio.to_thread(_write)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Upload audit logging failed for file_id=%s: %s", file_id, exc)
 
 
 @router.post("/admin/retry/{file_id}")
@@ -670,6 +738,7 @@ async def get_document_status(
 @router.get("/{file_id}/raw")
 async def get_document_raw(
     file_id: int,
+    request: Request,
     conn: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
     evaluate: Callable = Depends(get_evaluate_policy),
@@ -711,6 +780,15 @@ async def get_document_raw(
 
     if not file_path.exists() or not file_path.is_file():
         raise HTTPException(status_code=404, detail="Document file not found")
+
+    await _safe_record_action(
+        file_id,
+        "read",
+        "success",
+        user,
+        getattr(request.app.state, "secret_manager", None),
+        conn,
+    )
 
     media_type = mimetypes.guess_type(row["file_name"])[0] or "application/octet-stream"
     is_pdf = media_type == "application/pdf" or row["file_name"].lower().endswith(".pdf")
@@ -848,7 +926,7 @@ async def upload_document_root(
     runs in the background processor; clients poll
     ``GET /documents/{file_id}/status`` for progress.
     """
-    return await _do_upload(
+    response = await _do_upload(
         request,
         file,
         settings_dep,
@@ -858,6 +936,10 @@ async def upload_document_root(
         background_processor,
         vault_id,
     )
+    await _record_upload_audit(
+        response.file_id, user, getattr(request.app.state, "secret_manager", None), db_pool
+    )
+    return response
 
 
 @router.post("/upload", response_model=UploadResponse)
@@ -881,7 +963,7 @@ async def upload_document(
     background processor. Returns immediately so the client can poll
     ``GET /documents/{file_id}/status`` for phase-aware progress.
     """
-    return await _do_upload(
+    response = await _do_upload(
         request,
         file,
         settings_dep,
@@ -891,6 +973,10 @@ async def upload_document(
         background_processor,
         vault_id,
     )
+    await _record_upload_audit(
+        response.file_id, user, getattr(request.app.state, "secret_manager", None), db_pool
+    )
+    return response
 
 
 async def _do_upload(
@@ -1181,6 +1267,31 @@ async def scan_directories(
     # Note: No finally block to stop processor - it runs continuously
 
 
+def _unlink_document_file(stored_path: str, vault_id: int) -> None:
+    """Best-effort delete of an on-disk document, confined to the vault's roots.
+
+    Prevents orphaned files accumulating after a record is deleted (DD-C003).
+    Path containment is enforced so a tampered DB row can never cause deletion
+    outside the configured document roots.
+    """
+    try:
+        file_path = Path(stored_path).resolve(strict=False)
+    except (OSError, RuntimeError, ValueError, TypeError):
+        return
+    roots = [
+        root.resolve(strict=False) for root in _allowed_document_roots(settings, vault_id)
+    ]
+    if not any(_path_is_within(file_path, root) for root in roots):
+        logger.warning(
+            "Refusing to unlink document outside configured roots: %s", file_path
+        )
+        return
+    try:
+        file_path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("Failed to unlink document file %s: %s", file_path, exc)
+
+
 async def _delete_file_record(
     conn: sqlite3.Connection,
     vector_store: VectorStore,
@@ -1190,6 +1301,19 @@ async def _delete_file_record(
 ) -> None:
     """Delete one file and its derived data with consistent cleanup."""
     try:
+        # Resolve the on-disk path before deleting the row so the file can be
+        # garbage-collected from disk after the DB row is gone (DD-C003).
+        stored_path: Optional[str] = None
+        try:
+            path_cursor = await asyncio.to_thread(
+                conn.execute, "SELECT file_path FROM files WHERE id = ?", (file_id,)
+            )
+            path_row = await asyncio.to_thread(path_cursor.fetchone)
+            if path_row is not None:
+                stored_path = path_row["file_path"]
+        except sqlite3.Error:
+            stored_path = None
+
         try:
             db = vector_store.db
             if db is not None and "chunks" in await db.table_names():
@@ -1222,6 +1346,10 @@ async def _delete_file_record(
         )
         await asyncio.to_thread(conn.commit)
         logger.info("Deleted document '%s' (id: %d)", file_name, file_id)
+
+        # GC the original file from disk after the row is committed.
+        if stored_path:
+            await asyncio.to_thread(_unlink_document_file, stored_path, vault_id)
     except Exception:
         await asyncio.to_thread(conn.rollback)
         raise
@@ -1269,6 +1397,15 @@ async def delete_document(
             file_id,
             file_name,
             file_vault_id,
+        )
+
+        await _safe_record_action(
+            file_id,
+            "delete",
+            "success",
+            user,
+            getattr(request.app.state, "secret_manager", None),
+            conn,
         )
 
         return DeleteResponse(

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1476,6 +1476,14 @@ async def batch_delete_documents(
                 file_name,
                 file_vault_id,
             )
+            await _safe_record_action(
+                normalized_file_id,
+                "delete",
+                "success",
+                user,
+                getattr(request.app.state, "secret_manager", None),
+                conn,
+            )
             deleted_count += 1
 
         except Exception:
@@ -1520,6 +1528,14 @@ async def delete_all_vault_documents(
                 file_id,
                 file_name,
                 vault_id,
+            )
+            await _safe_record_action(
+                file_id,
+                "delete",
+                "success",
+                user,
+                getattr(request.app.state, "secret_manager", None),
+                conn,
             )
             deleted_count += 1
 

--- a/backend/app/api/routes/kms.py
+++ b/backend/app/api/routes/kms.py
@@ -15,10 +15,23 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from app.api.deps import evaluate_policy, get_current_active_user, get_db
+from app.config import settings
+from app.security import csrf_protect
 from app.services.kms_store import KMSStore
 
 logger = logging.getLogger(__name__)
-router = APIRouter()
+
+
+def require_kms_enabled() -> None:
+    """Master switch (config.kms_enabled). When off, the entire KMS subsystem —
+    reads, writes, and job creation — is unavailable, not just auto-ingest."""
+    if not settings.kms_enabled:
+        raise HTTPException(status_code=403, detail="KMS subsystem is disabled")
+
+
+# Apply the master switch to every KMS route. CSRF is added per-route on the
+# mutating endpoints below.
+router = APIRouter(dependencies=[Depends(require_kms_enabled)])
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +125,7 @@ async def create_kms_entry(
     request: KMSEntryCreateRequest,
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
+    _csrf: str = Depends(csrf_protect),
 ):
     await _require_vault_write(user, request.vault_id)
     _validate_status(request.status)
@@ -154,6 +168,7 @@ async def update_kms_entry(
     request: KMSEntryUpdateRequest,
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
+    _csrf: str = Depends(csrf_protect),
 ):
     store = KMSStore(db)
     entry = store.get_entry(entry_id)
@@ -173,6 +188,7 @@ async def delete_kms_entry(
     entry_id: int,
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
+    _csrf: str = Depends(csrf_protect),
 ):
     store = KMSStore(db)
     entry = store.get_entry(entry_id)
@@ -220,6 +236,7 @@ async def compile_document_kms(
     vault_id: int = Query(...),
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
+    _csrf: str = Depends(csrf_protect),
 ):
     """Enqueue a KMS ingest job for an already-indexed document."""
     await _require_vault_write(user, vault_id)
@@ -247,6 +264,7 @@ async def recompile_vault_kms(
     vault_id: int = Query(...),
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
+    _csrf: str = Depends(csrf_protect),
 ):
     """Enqueue a settings_reindex job to recompile all document entries in a vault."""
     await _require_vault_write(user, vault_id)

--- a/backend/app/api/routes/kms.py
+++ b/backend/app/api/routes/kms.py
@@ -1,0 +1,293 @@
+"""
+KMS / Knowledge Management API routes.
+
+User-curated documentation entries, scoped per vault. Entries may be authored
+manually or compiled from ingested documents (source_type='document'). All
+endpoints follow vault access permissions, mirroring the wiki routes.
+"""
+
+import logging
+import sqlite3
+from dataclasses import asdict
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.api.deps import evaluate_policy, get_current_active_user, get_db
+from app.services.kms_store import KMSStore
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry_dict(entry) -> dict:
+    d = asdict(entry)
+    d["tags"] = entry.tags
+    return d
+
+
+async def _require_vault_read(user: dict, vault_id: int) -> None:
+    if not await evaluate_policy(user, "vault", vault_id, "read"):
+        raise HTTPException(status_code=403, detail="No read access to this vault")
+
+
+async def _require_vault_write(user: dict, vault_id: int) -> None:
+    if not await evaluate_policy(user, "vault", vault_id, "write"):
+        raise HTTPException(status_code=403, detail="No write access to this vault")
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class KMSEntryCreateRequest(BaseModel):
+    vault_id: int
+    title: str = Field(..., min_length=1, max_length=500)
+    body: str = ""
+    summary: str = Field("", max_length=2000)
+    tags: list[str] = Field(default_factory=list)
+    slug: Optional[str] = None
+    status: str = "draft"
+
+
+class KMSEntryUpdateRequest(BaseModel):
+    title: Optional[str] = Field(None, min_length=1, max_length=500)
+    body: Optional[str] = None
+    summary: Optional[str] = Field(None, max_length=2000)
+    tags: Optional[list[str]] = None
+    slug: Optional[str] = None
+    status: Optional[str] = None
+
+
+_VALID_STATUSES = {"draft", "published", "archived"}
+
+
+def _validate_status(status: Optional[str]) -> None:
+    if status is not None and status not in _VALID_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid status {status!r}. Allowed: {sorted(_VALID_STATUSES)}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/kms/entries")
+async def list_kms_entries(
+    vault_id: int = Query(..., description="Vault ID"),
+    status: Optional[str] = Query(None),
+    tag: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = KMSStore(db)
+    entries = store.list_entries(
+        vault_id, status=status, tag=tag, search=search, page=page, per_page=per_page
+    )
+    total = store.count_entries(vault_id, status=status, tag=tag, search=search)
+    return {
+        "entries": [_entry_dict(e) for e in entries],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+    }
+
+
+@router.post("/kms/entries", status_code=201)
+async def create_kms_entry(
+    request: KMSEntryCreateRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_write(user, request.vault_id)
+    _validate_status(request.status)
+    store = KMSStore(db)
+    try:
+        entry = store.create_entry(
+            vault_id=request.vault_id,
+            title=request.title,
+            body=request.body,
+            summary=request.summary,
+            tags=request.tags,
+            slug=request.slug,
+            source_type="manual",
+            status=request.status,
+            created_by=user.get("id"),
+        )
+    except Exception as e:
+        logger.exception("Error creating KMS entry")
+        raise HTTPException(status_code=400, detail=str(e))
+    return _entry_dict(entry)
+
+
+@router.get("/kms/entries/{entry_id}")
+async def get_kms_entry(
+    entry_id: int,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    store = KMSStore(db)
+    entry = store.get_entry(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="KMS entry not found")
+    await _require_vault_read(user, entry.vault_id)
+    return _entry_dict(entry)
+
+
+@router.put("/kms/entries/{entry_id}")
+async def update_kms_entry(
+    entry_id: int,
+    request: KMSEntryUpdateRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    store = KMSStore(db)
+    entry = store.get_entry(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="KMS entry not found")
+    await _require_vault_write(user, entry.vault_id)
+    _validate_status(request.status)
+    updates = request.model_dump(exclude_none=True)
+    updated = store.update_entry(entry_id, entry.vault_id, **updates)
+    if not updated:
+        raise HTTPException(status_code=404, detail="KMS entry not found")
+    return _entry_dict(updated)
+
+
+@router.delete("/kms/entries/{entry_id}", status_code=204)
+async def delete_kms_entry(
+    entry_id: int,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    store = KMSStore(db)
+    entry = store.get_entry(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="KMS entry not found")
+    await _require_vault_write(user, entry.vault_id)
+    store.delete_entry(entry_id, entry.vault_id)
+
+
+# ---------------------------------------------------------------------------
+# Search endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/kms/search")
+async def search_kms(
+    vault_id: int = Query(...),
+    q: str = Query(..., min_length=1),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = KMSStore(db)
+    entries = store.list_entries(vault_id, search=q, page=page, per_page=per_page)
+    total = store.count_entries(vault_id, search=q)
+    return {
+        "query": q,
+        "entries": [_entry_dict(e) for e in entries],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Compile endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/kms/documents/{file_id}/compile", status_code=202)
+async def compile_document_kms(
+    file_id: int,
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    """Enqueue a KMS ingest job for an already-indexed document."""
+    await _require_vault_write(user, vault_id)
+    db.row_factory = sqlite3.Row
+    file_row = db.execute(
+        "SELECT id FROM files WHERE id = ? AND vault_id = ?",
+        (file_id, vault_id),
+    ).fetchone()
+    if not file_row:
+        raise HTTPException(
+            status_code=404, detail=f"File {file_id} not found in vault {vault_id}"
+        )
+    store = KMSStore(db)
+    job = store.create_job(
+        vault_id=vault_id,
+        trigger_type="ingest",
+        trigger_id=f"file:{file_id}",
+        input_json={"file_id": file_id, "vault_id": vault_id},
+    )
+    return {"job_id": job.id, "status": job.status}
+
+
+@router.post("/kms/recompile", status_code=202)
+async def recompile_vault_kms(
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    """Enqueue a settings_reindex job to recompile all document entries in a vault."""
+    await _require_vault_write(user, vault_id)
+    store = KMSStore(db)
+    job = store.create_job(
+        vault_id=vault_id,
+        trigger_type="settings_reindex",
+        trigger_id=f"vault:{vault_id}",
+        input_json={"vault_id": vault_id},
+    )
+    return {"job_id": job.id, "status": job.status}
+
+
+# ---------------------------------------------------------------------------
+# Job status endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/kms/jobs")
+async def list_kms_jobs(
+    vault_id: int = Query(...),
+    status: Optional[str] = Query(None),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = KMSStore(db)
+    jobs = store.list_jobs(vault_id, status=status)
+    return {"jobs": [asdict(j) for j in jobs]}
+
+
+@router.get("/kms/jobs/{job_id}")
+async def get_kms_job(
+    job_id: int,
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = KMSStore(db)
+    job = store.get_job(job_id, vault_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    return asdict(job)

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -91,6 +91,10 @@ class SettingsUpdate(BaseModel):
     wiki_llm_curator_run_on_query: Optional[bool] = None
     wiki_llm_curator_run_on_manual: Optional[bool] = None
 
+    # KMS / Knowledge Management config
+    kms_enabled: Optional[bool] = None
+    kms_compile_on_ingest: Optional[bool] = None
+
     @field_validator("chunk_size")
     @classmethod
     def validate_chunk_size(cls, v):
@@ -401,6 +405,9 @@ ALLOWED_FIELDS = [
     "wiki_llm_curator_run_on_ingest",
     "wiki_llm_curator_run_on_query",
     "wiki_llm_curator_run_on_manual",
+    # KMS / Knowledge Management
+    "kms_enabled",
+    "kms_compile_on_ingest",
 ]
 
 
@@ -545,6 +552,10 @@ class SettingsResponse(BaseModel):
     wiki_llm_curator_run_on_query: bool = False
     wiki_llm_curator_run_on_manual: bool = True
 
+    # KMS / Knowledge Management config
+    kms_enabled: bool = True
+    kms_compile_on_ingest: bool = True
+
     # Limits (safe to expose)
     max_file_size_mb: int
     allowed_extensions: list[str]
@@ -637,6 +648,9 @@ def _build_settings_dict() -> dict:
         "wiki_llm_curator_run_on_ingest": settings.wiki_llm_curator_run_on_ingest,
         "wiki_llm_curator_run_on_query": settings.wiki_llm_curator_run_on_query,
         "wiki_llm_curator_run_on_manual": settings.wiki_llm_curator_run_on_manual,
+        # KMS / Knowledge Management
+        "kms_enabled": settings.kms_enabled,
+        "kms_compile_on_ingest": settings.kms_compile_on_ingest,
     }
     # NOTE: callers MUST set base["effective_sources"] explicitly with a
     # real DB connection. _compute_effective_sources(None) would silently

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -362,6 +362,12 @@ class Settings(BaseSettings):
     wiki_llm_curator_run_on_manual: bool = True
     """Run the curator in manual / recompile jobs when curator is enabled."""
 
+    # ── KMS / Knowledge Management configuration ─────────────────────────
+    kms_enabled: bool = True
+    """Master switch for the KMS (user-curated knowledge management) subsystem."""
+    kms_compile_on_ingest: bool = True
+    """Create/refresh a KMS document entry when a document finishes indexing."""
+
     # ── Retrieval profile configuration ──────────────────────────────────
     retrieval_profile: str = "advanced"
     """Retrieval profile: 'baseline' (dense + hybrid + rerank), 'advanced' (adds enrichment)."""
@@ -434,6 +440,7 @@ class Settings(BaseSettings):
         ".md",
         ".pdf",
         ".docx",
+        ".pptx",
         ".csv",
         ".xls",
         ".xlsx",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -484,6 +484,7 @@ class Settings(BaseSettings):
         "text/x-log",
         "application/vnd.ms-excel",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     }
 
     # CORS settings

--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -16,6 +16,7 @@ from app.services.background_tasks import get_background_processor
 from app.services.email_service import EmailIngestionService
 from app.services.embeddings import EmbeddingService
 from app.services.file_watcher import FileWatcher
+from app.services.kms_compile_processor import KMSCompileProcessor
 from app.services.llm_client import (
     LLMClient,
     create_instant_client,
@@ -155,6 +156,8 @@ def _load_persisted_settings(sqlite_path: str) -> None:
             "instant_memory_context_top_k",
             "instant_max_tokens",
             "vector_top_k",
+            "kms_enabled",
+            "kms_compile_on_ingest",
         ]
         for key in NEW_DIRECT_KEYS:
             if key in persisted:
@@ -477,6 +480,18 @@ async def lifespan(app: FastAPI):
         logger.warning("WikiCompileProcessor start failed (continuing): %s", e)
         app.state.wiki_compile_processor = None
 
+    # Start KMSCompileProcessor (background KMS job worker)
+    try:
+        app.state.kms_compile_processor = KMSCompileProcessor(pool=app.state.db_pool)
+        await _safe_await(
+            app.state.kms_compile_processor.start(),
+            "KMSCompileProcessor start",
+            timeout=10,
+        )
+    except Exception as e:
+        logger.warning("KMSCompileProcessor start failed (continuing): %s", e)
+        app.state.kms_compile_processor = None
+
     # Initialize RAGEngine singleton with cached services
     app.state.rag_engine = RAGEngine(
         embedding_service=app.state.embedding_service,
@@ -538,6 +553,8 @@ async def lifespan(app: FastAPI):
         await app.state.background_processor.stop()
     if getattr(app.state, "wiki_compile_processor", None):
         await app.state.wiki_compile_processor.stop()
+    if getattr(app.state, "kms_compile_processor", None):
+        await app.state.kms_compile_processor.stop()
     # Close both underlying LLM clients. The ``llm_client`` attr is an
     # alias of ``thinking_llm_client`` so closing it separately is
     # unnecessary; ``LLMClient.close()`` is also idempotent.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.api.routes.email import router as email_router
 from app.api.routes.eval import router as eval_router
 from app.api.routes.groups import router as groups_router
 from app.api.routes.health import router as health_router
+from app.api.routes.kms import router as kms_router
 from app.api.routes.memories import router as memories_router
 from app.api.routes.organizations import router as organizations_router
 from app.api.routes.search import router as search_router
@@ -121,6 +122,7 @@ app.include_router(vault_group_access_router, prefix="/api")
 app.include_router(organizations_router, prefix="/api")
 app.include_router(groups_router, prefix="/api")
 app.include_router(wiki_router, prefix="/api")
+app.include_router(kms_router, prefix="/api")
 
 # Register exception handler for validation errors (empty filename)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -525,6 +525,69 @@ CREATE INDEX IF NOT EXISTS idx_wiki_claims_vault_page_status ON wiki_claims(vaul
 CREATE INDEX IF NOT EXISTS idx_wiki_claim_sources_claim_id ON wiki_claim_sources(claim_id);
 CREATE INDEX IF NOT EXISTS idx_wiki_compile_jobs_vault_status ON wiki_compile_jobs(vault_id, status);
 CREATE INDEX IF NOT EXISTS idx_wiki_lint_findings_vault_status_severity ON wiki_lint_findings(vault_id, status, severity);
+
+-- ============================================================
+-- KMS / Knowledge Management tables (user-curated documentation)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS kms_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    vault_id INTEGER NOT NULL,
+    file_id INTEGER REFERENCES files(id) ON DELETE SET NULL,
+    slug TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    summary TEXT DEFAULT '',
+    tags_json TEXT DEFAULT '[]',
+    source_type TEXT NOT NULL DEFAULT 'manual' CHECK (source_type IN (
+        'manual','document','import')),
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN (
+        'draft','published','archived')),
+    created_by INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_compiled_at TIMESTAMP,
+    UNIQUE(vault_id, slug)
+);
+
+CREATE TABLE IF NOT EXISTS kms_compile_jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    vault_id INTEGER NOT NULL,
+    trigger_type TEXT NOT NULL CHECK (trigger_type IN (
+        'ingest','manual','settings_reindex')),
+    trigger_id TEXT,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+        'pending','running','completed','failed','cancelled')),
+    error TEXT,
+    result_json TEXT DEFAULT '{}',
+    input_json TEXT DEFAULT '{}',
+    retry_count INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP
+);
+
+-- FTS index over KMS entry content (title + summary + body + tags)
+CREATE VIRTUAL TABLE IF NOT EXISTS kms_entries_fts USING fts5(
+    title, summary, body, tags_json,
+    content='kms_entries', content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS kms_entries_fts_insert AFTER INSERT ON kms_entries BEGIN
+    INSERT INTO kms_entries_fts(rowid, title, summary, body, tags_json) VALUES (new.id, new.title, new.summary, new.body, new.tags_json);
+END;
+CREATE TRIGGER IF NOT EXISTS kms_entries_fts_delete AFTER DELETE ON kms_entries BEGIN
+    INSERT INTO kms_entries_fts(kms_entries_fts, rowid, title, summary, body, tags_json) VALUES ('delete', old.id, old.title, old.summary, old.body, old.tags_json);
+END;
+CREATE TRIGGER IF NOT EXISTS kms_entries_fts_update AFTER UPDATE ON kms_entries BEGIN
+    INSERT INTO kms_entries_fts(kms_entries_fts, rowid, title, summary, body, tags_json) VALUES ('delete', old.id, old.title, old.summary, old.body, old.tags_json);
+    INSERT INTO kms_entries_fts(rowid, title, summary, body, tags_json) VALUES (new.id, new.title, new.summary, new.body, new.tags_json);
+END;
+
+CREATE INDEX IF NOT EXISTS idx_kms_entries_vault_status ON kms_entries(vault_id, status);
+CREATE INDEX IF NOT EXISTS idx_kms_entries_vault_slug ON kms_entries(vault_id, slug);
+CREATE INDEX IF NOT EXISTS idx_kms_entries_file_id ON kms_entries(file_id);
+CREATE INDEX IF NOT EXISTS idx_kms_compile_jobs_vault_status ON kms_compile_jobs(vault_id, status);
 """
 
 
@@ -657,6 +720,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_tables(sqlite_path)
     migrate_add_wiki_refs_and_job_input(sqlite_path)
     migrate_add_wiki_jobs_retry_count(sqlite_path)
+    migrate_add_kms_tables(sqlite_path)
     migrate_add_files_parsed_text(sqlite_path)
     migrate_add_files_processing_progress(sqlite_path)
     migrate_add_files_enrichment_status(sqlite_path)
@@ -1365,6 +1429,83 @@ def migrate_add_wiki_jobs_retry_count(sqlite_path: str) -> None:
             conn.execute(
                 "ALTER TABLE wiki_compile_jobs ADD COLUMN retry_count INTEGER DEFAULT 0"
             )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_kms_tables(sqlite_path: str) -> None:
+    """
+    Migration: Add KMS / Knowledge Management tables for existing databases.
+
+    Idempotent — safe to run multiple times. All tables, FTS virtual tables,
+    triggers, and indexes use IF NOT EXISTS guards.
+
+    Args:
+        sqlite_path: Path to the SQLite database file.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS kms_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL,
+                file_id INTEGER REFERENCES files(id) ON DELETE SET NULL,
+                slug TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL DEFAULT '',
+                summary TEXT DEFAULT '',
+                tags_json TEXT DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'manual' CHECK (source_type IN (
+                    'manual','document','import')),
+                status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN (
+                    'draft','published','archived')),
+                created_by INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_compiled_at TIMESTAMP,
+                UNIQUE(vault_id, slug)
+            );
+
+            CREATE TABLE IF NOT EXISTS kms_compile_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL,
+                trigger_type TEXT NOT NULL CHECK (trigger_type IN (
+                    'ingest','manual','settings_reindex')),
+                trigger_id TEXT,
+                status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+                    'pending','running','completed','failed','cancelled')),
+                error TEXT,
+                result_json TEXT DEFAULT '{}',
+                input_json TEXT DEFAULT '{}',
+                retry_count INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                started_at TIMESTAMP,
+                completed_at TIMESTAMP
+            );
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS kms_entries_fts USING fts5(
+                title, summary, body, tags_json,
+                content='kms_entries', content_rowid='id'
+            );
+
+            CREATE TRIGGER IF NOT EXISTS kms_entries_fts_insert AFTER INSERT ON kms_entries BEGIN
+                INSERT INTO kms_entries_fts(rowid, title, summary, body, tags_json) VALUES (new.id, new.title, new.summary, new.body, new.tags_json);
+            END;
+            CREATE TRIGGER IF NOT EXISTS kms_entries_fts_delete AFTER DELETE ON kms_entries BEGIN
+                INSERT INTO kms_entries_fts(kms_entries_fts, rowid, title, summary, body, tags_json) VALUES ('delete', old.id, old.title, old.summary, old.body, old.tags_json);
+            END;
+            CREATE TRIGGER IF NOT EXISTS kms_entries_fts_update AFTER UPDATE ON kms_entries BEGIN
+                INSERT INTO kms_entries_fts(kms_entries_fts, rowid, title, summary, body, tags_json) VALUES ('delete', old.id, old.title, old.summary, old.body, old.tags_json);
+                INSERT INTO kms_entries_fts(rowid, title, summary, body, tags_json) VALUES (new.id, new.title, new.summary, new.body, new.tags_json);
+            END;
+
+            CREATE INDEX IF NOT EXISTS idx_kms_entries_vault_status ON kms_entries(vault_id, status);
+            CREATE INDEX IF NOT EXISTS idx_kms_entries_vault_slug ON kms_entries(vault_id, slug);
+            CREATE INDEX IF NOT EXISTS idx_kms_entries_file_id ON kms_entries(file_id);
+            CREATE INDEX IF NOT EXISTS idx_kms_compile_jobs_vault_status ON kms_compile_jobs(vault_id, status);
+        """)
         conn.commit()
     finally:
         conn.close()

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -1890,6 +1890,32 @@ class DocumentProcessor:
             # If wiki enqueue failed, don't leave wiki_pending=1 hanging.
             set_wiki_pending(self.pool, file_id, False)
 
+        # Enqueue a KMS compile job so the document becomes a user-curatable,
+        # full-text-searchable KMS entry. Independent of the wiki pipeline and
+        # gated by the kms_enabled / kms_compile_on_ingest flags.
+        try:
+            from app.config import settings as _settings
+
+            if _settings.kms_enabled and _settings.kms_compile_on_ingest:
+                from app.services.kms_store import KMSStore as _KMSStore
+
+                if self._write_semaphore:
+                    await self._write_semaphore.acquire()
+                conn = self.pool.get_connection()
+                try:
+                    _KMSStore(conn).create_job(
+                        vault_id=vault_id,
+                        trigger_type="ingest",
+                        trigger_id=f"file:{file_id}",
+                        input_json={"file_id": file_id, "vault_id": vault_id},
+                    )
+                finally:
+                    self.pool.release_connection(conn)
+                    if self._write_semaphore:
+                        self._write_semaphore.release()
+        except Exception as _kms_exc:
+            logger.warning("Failed to enqueue KMS ingest job for file_id=%d: %s", file_id, _kms_exc)
+
         # Clear transient progress fields and pin phase=indexed so polls show
         # a clean "ready" snapshot rather than stale embedding counters.
         clear_progress(self.pool, file_id)

--- a/backend/app/services/kms_compile_processor.py
+++ b/backend/app/services/kms_compile_processor.py
@@ -1,0 +1,230 @@
+"""
+KMSCompileProcessor: asyncio background worker that drains kms_compile_jobs.
+
+Single worker per process. Polls every POLL_INTERVAL seconds.
+On startup, resets orphaned 'running' jobs back to 'pending' (crash recovery).
+All DB work runs in threads via asyncio.to_thread() since SQLite is sync.
+
+"Compiling" a KMS entry is deterministic: for an ingested document it creates
+(or refreshes) a user-curatable kms_entries row from the file's parsed_text so
+the document content becomes browsable and full-text searchable in the KMS
+without going through the RAG pipeline.
+"""
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from app.models.database import SQLiteConnectionPool
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = 5  # seconds between polls when queue is empty
+MAX_RETRIES = 3    # max automatic retries before a job is permanently failed
+SUMMARY_CHARS = 500  # leading characters of body used as the entry summary
+
+
+class KMSCompileProcessor:
+    """Background worker that processes kms_compile_jobs from the SQLite queue.
+
+    One worker per process. A connection is acquired per-job and released
+    before each sleep, so it never holds a connection across the idle period.
+    """
+
+    def __init__(self, pool: "SQLiteConnectionPool") -> None:
+        self._pool = pool
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        await asyncio.to_thread(self._reset_orphans)
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info("KMSCompileProcessor started")
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("KMSCompileProcessor stopped")
+
+    # ------------------------------------------------------------------
+    # Startup orphan recovery
+    # ------------------------------------------------------------------
+
+    def _reset_orphans(self) -> None:
+        from app.services.kms_store import KMSStore
+
+        with self._pool.connection() as conn:
+            n = KMSStore(conn).reset_running_jobs()
+        if n:
+            logger.warning("KMSCompileProcessor: reset %d orphaned running jobs to pending", n)
+
+    # ------------------------------------------------------------------
+    # Poll loop
+    # ------------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        while self._running:
+            try:
+                job = await asyncio.to_thread(self._claim_next_job)
+                if job is None:
+                    await asyncio.sleep(POLL_INTERVAL)
+                    continue
+
+                logger.info(
+                    "KMSCompileProcessor: claimed job id=%d type=%s vault=%d",
+                    job.id,
+                    job.trigger_type,
+                    job.vault_id,
+                )
+
+                try:
+                    result = await asyncio.to_thread(self._dispatch, job)
+                    await asyncio.to_thread(self._complete_job, job.id, result)
+                    logger.info("KMSCompileProcessor: completed job id=%d", job.id)
+                except Exception as exc:
+                    logger.exception(
+                        "KMSCompileProcessor: job id=%d failed: %s", job.id, exc
+                    )
+                    try:
+                        new_retry_count = await asyncio.to_thread(
+                            self._fail_job, job.id, str(exc)
+                        )
+                        if new_retry_count < MAX_RETRIES:
+                            backoff = 2.0 ** new_retry_count
+                            logger.info(
+                                "KMSCompileProcessor: job id=%d will auto-retry (%d/%d) in %.0fs",
+                                job.id, new_retry_count, MAX_RETRIES, backoff,
+                            )
+                            await asyncio.sleep(backoff)
+                            await asyncio.to_thread(self._reset_job_to_pending, job.id)
+                        else:
+                            logger.error(
+                                "KMSCompileProcessor: job id=%d permanently failed after %d retries",
+                                job.id, new_retry_count,
+                            )
+                    except Exception as e2:
+                        logger.error(
+                            "KMSCompileProcessor: could not mark job id=%d failed: %s", job.id, e2
+                        )
+
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.exception("KMSCompileProcessor: poll loop error: %s", exc)
+                await asyncio.sleep(POLL_INTERVAL)
+
+    # ------------------------------------------------------------------
+    # Synchronous helpers (run in thread)
+    # ------------------------------------------------------------------
+
+    def _claim_next_job(self):
+        from app.services.kms_store import KMSStore
+
+        with self._pool.connection() as conn:
+            return KMSStore(conn).claim_next_pending_job()
+
+    def _complete_job(self, job_id: int, result: dict) -> None:
+        from app.services.kms_store import KMSStore
+
+        with self._pool.connection() as conn:
+            KMSStore(conn).complete_job(job_id, result)
+
+    def _fail_job(self, job_id: int, error: str) -> int:
+        from app.services.kms_store import KMSStore
+
+        with self._pool.connection() as conn:
+            return KMSStore(conn).fail_job(job_id, error)
+
+    def _reset_job_to_pending(self, job_id: int) -> None:
+        from app.services.kms_store import KMSStore
+
+        with self._pool.connection() as conn:
+            KMSStore(conn).reset_job_to_pending(job_id)
+
+    def _dispatch(self, job) -> dict:
+        """Dispatch a job to the appropriate handler. Runs in a thread."""
+        from app.services.kms_store import KMSStore
+
+        input_json: dict = {}
+        if job.input_json:
+            try:
+                input_json = json.loads(job.input_json) if isinstance(job.input_json, str) else job.input_json
+            except (json.JSONDecodeError, TypeError):
+                input_json = {}
+
+        with self._pool.connection() as conn:
+            store = KMSStore(conn)
+
+            if job.trigger_type == "ingest":
+                file_id = input_json.get("file_id")
+                if not file_id:
+                    return {"skipped": True, "reason": "no file_id in input_json"}
+                return self._compile_file(conn, store, job.vault_id, int(file_id))
+
+            if job.trigger_type in ("manual", "settings_reindex"):
+                file_id = input_json.get("file_id")
+                if file_id:
+                    return self._compile_file(conn, store, job.vault_id, int(file_id))
+                return self._compile_vault(conn, store, job.vault_id)
+
+            logger.warning(
+                "KMSCompileProcessor: unknown trigger_type %r for job id=%d",
+                job.trigger_type, job.id,
+            )
+            return {"skipped": True, "reason": f"unknown trigger_type: {job.trigger_type}"}
+
+    # ------------------------------------------------------------------
+    # Compile handlers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compile_file(conn, store, vault_id: int, file_id: int) -> dict:
+        """Create/refresh the document-sourced KMS entry for one file."""
+        row = conn.execute(
+            "SELECT file_name, parsed_text FROM files WHERE id = ? AND vault_id = ?",
+            (file_id, vault_id),
+        ).fetchone()
+        if not row:
+            return {"skipped": True, "reason": f"file {file_id} not found in vault {vault_id}"}
+        d = dict(row)
+        body = d.get("parsed_text") or ""
+        if not body.strip():
+            return {"skipped": True, "reason": "no parsed_text to compile"}
+        summary = body[:SUMMARY_CHARS].strip()
+        entry = store.upsert_document_entry(
+            vault_id=vault_id,
+            file_id=file_id,
+            title=d.get("file_name") or f"Document {file_id}",
+            body=body,
+            summary=summary,
+        )
+        return {"entry_id": entry.id, "file_id": file_id, "skipped": False}
+
+    def _compile_vault(self, conn, store, vault_id: int) -> dict:
+        """Recompile document entries for every indexed file in the vault."""
+        rows = conn.execute(
+            "SELECT id FROM files WHERE vault_id = ? AND status = 'indexed'",
+            (vault_id,),
+        ).fetchall()
+        compiled = 0
+        skipped = 0
+        for r in rows:
+            res = self._compile_file(conn, store, vault_id, dict(r)["id"])
+            if res.get("skipped"):
+                skipped += 1
+            else:
+                compiled += 1
+        return {"compiled": compiled, "skipped": skipped, "total": len(rows)}
+
+
+__all__ = ["KMSCompileProcessor"]

--- a/backend/app/services/kms_store.py
+++ b/backend/app/services/kms_store.py
@@ -257,9 +257,14 @@ class KMSStore:
             return self.get_entry(entry_id)
         if "tags" in updates:
             updates["tags_json"] = json.dumps(updates.pop("tags") or [])
-        if "slug" in updates and updates["slug"]:
+        # A provided-but-blank slug must never be persisted: slug is NOT NULL and
+        # an empty value would collide on the next blank-slug update. Drop it so it
+        # is regenerated from the title (if also being updated) or left unchanged.
+        if "slug" in updates and not str(updates["slug"] or "").strip():
+            del updates["slug"]
+        if "slug" in updates:
             updates["slug"] = self._unique_slug(vault_id, updates["slug"], exclude_id=entry_id)
-        elif "title" in updates and "slug" not in updates:
+        elif "title" in updates:
             updates["slug"] = self._unique_slug(vault_id, updates["title"], exclude_id=entry_id)
         updates["updated_at"] = datetime.utcnow().isoformat()
         set_clause = ", ".join(f"{k} = ?" for k in updates)

--- a/backend/app/services/kms_store.py
+++ b/backend/app/services/kms_store.py
@@ -1,0 +1,489 @@
+"""
+KMSStore: CRUD + FTS search for user-curated Knowledge Management entries,
+plus the kms_compile_jobs queue.
+
+All operations are vault-scoped. Slug normalization is enforced on create and
+on title/slug updates; slug collisions within a vault are resolved by appending
+a numeric suffix. FTS search is backed by kms_entries_fts.
+
+The job methods mirror WikiStore's compile-job API so KMSCompileProcessor can
+follow the same poll / claim / complete / fail / retry lifecycle.
+"""
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+from app.services.wiki_store import normalize_slug
+
+# ---------------------------------------------------------------------------
+# DTO dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KMSEntry:
+    id: int
+    vault_id: int
+    file_id: Optional[int]
+    slug: str
+    title: str
+    body: str
+    summary: str
+    tags_json: str
+    source_type: str
+    status: str
+    created_by: Optional[int]
+    created_at: str
+    updated_at: str
+    last_compiled_at: Optional[str]
+
+    @property
+    def tags(self) -> list:
+        try:
+            return json.loads(self.tags_json)
+        except (json.JSONDecodeError, TypeError):
+            return []
+
+
+@dataclass
+class KMSCompileJob:
+    id: int
+    vault_id: int
+    trigger_type: str
+    trigger_id: Optional[str]
+    status: str
+    error: Optional[str]
+    result_json: str
+    created_at: str
+    started_at: Optional[str]
+    completed_at: Optional[str]
+    input_json: Optional[str] = None
+    retry_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Row -> DTO helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_entry(row: sqlite3.Row) -> KMSEntry:
+    d = dict(row)
+    return KMSEntry(
+        id=d["id"],
+        vault_id=d["vault_id"],
+        file_id=d.get("file_id"),
+        slug=d["slug"],
+        title=d["title"],
+        body=d["body"] or "",
+        summary=d["summary"] or "",
+        tags_json=d.get("tags_json") or "[]",
+        source_type=d["source_type"],
+        status=d["status"],
+        created_by=d.get("created_by"),
+        created_at=d["created_at"],
+        updated_at=d["updated_at"],
+        last_compiled_at=d.get("last_compiled_at"),
+    )
+
+
+def _to_job(row: sqlite3.Row) -> KMSCompileJob:
+    d = dict(row)
+    return KMSCompileJob(
+        id=d["id"],
+        vault_id=d["vault_id"],
+        trigger_type=d["trigger_type"],
+        trigger_id=d.get("trigger_id"),
+        status=d["status"],
+        error=d.get("error"),
+        result_json=d.get("result_json") or "{}",
+        created_at=d["created_at"],
+        started_at=d.get("started_at"),
+        completed_at=d.get("completed_at"),
+        input_json=d.get("input_json"),
+        retry_count=d.get("retry_count") or 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# KMSStore
+# ---------------------------------------------------------------------------
+
+
+class KMSStore:
+    """Vault-scoped CRUD and FTS search for kms_entries + kms_compile_jobs."""
+
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+        self._db.row_factory = sqlite3.Row
+
+    # -----------------------------------------------------------------------
+    # Slug helpers
+    # -----------------------------------------------------------------------
+
+    def _unique_slug(self, vault_id: int, base: str, exclude_id: Optional[int] = None) -> str:
+        """Return a vault-unique slug derived from ``base``.
+
+        Appends -2, -3, … on collision. ``exclude_id`` lets an update keep its
+        own slug without colliding with itself.
+        """
+        slug = normalize_slug(base) or "entry"
+        candidate = slug
+        n = 1
+        while True:
+            row = self._db.execute(
+                "SELECT id FROM kms_entries WHERE vault_id = ? AND slug = ?",
+                (vault_id, candidate),
+            ).fetchone()
+            if row is None or (exclude_id is not None and dict(row)["id"] == exclude_id):
+                return candidate
+            n += 1
+            candidate = f"{slug}-{n}"
+
+    # -----------------------------------------------------------------------
+    # Entries
+    # -----------------------------------------------------------------------
+
+    def create_entry(
+        self,
+        vault_id: int,
+        title: str,
+        body: str = "",
+        summary: str = "",
+        tags: Optional[list] = None,
+        slug: Optional[str] = None,
+        file_id: Optional[int] = None,
+        source_type: str = "manual",
+        status: str = "draft",
+        created_by: Optional[int] = None,
+    ) -> KMSEntry:
+        now = datetime.utcnow().isoformat()
+        slug = self._unique_slug(vault_id, slug or title)
+        tags_json = json.dumps(tags or [])
+        cur = self._db.execute(
+            """
+            INSERT INTO kms_entries
+                (vault_id, file_id, slug, title, body, summary, tags_json,
+                 source_type, status, created_by, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (vault_id, file_id, slug, title, body, summary, tags_json,
+             source_type, status, created_by, now, now),
+        )
+        self._db.commit()
+        return self.get_entry(cur.lastrowid)  # type: ignore[return-value]
+
+    def get_entry(self, entry_id: int) -> Optional[KMSEntry]:
+        row = self._db.execute(
+            "SELECT * FROM kms_entries WHERE id = ?", (entry_id,)
+        ).fetchone()
+        return _to_entry(row) if row else None
+
+    def get_entry_by_file(
+        self, vault_id: int, file_id: int, source_type: str = "document"
+    ) -> Optional[KMSEntry]:
+        """Return the document-sourced entry for a file, or None."""
+        row = self._db.execute(
+            "SELECT * FROM kms_entries WHERE vault_id = ? AND file_id = ? AND source_type = ? LIMIT 1",
+            (vault_id, file_id, source_type),
+        ).fetchone()
+        return _to_entry(row) if row else None
+
+    def list_entries(
+        self,
+        vault_id: int,
+        status: Optional[str] = None,
+        tag: Optional[str] = None,
+        search: Optional[str] = None,
+        page: int = 1,
+        per_page: int = 50,
+    ) -> list[KMSEntry]:
+        offset = (page - 1) * per_page
+        params: list[Any] = []
+        if search:
+            ids = self._fts_entry_ids(search)
+            if not ids:
+                return []
+            placeholders = ",".join("?" * len(ids))
+            sql = f"SELECT * FROM kms_entries WHERE id IN ({placeholders}) AND vault_id = ?"
+            params = [*ids, vault_id]
+        else:
+            sql = "SELECT * FROM kms_entries WHERE vault_id = ?"
+            params = [vault_id]
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+        if tag:
+            # Membership test via json_each avoids LIKE false-positives.
+            sql += " AND EXISTS (SELECT 1 FROM json_each(tags_json) WHERE value = ?)"
+            params.append(tag)
+        sql += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        params += [per_page, offset]
+        rows = self._db.execute(sql, params).fetchall()
+        return [_to_entry(r) for r in rows]
+
+    def count_entries(
+        self,
+        vault_id: int,
+        status: Optional[str] = None,
+        tag: Optional[str] = None,
+        search: Optional[str] = None,
+    ) -> int:
+        params: list[Any] = []
+        if search:
+            ids = self._fts_entry_ids(search)
+            if not ids:
+                return 0
+            placeholders = ",".join("?" * len(ids))
+            sql = f"SELECT COUNT(*) FROM kms_entries WHERE id IN ({placeholders}) AND vault_id = ?"
+            params = [*ids, vault_id]
+        else:
+            sql = "SELECT COUNT(*) FROM kms_entries WHERE vault_id = ?"
+            params = [vault_id]
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+        if tag:
+            sql += " AND EXISTS (SELECT 1 FROM json_each(tags_json) WHERE value = ?)"
+            params.append(tag)
+        return int(self._db.execute(sql, params).fetchone()[0])
+
+    def update_entry(self, entry_id: int, vault_id: int, **kwargs: Any) -> Optional[KMSEntry]:
+        allowed = {"title", "body", "summary", "tags", "slug", "status", "last_compiled_at"}
+        updates = {k: v for k, v in kwargs.items() if k in allowed}
+        if not updates:
+            return self.get_entry(entry_id)
+        if "tags" in updates:
+            updates["tags_json"] = json.dumps(updates.pop("tags") or [])
+        if "slug" in updates and updates["slug"]:
+            updates["slug"] = self._unique_slug(vault_id, updates["slug"], exclude_id=entry_id)
+        elif "title" in updates and "slug" not in updates:
+            updates["slug"] = self._unique_slug(vault_id, updates["title"], exclude_id=entry_id)
+        updates["updated_at"] = datetime.utcnow().isoformat()
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [entry_id, vault_id]
+        cur = self._db.execute(
+            f"UPDATE kms_entries SET {set_clause} WHERE id = ? AND vault_id = ?", values
+        )
+        if cur.rowcount == 0:
+            return None
+        self._db.commit()
+        return self.get_entry(entry_id)
+
+    def delete_entry(self, entry_id: int, vault_id: int) -> bool:
+        cur = self._db.execute(
+            "DELETE FROM kms_entries WHERE id = ? AND vault_id = ?", (entry_id, vault_id)
+        )
+        self._db.commit()
+        return cur.rowcount > 0
+
+    def upsert_document_entry(
+        self,
+        vault_id: int,
+        file_id: int,
+        title: str,
+        body: str,
+        summary: str = "",
+    ) -> KMSEntry:
+        """Create or update the document-sourced entry for a file (idempotent).
+
+        Used by the compile-on-ingest hook. Preserves a user-chosen status and
+        tags on re-compile; only refreshes title/body/summary and bumps
+        last_compiled_at.
+        """
+        now = datetime.utcnow().isoformat()
+        existing = self.get_entry_by_file(vault_id, file_id, source_type="document")
+        if existing:
+            self._db.execute(
+                """UPDATE kms_entries
+                   SET title = ?, body = ?, summary = ?, updated_at = ?, last_compiled_at = ?
+                   WHERE id = ?""",
+                (title, body, summary, now, now, existing.id),
+            )
+            self._db.commit()
+            return self.get_entry(existing.id)  # type: ignore[return-value]
+        slug = self._unique_slug(vault_id, title)
+        cur = self._db.execute(
+            """INSERT INTO kms_entries
+               (vault_id, file_id, slug, title, body, summary, tags_json,
+                source_type, status, created_by, created_at, updated_at, last_compiled_at)
+               VALUES (?, ?, ?, ?, ?, ?, '[]', 'document', 'draft', NULL, ?, ?, ?)""",
+            (vault_id, file_id, slug, title, body, summary, now, now, now),
+        )
+        self._db.commit()
+        return self.get_entry(cur.lastrowid)  # type: ignore[return-value]
+
+    def _fts_entry_ids(self, query: str) -> list[int]:
+        try:
+            rows = self._db.execute(
+                "SELECT rowid FROM kms_entries_fts WHERE kms_entries_fts MATCH ? ORDER BY rank",
+                (query,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # Malformed FTS5 query (unbalanced quotes etc.) — treat as no match.
+            return []
+        return [r[0] for r in rows]
+
+    # -----------------------------------------------------------------------
+    # Compile Jobs (mirror WikiStore lifecycle)
+    # -----------------------------------------------------------------------
+
+    def create_job(
+        self,
+        vault_id: int,
+        trigger_type: str,
+        trigger_id: Optional[str] = None,
+        input_json: Optional[Any] = None,
+    ) -> KMSCompileJob:
+        now = datetime.utcnow().isoformat()
+        if isinstance(input_json, dict):
+            input_json = json.dumps(input_json)
+        cur = self._db.execute(
+            """INSERT INTO kms_compile_jobs (vault_id, trigger_type, trigger_id, status, input_json, created_at)
+               VALUES (?, ?, ?, 'pending', ?, ?)""",
+            (vault_id, trigger_type, trigger_id, input_json or "{}", now),
+        )
+        self._db.commit()
+        row = self._db.execute(
+            "SELECT * FROM kms_compile_jobs WHERE id = ?", (cur.lastrowid,)
+        ).fetchone()
+        return _to_job(row)
+
+    def list_jobs(self, vault_id: int, status: Optional[str] = None) -> list[KMSCompileJob]:
+        if status:
+            rows = self._db.execute(
+                "SELECT * FROM kms_compile_jobs WHERE vault_id = ? AND status = ? ORDER BY created_at DESC",
+                (vault_id, status),
+            ).fetchall()
+        else:
+            rows = self._db.execute(
+                "SELECT * FROM kms_compile_jobs WHERE vault_id = ? ORDER BY created_at DESC",
+                (vault_id,),
+            ).fetchall()
+        return [_to_job(r) for r in rows]
+
+    def get_job(self, job_id: int, vault_id: int) -> Optional[KMSCompileJob]:
+        row = self._db.execute(
+            "SELECT * FROM kms_compile_jobs WHERE id = ? AND vault_id = ?",
+            (job_id, vault_id),
+        ).fetchone()
+        return _to_job(row) if row else None
+
+    def claim_next_pending_job(self) -> Optional[KMSCompileJob]:
+        """Atomically claim the oldest pending job. Returns it or None.
+
+        Uses BEGIN IMMEDIATE so concurrent workers cannot claim the same row.
+        """
+        now = datetime.utcnow().isoformat()
+        try:
+            self._db.execute("BEGIN IMMEDIATE")
+            row = self._db.execute(
+                "SELECT * FROM kms_compile_jobs WHERE status = 'pending' ORDER BY created_at ASC LIMIT 1"
+            ).fetchone()
+            if not row:
+                self._db.rollback()
+                return None
+            job_id = dict(row)["id"]
+            self._db.execute(
+                "UPDATE kms_compile_jobs SET status = 'running', started_at = ? WHERE id = ?",
+                (now, job_id),
+            )
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
+        row = self._db.execute(
+            "SELECT * FROM kms_compile_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+        return _to_job(row) if row else None
+
+    def complete_job(self, job_id: int, result_json: Any) -> None:
+        """Mark job completed. No-op if the job was already cancelled."""
+        row = self._db.execute(
+            "SELECT status FROM kms_compile_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+        if row and dict(row)["status"] == "cancelled":
+            return
+        now = datetime.utcnow().isoformat()
+        if isinstance(result_json, dict):
+            result_json = json.dumps(result_json)
+        self._db.execute(
+            "UPDATE kms_compile_jobs SET status = 'completed', completed_at = ?, result_json = ? WHERE id = ?",
+            (now, result_json or "{}", job_id),
+        )
+        self._db.commit()
+
+    def fail_job(self, job_id: int, error: str) -> int:
+        """Mark job failed, increment retry_count. Returns new retry_count.
+
+        No-op if the job is already cancelled.
+        """
+        now = datetime.utcnow().isoformat()
+        self._db.execute(
+            """UPDATE kms_compile_jobs
+               SET status = 'failed', completed_at = ?, error = ?, retry_count = retry_count + 1
+               WHERE id = ? AND status != 'cancelled'""",
+            (now, error[:2000], job_id),
+        )
+        self._db.commit()
+        row = self._db.execute(
+            "SELECT retry_count FROM kms_compile_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+        return dict(row)["retry_count"] if row else 0
+
+    def reset_job_to_pending(self, job_id: int) -> None:
+        """Reset a failed job back to pending for auto-retry by the processor."""
+        self._db.execute(
+            "UPDATE kms_compile_jobs SET status = 'pending', started_at = NULL, completed_at = NULL WHERE id = ?",
+            (job_id,),
+        )
+        self._db.commit()
+
+    def cancel_job(self, job_id: int, vault_id: int) -> bool:
+        """Cancel a pending or running job. Returns True if cancelled."""
+        row = self._db.execute(
+            "SELECT status FROM kms_compile_jobs WHERE id = ? AND vault_id = ?",
+            (job_id, vault_id),
+        ).fetchone()
+        if not row or dict(row)["status"] not in ("pending", "running"):
+            return False
+        self._db.execute(
+            "UPDATE kms_compile_jobs SET status = 'cancelled', completed_at = ? WHERE id = ?",
+            (datetime.utcnow().isoformat(), job_id),
+        )
+        self._db.commit()
+        return True
+
+    def retry_job(self, job_id: int, vault_id: int) -> Optional[KMSCompileJob]:
+        """Reset a failed job to pending. Returns the updated job or None."""
+        row = self._db.execute(
+            "SELECT status FROM kms_compile_jobs WHERE id = ? AND vault_id = ?",
+            (job_id, vault_id),
+        ).fetchone()
+        if not row or dict(row)["status"] != "failed":
+            return None
+        self._db.execute(
+            "UPDATE kms_compile_jobs SET status = 'pending', error = NULL, started_at = NULL, completed_at = NULL WHERE id = ?",
+            (job_id,),
+        )
+        self._db.commit()
+        row = self._db.execute(
+            "SELECT * FROM kms_compile_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+        return _to_job(row) if row else None
+
+    def reset_running_jobs(self) -> int:
+        """Reset jobs stuck in 'running' to 'pending' on processor startup.
+
+        Returns the number of jobs reset (orphans from a previous crash).
+        """
+        cur = self._db.execute(
+            "UPDATE kms_compile_jobs SET status = 'pending', started_at = NULL WHERE status = 'running'"
+        )
+        self._db.commit()
+        return cur.rowcount
+
+
+__all__ = ["KMSEntry", "KMSCompileJob", "KMSStore"]

--- a/backend/tests/test_documents_auth.py
+++ b/backend/tests/test_documents_auth.py
@@ -817,5 +817,69 @@ class TestReadAccess(TestDocumentAuthBase):
         self.assertEqual(filenames, ["operator-report.pdf"])
 
 
+class TestDeleteAuditLogging(TestDocumentAuthBase):
+    """Bulk and vault-wide deletes must each write a per-file HMAC audit row."""
+
+    def _install_secret_manager(self):
+        sm = MagicMock()
+        sm.get_hmac_key.return_value = (b"test-hmac-key", "v1")
+        app.state.secret_manager = sm
+        return sm
+
+    def _seed_files(self, ids):
+        conn = self._connection_pool.get_connection()
+        try:
+            # Clean slate for vault 2 so vault-wide delete counts are deterministic
+            # (the base setUp seeds an unrelated file in vault 2).
+            conn.execute("DELETE FROM files WHERE vault_id = 2")
+            for fid in ids:
+                conn.execute(
+                    "INSERT OR REPLACE INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id) "
+                    "VALUES (?, ?, ?, ?, 'indexed', 0, 2)",
+                    (fid, f"doc{fid}.txt", f"/uploads/doc{fid}.txt", 10),
+                )
+            conn.execute("DELETE FROM document_actions")
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def _audit_count(self, action="delete"):
+        conn = self._connection_pool.get_connection()
+        try:
+            return conn.execute(
+                "SELECT COUNT(*) FROM document_actions WHERE action = ?", (action,)
+            ).fetchone()[0]
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def tearDown(self):
+        if hasattr(app.state, "secret_manager"):
+            delattr(app.state, "secret_manager")
+        super().tearDown()
+
+    def test_batch_delete_writes_audit_row_per_file(self):
+        self._install_secret_manager()
+        self._seed_files([101, 102])
+        resp = self.client.post(
+            "/api/documents/batch",
+            headers=self._auth_headers(self._superadmin_token()),
+            json={"file_ids": ["101", "102"]},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(resp.json()["deleted_count"], 2)
+        self.assertEqual(self._audit_count("delete"), 2)
+
+    def test_vault_all_delete_writes_audit_row_per_file(self):
+        self._install_secret_manager()
+        self._seed_files([201, 202, 203])
+        resp = self.client.delete(
+            "/api/documents/vault/2/all",
+            headers=self._auth_headers(self._superadmin_token()),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(resp.json()["deleted_count"], 3)
+        self.assertEqual(self._audit_count("delete"), 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_kms_routes.py
+++ b/backend/tests/test_kms_routes.py
@@ -39,6 +39,7 @@ from fastapi.testclient import TestClient
 from app.api.deps import get_db
 from app.config import settings
 from app.main import app
+from app.security import csrf_protect
 from app.services.auth_service import create_access_token
 from app.services.kms_store import KMSStore
 
@@ -117,6 +118,8 @@ class KMSTestBase(unittest.TestCase):
                 self._connection_pool.release_connection(conn)
 
         app.dependency_overrides[get_db] = override_get_db
+        # CSRF is exercised separately; bypass it for the JWT-based route tests.
+        app.dependency_overrides[csrf_protect] = lambda: "test-csrf"
 
         conn = self._connection_pool.get_connection()
         try:
@@ -168,6 +171,7 @@ class KMSTestBase(unittest.TestCase):
         settings.users_enabled = self._original_users_enabled
         settings.data_dir = self._original_data_dir
         app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(csrf_protect, None)
         if hasattr(self, "_connection_pool"):
             self._connection_pool.close_all()
         shutil.rmtree(self._temp_dir, ignore_errors=True)
@@ -321,6 +325,30 @@ class TestKMSCrud(KMSTestBase):
             self.client.get(f"/api/kms/entries/{eid}", headers=h).status_code, 404
         )
 
+    def test_blank_slug_update_does_not_persist_empty_slug(self):
+        h = self._write_headers()
+        created = self.client.post(
+            "/api/kms/entries",
+            json={"vault_id": 2, "title": "Slug Test"},
+            headers=h,
+        ).json()
+        eid = created["id"]
+        self.assertEqual(created["slug"], "slug-test")
+
+        # Blank slug alone must not overwrite with an empty string.
+        r1 = self.client.put(
+            f"/api/kms/entries/{eid}", json={"slug": ""}, headers=h
+        )
+        self.assertEqual(r1.status_code, 200)
+        self.assertTrue(r1.json()["slug"], "slug must not be empty after blank update")
+
+        # Blank slug + new title regenerates the slug from the title.
+        r2 = self.client.put(
+            f"/api/kms/entries/{eid}", json={"slug": "", "title": "Renamed Thing"}, headers=h
+        )
+        self.assertEqual(r2.status_code, 200)
+        self.assertEqual(r2.json()["slug"], "renamed-thing")
+
     def test_invalid_status_rejected(self):
         r = self.client.post(
             "/api/kms/entries",
@@ -417,6 +445,105 @@ class TestKMSStoreUnit(KMSTestBase):
             self.assertEqual(store.reset_running_jobs(), 0)
         finally:
             self._connection_pool.release_connection(conn)
+
+
+class TestKMSMasterSwitch(KMSTestBase):
+    """kms_enabled=False must disable the whole subsystem, not just auto-ingest."""
+
+    def test_disabled_blocks_read_and_write(self):
+        original = settings.kms_enabled
+        settings.kms_enabled = False
+        try:
+            h = self._write_headers()
+            r_list = self.client.get("/api/kms/entries?vault_id=2", headers=h)
+            self.assertEqual(r_list.status_code, 403)
+            self.assertIn("disabled", r_list.text.lower())
+
+            r_create = self.client.post(
+                "/api/kms/entries",
+                json={"vault_id": 2, "title": "X"},
+                headers=h,
+            )
+            self.assertEqual(r_create.status_code, 403)
+
+            r_compile = self.client.post(
+                "/api/kms/documents/1/compile?vault_id=2", headers=h
+            )
+            self.assertEqual(r_compile.status_code, 403)
+        finally:
+            settings.kms_enabled = original
+
+    def test_enabled_allows_access(self):
+        # Sanity: with the default flag, the same list call works.
+        original = settings.kms_enabled
+        settings.kms_enabled = True
+        try:
+            r = self.client.get(
+                "/api/kms/entries?vault_id=2", headers=self._write_headers()
+            )
+            self.assertEqual(r.status_code, 200)
+        finally:
+            settings.kms_enabled = original
+
+
+class TestKMSCsrf(KMSTestBase):
+    """Mutating KMS routes must enforce CSRF (cookie-auth deployments)."""
+
+    def test_create_without_csrf_rejected(self):
+        from app.security import CSRFManager
+
+        # Remove the test bypass and install a real (in-memory) CSRF manager so
+        # csrf_protect runs its actual check rather than the lambda override.
+        app.dependency_overrides.pop(csrf_protect, None)
+        app.state.csrf_manager = CSRFManager(settings.redis_url)
+        try:
+            r = self.client.post(
+                "/api/kms/entries",
+                json={"vault_id": 2, "title": "NoCsrf"},
+                headers=self._write_headers(),  # valid JWT, but no CSRF cookie/header
+            )
+            self.assertEqual(r.status_code, 403)
+            self.assertIn("csrf", r.text.lower())
+        finally:
+            app.dependency_overrides[csrf_protect] = lambda: "test-csrf"
+            if hasattr(app.state, "csrf_manager"):
+                delattr(app.state, "csrf_manager")
+
+
+class TestKMSProcessorE2E(KMSTestBase):
+    """End-to-end: a queued ingest job is compiled into a document entry."""
+
+    def test_compile_job_produces_searchable_entry(self):
+        from app.models.database import get_pool
+        from app.services.kms_compile_processor import KMSCompileProcessor
+
+        pool = get_pool(self._db_path)
+        with pool.connection() as c:
+            cur = c.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_size, status, parsed_text) "
+                "VALUES (2,'/uploads/e2e.txt','e2e.txt',32,'indexed','unique_needle_term in the document body')"
+            )
+            file_id = cur.lastrowid
+            c.commit()
+            KMSStore(c).create_job(
+                2, "ingest", f"file:{file_id}", {"file_id": file_id, "vault_id": 2}
+            )
+
+        proc = KMSCompileProcessor(pool)
+        claimed = proc._claim_next_job()
+        self.assertIsNotNone(claimed)
+        result = proc._dispatch(claimed)
+        proc._complete_job(claimed.id, result)
+
+        self.assertFalse(result.get("skipped"))
+        with pool.connection() as c:
+            store = KMSStore(c)
+            entry = store.get_entry_by_file(2, file_id)
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.source_type, "document")
+            self.assertIn("unique_needle_term", entry.body)
+            # Content is full-text searchable.
+            self.assertTrue(any(e.id == entry.id for e in store.list_entries(2, search="unique_needle_term")))
 
 
 class TestKMSSettingsReload(KMSTestBase):

--- a/backend/tests/test_kms_routes.py
+++ b/backend/tests/test_kms_routes.py
@@ -1,0 +1,456 @@
+"""Tests for KMS (Knowledge Management) routes + KMSStore.
+
+Covers:
+- Authentication: KMS endpoints return 401 when unauthenticated.
+- Authorization: vault read/write RBAC for list/get/search vs create/update/delete/compile.
+- Functional: full CRUD round-trip, content-level FTS search, cross-vault isolation,
+  document compile enqueues a job, and KMSStore-level compile/upsert/job lifecycle.
+"""
+
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from queue import Empty, Queue
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub optional heavy deps so importing app.main is cheap in CI.
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_db
+from app.config import settings
+from app.main import app
+from app.services.auth_service import create_access_token
+from app.services.kms_store import KMSStore
+
+
+class SimpleConnectionPool:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self._pool = Queue(maxsize=5)
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def get_connection(self):
+        if self._closed:
+            raise RuntimeError("Pool closed")
+        try:
+            return self._pool.get_nowait()
+        except Empty:
+            return self._create_connection()
+
+    def _create_connection(self):
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def release_connection(self, conn):
+        if not self._closed:
+            try:
+                self._pool.put_nowait(conn)
+            except Exception:
+                conn.close()
+
+    def close_all(self):
+        self._closed = True
+        while True:
+            try:
+                conn = self._pool.get_nowait()
+                conn.close()
+            except Empty:
+                break
+
+
+class KMSTestBase(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self._temp_dir = tempfile.mkdtemp()
+
+        self._original_jwt_secret = settings.jwt_secret_key
+        self._original_users_enabled = settings.users_enabled
+        self._original_data_dir = settings.data_dir
+
+        settings.data_dir = Path(self._temp_dir)
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+
+        self._db_path = str(Path(self._temp_dir) / "app.db")
+
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        with _pool_cache_lock:
+            for _path, pool in list(_pool_cache.items()):
+                pool.close_all()
+            _pool_cache.clear()
+
+        from app.models.database import init_db, run_migrations
+
+        init_db(self._db_path)
+        run_migrations(self._db_path)
+        self._connection_pool = SimpleConnectionPool(self._db_path)
+
+        def override_get_db():
+            conn = self._connection_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self._connection_pool.release_connection(conn)
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        conn = self._connection_pool.get_connection()
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            pw = "test-password-hash"
+            # superadmin (1), write-member (3) on vault 2, read-member (4) on vault 3,
+            # no-access member (5).
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, username, hashed_password, full_name, role, is_active) VALUES (1,'superadmin',?, 'Super','superadmin',1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, username, hashed_password, full_name, role, is_active) VALUES (3,'member1',?, 'Member One','member',1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, username, hashed_password, full_name, role, is_active) VALUES (4,'member_ro',?, 'Read Only','member',1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, username, hashed_password, full_name, role, is_active) VALUES (5,'member_novault',?, 'No Vault','member',1)",
+                (pw,),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (2,'Write Vault','w')"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (3,'Read Vault','r')"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (2,3,'write',1)"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (3,4,'read',1)"
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def tearDown(self):
+        from app.models.database import _pool_cache, _pool_cache_lock
+
+        with _pool_cache_lock:
+            for _path, pool in list(_pool_cache.items()):
+                pool.close_all()
+            _pool_cache.clear()
+
+        settings.jwt_secret_key = self._original_jwt_secret
+        settings.users_enabled = self._original_users_enabled
+        settings.data_dir = self._original_data_dir
+        app.dependency_overrides.pop(get_db, None)
+        if hasattr(self, "_connection_pool"):
+            self._connection_pool.close_all()
+        shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    def _headers(self, user_id, username, role):
+        return {"Authorization": f"Bearer {create_access_token(user_id, username, role)}"}
+
+    def _write_headers(self):
+        return self._headers(3, "member1", "member")
+
+    def _readonly_headers(self):
+        return self._headers(4, "member_ro", "member")
+
+    def _noaccess_headers(self):
+        return self._headers(5, "member_novault", "member")
+
+
+class TestKMSAuthentication(KMSTestBase):
+    def test_list_unauthenticated(self):
+        self.assertEqual(self.client.get("/api/kms/entries?vault_id=2").status_code, 401)
+
+    def test_create_unauthenticated(self):
+        r = self.client.post("/api/kms/entries", json={"vault_id": 2, "title": "X"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_get_unauthenticated(self):
+        self.assertEqual(self.client.get("/api/kms/entries/1").status_code, 401)
+
+    def test_update_unauthenticated(self):
+        self.assertEqual(
+            self.client.put("/api/kms/entries/1", json={"title": "Y"}).status_code, 401
+        )
+
+    def test_delete_unauthenticated(self):
+        self.assertEqual(self.client.delete("/api/kms/entries/1").status_code, 401)
+
+    def test_search_unauthenticated(self):
+        self.assertEqual(
+            self.client.get("/api/kms/search?vault_id=2&q=x").status_code, 401
+        )
+
+    def test_compile_unauthenticated(self):
+        self.assertEqual(
+            self.client.post("/api/kms/documents/1/compile?vault_id=2").status_code, 401
+        )
+
+
+class TestKMSAuthorization(KMSTestBase):
+    def test_no_access_member_cannot_list(self):
+        r = self.client.get("/api/kms/entries?vault_id=2", headers=self._noaccess_headers())
+        self.assertEqual(r.status_code, 403)
+
+    def test_no_access_member_cannot_create(self):
+        r = self.client.post(
+            "/api/kms/entries",
+            json={"vault_id": 2, "title": "X"},
+            headers=self._noaccess_headers(),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_readonly_member_can_list_but_not_create(self):
+        r_list = self.client.get(
+            "/api/kms/entries?vault_id=3", headers=self._readonly_headers()
+        )
+        self.assertEqual(r_list.status_code, 200)
+        r_create = self.client.post(
+            "/api/kms/entries",
+            json={"vault_id": 3, "title": "Nope"},
+            headers=self._readonly_headers(),
+        )
+        self.assertEqual(r_create.status_code, 403)
+
+    def test_cross_vault_get_forbidden(self):
+        # Create entry in vault 2 (write member), then read it as the vault-3-only member.
+        created = self.client.post(
+            "/api/kms/entries",
+            json={"vault_id": 2, "title": "Secret"},
+            headers=self._write_headers(),
+        ).json()
+        r = self.client.get(
+            f"/api/kms/entries/{created['id']}", headers=self._readonly_headers()
+        )
+        self.assertEqual(r.status_code, 403)
+
+
+class TestKMSCrud(KMSTestBase):
+    def test_full_crud_and_content_search(self):
+        h = self._write_headers()
+        # Create
+        create = self.client.post(
+            "/api/kms/entries",
+            json={
+                "vault_id": 2,
+                "title": "Runbook",
+                "body": "restart the widget service when the gauge turns red",
+                "tags": ["ops", "runbook"],
+            },
+            headers=h,
+        )
+        self.assertEqual(create.status_code, 201, create.text)
+        entry = create.json()
+        self.assertEqual(entry["slug"], "runbook")
+        self.assertEqual(entry["tags"], ["ops", "runbook"])
+        eid = entry["id"]
+
+        # Get
+        got = self.client.get(f"/api/kms/entries/{eid}", headers=h)
+        self.assertEqual(got.status_code, 200)
+        self.assertEqual(got.json()["title"], "Runbook")
+
+        # List
+        listed = self.client.get("/api/kms/entries?vault_id=2", headers=h).json()
+        self.assertEqual(listed["total"], 1)
+        self.assertEqual(len(listed["entries"]), 1)
+
+        # Content-level search hits the body (DD-C002 capability for KMS).
+        found = self.client.get(
+            "/api/kms/search?vault_id=2&q=widget", headers=h
+        ).json()
+        self.assertEqual(found["total"], 1)
+        self.assertEqual(found["entries"][0]["id"], eid)
+
+        # Tag filter
+        by_tag = self.client.get(
+            "/api/kms/entries?vault_id=2&tag=ops", headers=h
+        ).json()
+        self.assertEqual(by_tag["total"], 1)
+
+        # Update + status; FTS must re-sync.
+        upd = self.client.put(
+            f"/api/kms/entries/{eid}",
+            json={"title": "Runbook v2", "status": "published", "body": "press the lever"},
+            headers=h,
+        )
+        self.assertEqual(upd.status_code, 200)
+        self.assertEqual(upd.json()["status"], "published")
+        self.assertEqual(
+            self.client.get("/api/kms/search?vault_id=2&q=lever", headers=h).json()["total"],
+            1,
+        )
+        self.assertEqual(
+            self.client.get("/api/kms/search?vault_id=2&q=widget", headers=h).json()["total"],
+            0,
+        )
+
+        # Delete
+        self.assertEqual(
+            self.client.delete(f"/api/kms/entries/{eid}", headers=h).status_code, 204
+        )
+        self.assertEqual(
+            self.client.get(f"/api/kms/entries/{eid}", headers=h).status_code, 404
+        )
+
+    def test_invalid_status_rejected(self):
+        r = self.client.post(
+            "/api/kms/entries",
+            json={"vault_id": 2, "title": "X", "status": "bogus"},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(r.status_code, 422)
+
+
+class TestKMSCompile(KMSTestBase):
+    def _seed_file(self, vault_id=2, parsed_text="alpha beta gamma content"):
+        conn = self._connection_pool.get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_size, status, parsed_text) VALUES (?,?,?,?,?,?)",
+                (vault_id, "/uploads/seed.txt", "seed.txt", 24, "indexed", parsed_text),
+            )
+            conn.commit()
+            return cur.lastrowid
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def test_compile_unknown_file_404(self):
+        r = self.client.post(
+            "/api/kms/documents/99999/compile?vault_id=2", headers=self._write_headers()
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_compile_enqueues_job(self):
+        file_id = self._seed_file()
+        r = self.client.post(
+            f"/api/kms/documents/{file_id}/compile?vault_id=2",
+            headers=self._write_headers(),
+        )
+        self.assertEqual(r.status_code, 202, r.text)
+        body = r.json()
+        self.assertEqual(body["status"], "pending")
+        jobs = self.client.get(
+            "/api/kms/jobs?vault_id=2", headers=self._write_headers()
+        ).json()["jobs"]
+        self.assertTrue(any(j["id"] == body["job_id"] for j in jobs))
+
+    def test_compile_requires_write(self):
+        # Read-only member on vault 3 cannot compile.
+        file_id = self._seed_file(vault_id=3)
+        r = self.client.post(
+            f"/api/kms/documents/{file_id}/compile?vault_id=3",
+            headers=self._readonly_headers(),
+        )
+        self.assertEqual(r.status_code, 403)
+
+
+class TestKMSStoreUnit(KMSTestBase):
+    """KMSStore-level coverage (compile dispatch path + job lifecycle)."""
+
+    def _conn(self):
+        return self._connection_pool.get_connection()
+
+    def test_upsert_document_entry_idempotent_and_searchable(self):
+        conn = self._conn()
+        try:
+            store = KMSStore(conn)
+            e1 = store.upsert_document_entry(2, None, "Doc A", "needle in body", "sum")
+            # file_id None path still creates an entry; re-upsert by file requires file_id,
+            # so use a real file_id for idempotency check.
+            cur = conn.execute(
+                "INSERT INTO files (vault_id, file_path, file_name, file_size, status, parsed_text) VALUES (2,'/x/a.txt','a.txt',5,'indexed','needle body')"
+            )
+            fid = cur.lastrowid
+            conn.commit()
+            a = store.upsert_document_entry(2, fid, "a.txt", "needle body", "s")
+            b = store.upsert_document_entry(2, fid, "a.txt", "needle body v2", "s")
+            self.assertEqual(a.id, b.id)
+            self.assertTrue(b.body.endswith("v2"))
+            # FTS content search finds the needle.
+            res = store.list_entries(2, search="needle")
+            self.assertGreaterEqual(len(res), 1)
+            self.assertIn(e1.id, {r.id for r in res} | {e1.id})
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def test_job_lifecycle(self):
+        conn = self._conn()
+        try:
+            store = KMSStore(conn)
+            job = store.create_job(2, "ingest", "file:1", {"file_id": 1})
+            self.assertEqual(job.status, "pending")
+            claimed = store.claim_next_pending_job()
+            self.assertEqual(claimed.id, job.id)
+            self.assertEqual(claimed.status, "running")
+            store.complete_job(job.id, {"ok": True})
+            self.assertEqual(store.get_job(job.id, 2).status, "completed")
+            # reset_running_jobs only affects running rows.
+            self.assertEqual(store.reset_running_jobs(), 0)
+        finally:
+            self._connection_pool.release_connection(conn)
+
+
+class TestKMSSettingsReload(KMSTestBase):
+    """Persisted kms_* flags must take effect on restart (loaded into settings)."""
+
+    def test_persisted_kms_flag_reloads(self):
+        import json as _json
+
+        from app.lifespan import _load_persisted_settings
+
+        conn = self._connection_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO settings_kv (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                ("kms_enabled", _json.dumps(False)),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO settings_kv (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                ("kms_compile_on_ingest", _json.dumps(False)),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        original_enabled = settings.kms_enabled
+        original_ingest = settings.kms_compile_on_ingest
+        try:
+            _load_persisted_settings(self._db_path)
+            self.assertFalse(settings.kms_enabled)
+            self.assertFalse(settings.kms_compile_on_ingest)
+        finally:
+            settings.kms_enabled = original_enabled
+            settings.kms_compile_on_ingest = original_ingest
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,8 @@ const OrgsPage = lazy(() => import("@/pages/OrgsPage"));
 const ProfilePage = lazy(() => import("@/pages/ProfilePage"));
 const NotFoundPage = lazy(() => import("@/pages/NotFoundPage"));
 const WikiPage = lazy(() => import("@/pages/WikiPage"));
+const KMSPage = lazy(() => import("@/pages/KMSPage"));
+const KMSDetailPage = lazy(() => import("@/pages/KMSDetailPage"));
 
 function PageLoader() {
   return (
@@ -45,6 +47,7 @@ function MainAppShell({ children }: { children: React.ReactNode }) {
     if (pathname.startsWith("/documents")) return "documents";
     if (pathname.startsWith("/memory")) return "memory";
     if (pathname.startsWith("/wiki")) return "wiki";
+    if (pathname.startsWith("/kms")) return "kms";
     if (pathname.startsWith("/vaults")) return "vaults";
     if (pathname.startsWith("/settings")) return "settings";
     if (pathname.startsWith("/admin/groups")) return "groups";
@@ -72,6 +75,9 @@ function MainAppShell({ children }: { children: React.ReactNode }) {
         break;
       case "wiki":
         navigate("/wiki");
+        break;
+      case "kms":
+        navigate("/kms");
         break;
       case "vaults":
         navigate("/vaults");
@@ -238,6 +244,26 @@ function App() {
                   <ProtectedRoute>
                     <MainAppShell>
                       <WikiPage />
+                    </MainAppShell>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/kms"
+                element={
+                  <ProtectedRoute>
+                    <MainAppShell>
+                      <KMSPage />
+                    </MainAppShell>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/kms/:entryId"
+                element={
+                  <ProtectedRoute>
+                    <MainAppShell>
+                      <KMSDetailPage />
                     </MainAppShell>
                   </ProtectedRoute>
                 }

--- a/frontend/src/components/layout/NavigationRail.tsx
+++ b/frontend/src/components/layout/NavigationRail.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, FileText, Brain, Settings, Database, Users, UserCog, Building2, UserCircle, Sun, Moon, BookOpen, LogOut } from "lucide-react";
+import { MessageSquare, FileText, Brain, Settings, Database, Users, UserCog, Building2, UserCircle, Sun, Moon, BookOpen, Library, LogOut } from "lucide-react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { cn } from "@/lib/utils";
@@ -21,6 +21,7 @@ const navItems: NavConfigItem[] = [
   { id: "documents", label: "Documents", icon: FileText, to: "/documents" },
   { id: "memory", label: "Memory", icon: Brain, to: "/memory" },
   { id: "wiki", label: "Wiki", icon: BookOpen, to: "/wiki" },
+  { id: "kms", label: "KMS", icon: Library, to: "/kms" },
   { id: "vaults", label: "Vaults", icon: Database, to: "/vaults" },
   { id: "settings", label: "Settings", icon: Settings, to: "/settings" },
   { id: "groups", label: "Groups", icon: Users, to: "/admin/groups", adminOnly: true },

--- a/frontend/src/components/layout/navigationTypes.ts
+++ b/frontend/src/components/layout/navigationTypes.ts
@@ -1,7 +1,7 @@
 import type { HealthStatus } from "@/types/health";
 import type { ComponentType } from "react";
 
-export type NavItemId = "chat" | "chatNew" | "documents" | "memory" | "vaults" | "wiki" | "settings" | "groups" | "users" | "organizations" | "profile";
+export type NavItemId = "chat" | "chatNew" | "documents" | "memory" | "vaults" | "wiki" | "kms" | "settings" | "groups" | "users" | "organizations" | "profile";
 
 export interface NavItem {
   id: NavItemId;

--- a/frontend/src/components/shared/DocumentCard.tsx
+++ b/frontend/src/components/shared/DocumentCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Progress } from "@/components/ui/progress";
-import { Trash2, MoreVertical } from "lucide-react";
+import { Trash2, MoreVertical, Download } from "lucide-react";
 import { FileIcon } from "@/lib/fileIcon";
 import { StatusBadge } from "./StatusBadge";
 import { formatFileSize, formatDate } from "@/lib/formatters";
@@ -33,6 +33,8 @@ interface DocumentCardProps {
   };
   /** Callback when delete action is triggered */
   onDelete: (id: string) => void;
+  /** Callback when download action is triggered */
+  onDownload?: (id: string) => void;
   /** Loading state for delete action */
   isDeleting?: boolean;
   /** Whether delete actions should be available for this document */
@@ -55,6 +57,7 @@ interface DocumentCardProps {
 export function DocumentCard({
   document,
   onDelete,
+  onDownload,
   isDeleting = false,
   canDelete = true,
   isSelected = false,
@@ -135,7 +138,7 @@ export function DocumentCard({
           </div>
 
           {/* Actions dropdown (≥44×44px touch target) */}
-          {canDelete && (
+          {(canDelete || onDownload) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -149,15 +152,26 @@ export function DocumentCard({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem
-                  onClick={() => onDelete(document.id)}
-                  disabled={isDeleting}
-                  className="text-destructive focus:text-destructive"
-                  aria-label={`Delete ${document.filename}`}
-                >
-                  <Trash2 className="w-4 h-4 mr-2" />
-                  Delete
-                </DropdownMenuItem>
+                {onDownload && (
+                  <DropdownMenuItem
+                    onClick={() => onDownload(document.id)}
+                    aria-label={`Download ${document.filename}`}
+                  >
+                    <Download className="w-4 h-4 mr-2" />
+                    Download
+                  </DropdownMenuItem>
+                )}
+                {canDelete && (
+                  <DropdownMenuItem
+                    onClick={() => onDelete(document.id)}
+                    disabled={isDeleting}
+                    className="text-destructive focus:text-destructive"
+                    aria-label={`Delete ${document.filename}`}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Delete
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -373,6 +373,10 @@ export interface SettingsResponse {
   wiki_compile_after_indexing?: boolean;
   wiki_lint_enabled?: boolean;
 
+  // KMS / Knowledge Management config
+  kms_enabled?: boolean;
+  kms_compile_on_ingest?: boolean;
+
   // Optional LLM Wiki Curator config (PR B persists, PR C wires)
   wiki_llm_curator_enabled?: boolean;
   wiki_llm_curator_url?: string;
@@ -445,6 +449,9 @@ export interface UpdateSettingsRequest {
   wiki_compile_on_query?: boolean;
   wiki_compile_after_indexing?: boolean;
   wiki_lint_enabled?: boolean;
+  // KMS / Knowledge Management config
+  kms_enabled?: boolean;
+  kms_compile_on_ingest?: boolean;
   // Optional LLM Wiki Curator config
   wiki_llm_curator_enabled?: boolean;
   wiki_llm_curator_url?: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1882,4 +1882,161 @@ export async function resolveWikiLintFinding(
   return response.data;
 }
 
+// ---------------------------------------------------------------------------
+// KMS / Knowledge Management
+// ---------------------------------------------------------------------------
+
+export interface KMSEntry {
+  id: number;
+  vault_id: number;
+  file_id: number | null;
+  slug: string;
+  title: string;
+  body: string;
+  summary: string;
+  tags_json: string;
+  tags: string[];
+  source_type: "manual" | "document" | "import";
+  status: "draft" | "published" | "archived";
+  created_by: number | null;
+  created_at: string;
+  updated_at: string;
+  last_compiled_at: string | null;
+}
+
+export interface KMSEntryListResponse {
+  entries: KMSEntry[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+export interface KMSCompileJob {
+  id: number;
+  vault_id: number;
+  trigger_type: "ingest" | "manual" | "settings_reindex";
+  trigger_id: string | null;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  error: string | null;
+  result_json: string;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  input_json: string | null;
+  retry_count: number;
+}
+
+export async function listKMSEntries(params: {
+  vault_id: number;
+  status?: string;
+  tag?: string;
+  search?: string;
+  page?: number;
+  per_page?: number;
+}): Promise<KMSEntryListResponse> {
+  const response = await apiClient.get<KMSEntryListResponse>("/kms/entries", {
+    params,
+  });
+  return response.data;
+}
+
+export async function getKMSEntry(entryId: number): Promise<KMSEntry> {
+  const response = await apiClient.get<KMSEntry>(`/kms/entries/${entryId}`);
+  return response.data;
+}
+
+export async function createKMSEntry(data: {
+  vault_id: number;
+  title: string;
+  body?: string;
+  summary?: string;
+  tags?: string[];
+  slug?: string;
+  status?: string;
+}): Promise<KMSEntry> {
+  const response = await apiClient.post<KMSEntry>("/kms/entries", data);
+  return response.data;
+}
+
+export async function updateKMSEntry(
+  entryId: number,
+  data: {
+    title?: string;
+    body?: string;
+    summary?: string;
+    tags?: string[];
+    slug?: string;
+    status?: string;
+  }
+): Promise<KMSEntry> {
+  const response = await apiClient.put<KMSEntry>(`/kms/entries/${entryId}`, data);
+  return response.data;
+}
+
+export async function deleteKMSEntry(entryId: number): Promise<void> {
+  await apiClient.delete(`/kms/entries/${entryId}`);
+}
+
+export async function searchKMS(params: {
+  vault_id: number;
+  q: string;
+  page?: number;
+  per_page?: number;
+}): Promise<{ query: string } & KMSEntryListResponse> {
+  const response = await apiClient.get<{ query: string } & KMSEntryListResponse>(
+    "/kms/search",
+    { params }
+  );
+  return response.data;
+}
+
+export async function compileDocumentKMS(
+  fileId: number,
+  vaultId: number
+): Promise<{ job_id: number; status: string }> {
+  const response = await apiClient.post<{ job_id: number; status: string }>(
+    `/kms/documents/${fileId}/compile`,
+    null,
+    { params: { vault_id: vaultId } }
+  );
+  return response.data;
+}
+
+export async function recompileVaultKMS(
+  vaultId: number
+): Promise<{ job_id: number; status: string }> {
+  const response = await apiClient.post<{ job_id: number; status: string }>(
+    "/kms/recompile",
+    null,
+    { params: { vault_id: vaultId } }
+  );
+  return response.data;
+}
+
+export async function listKMSJobs(
+  vaultId: number,
+  status?: string
+): Promise<{ jobs: KMSCompileJob[] }> {
+  const response = await apiClient.get<{ jobs: KMSCompileJob[] }>("/kms/jobs", {
+    params: { vault_id: vaultId, status },
+  });
+  return response.data;
+}
+
+/** Trigger a browser download of a document's original bytes (DD-C009). */
+export async function downloadDocument(
+  fileId: string | number,
+  fileName: string
+): Promise<void> {
+  const blob = await getDocumentRawBlob(fileId);
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName || `document-${fileId}`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(url);
+}
+
 export default apiClient;

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -17,10 +17,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { FileText, Upload, Search, Trash2, ScanLine, AlertCircle, Loader2, X, RotateCcw, Trash, Info } from "lucide-react";
+import { FileText, Upload, Search, Trash2, ScanLine, AlertCircle, Loader2, X, RotateCcw, Trash, Info, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FileIcon } from "@/lib/fileIcon";
-import { listDocuments, scanDocuments, deleteDocument, deleteDocuments, deleteAllDocumentsInVault, getDocumentStats, getDocumentWikiStatus, compileDocumentWiki, type Document, type DocumentStatsResponse, type DocumentWikiStatus } from "@/lib/api";
+import { listDocuments, scanDocuments, deleteDocument, deleteDocuments, deleteAllDocumentsInVault, getDocumentStats, getDocumentWikiStatus, compileDocumentWiki, downloadDocument, type Document, type DocumentStatsResponse, type DocumentWikiStatus } from "@/lib/api";
 import { formatFileSize, formatDate } from "@/lib/formatters";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useVaultStore } from "@/stores/useVaultStore";
@@ -535,6 +535,14 @@ export default function DocumentsPage() {
       },
       variant: "destructive",
     });
+  };
+
+  const handleDownloadDocument = async (doc: Document) => {
+    try {
+      await downloadDocument(doc.id, doc.filename || `document-${doc.id}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to download document");
+    }
   };
 
   // Server already filters by search query — only apply the local optimistic-delete mask.
@@ -1123,7 +1131,7 @@ export default function DocumentsPage() {
                       <th scope="col" className="text-left p-4 font-medium flex-none w-[120px]">Wiki</th>
                       <th scope="col" className="text-left p-4 font-medium flex-none w-[100px]">Size</th>
                       <th scope="col" className="text-left p-4 font-medium flex-none w-[140px]">Uploaded</th>
-                      <th scope="col" className="text-right p-4 font-medium flex-none w-[60px]">Actions</th>
+                      <th scope="col" className="text-right p-4 font-medium flex-none w-[110px]">Actions</th>
                     </tr>
                   </thead>
                   <tbody role="rowgroup" style={{ height: `${tableVirtualizer.getTotalSize()}px`, position: 'relative' }}>
@@ -1232,7 +1240,16 @@ export default function DocumentsPage() {
                           </td>
                           <td className="p-4 flex-none w-[100px]">{formatFileSize(doc.size)}</td>
                           <td className="p-4 flex-none w-[140px] text-muted-foreground">{formatDate(doc.created_at)}</td>
-                          <td className="p-4 flex-none w-[60px] text-right">
+                          <td className="p-4 flex-none w-[110px] text-right">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="min-w-[44px] min-h-[44px]"
+                              onClick={() => handleDownloadDocument(doc)}
+                              aria-label="Download document"
+                            >
+                              <Download className="w-4 h-4" aria-hidden="true" />
+                            </Button>
                             {canMutateDocuments && (
                             <Button
                               variant="ghost"
@@ -1276,6 +1293,7 @@ export default function DocumentsPage() {
                      <DocumentCard
                        document={doc}
                        onDelete={(id) => handleDeleteDocument(String(id))}
+                       onDownload={() => handleDownloadDocument(doc)}
                        canDelete={canMutateDocuments}
                        isSelected={selectedIds.has(doc.id)}
                        onSelectionChange={canMutateDocuments ? handleSelectOne : undefined}

--- a/frontend/src/pages/KMSDetailPage.tsx
+++ b/frontend/src/pages/KMSDetailPage.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { ArrowLeft, Download, Edit, Save, Trash2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  deleteKMSEntry,
+  downloadDocument,
+  getKMSEntry,
+  updateKMSEntry,
+  type KMSEntry,
+} from "@/lib/api";
+
+const STATUS_VALUES = ["draft", "published", "archived"] as const;
+
+export default function KMSDetailPage() {
+  const { entryId } = useParams<{ entryId: string }>();
+  const navigate = useNavigate();
+  const id = Number(entryId);
+
+  const [entry, setEntry] = useState<KMSEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [summary, setSummary] = useState("");
+  const [tags, setTags] = useState("");
+  const [status, setStatus] = useState<string>("draft");
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!Number.isFinite(id)) {
+      setError("Invalid entry id");
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const e = await getKMSEntry(id);
+      setEntry(e);
+      setTitle(e.title);
+      setBody(e.body);
+      setSummary(e.summary);
+      setTags(e.tags.join(", "));
+      setStatus(e.status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load entry");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleSave() {
+    if (!entry) return;
+    setSaving(true);
+    try {
+      const updated = await updateKMSEntry(entry.id, {
+        title: title.trim(),
+        body,
+        summary,
+        status,
+        tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+      });
+      setEntry(updated);
+      setEditing(false);
+      toast.success("Entry saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save entry");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!entry) return;
+    if (!window.confirm(`Delete "${entry.title}"?`)) return;
+    try {
+      await deleteKMSEntry(entry.id);
+      toast.success("Entry deleted");
+      navigate("/kms");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete entry");
+    }
+  }
+
+  async function handleDownload() {
+    if (!entry?.file_id) return;
+    try {
+      await downloadDocument(entry.file_id, entry.title);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Download failed");
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading…</div>
+    );
+  }
+  if (error || !entry) {
+    return (
+      <div className="p-6">
+        <Button variant="ghost" size="sm" onClick={() => navigate("/kms")}>
+          <ArrowLeft className="w-4 h-4 mr-1" /> Back
+        </Button>
+        <p className="text-sm text-destructive mt-4">{error ?? "Entry not found"}</p>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-4 p-6 max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate("/kms")}
+              aria-label="Back"
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </Button>
+            <div>
+              {editing ? (
+                <Input value={title} onChange={(e) => setTitle(e.target.value)} className="text-lg font-semibold" />
+              ) : (
+                <h2 className="text-lg font-semibold">{entry.title}</h2>
+              )}
+              <p className="text-xs text-muted-foreground">{entry.slug}</p>
+            </div>
+          </div>
+          <div className="flex gap-1">
+            {entry.source_type === "document" && entry.file_id != null && (
+              <Button variant="outline" size="sm" onClick={handleDownload}>
+                <Download className="w-4 h-4 mr-1" />
+                Source
+              </Button>
+            )}
+            {editing ? (
+              <>
+                <Button variant="outline" size="sm" onClick={handleSave} disabled={saving}>
+                  <Save className="w-4 h-4 mr-1" />
+                  {saving ? "Saving…" : "Save"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setEditing(false);
+                    setTitle(entry.title);
+                    setBody(entry.body);
+                    setSummary(entry.summary);
+                    setTags(entry.tags.join(", "));
+                    setStatus(entry.status);
+                  }}
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+                  <Edit className="w-4 h-4 mr-1" />
+                  Edit
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDelete}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Meta */}
+        <div className="flex gap-2 flex-wrap items-center">
+          {editing ? (
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger className="w-36">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_VALUES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Badge variant="outline">{entry.status}</Badge>
+          )}
+          <Badge variant="secondary" className="capitalize">
+            {entry.source_type}
+          </Badge>
+        </div>
+
+        {/* Tags */}
+        {editing ? (
+          <div>
+            <Label htmlFor="kms-edit-tags">Tags (comma-separated)</Label>
+            <Input
+              id="kms-edit-tags"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+            />
+          </div>
+        ) : (
+          entry.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {entry.tags.map((tag) => (
+                <Badge key={tag} variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )
+        )}
+
+        {/* Summary */}
+        {editing ? (
+          <div>
+            <Label htmlFor="kms-edit-summary">Summary</Label>
+            <Textarea
+              id="kms-edit-summary"
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              rows={3}
+            />
+          </div>
+        ) : (
+          entry.summary && (
+            <p className="text-sm text-muted-foreground">{entry.summary}</p>
+          )
+        )}
+
+        {/* Body */}
+        <Card>
+          <CardHeader className="pb-2 pt-3 px-4">
+            <CardTitle className="text-sm">Content</CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 pb-3">
+            {editing ? (
+              <Textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={16}
+                className="font-mono text-xs"
+              />
+            ) : entry.body ? (
+              <pre className="text-xs whitespace-pre-wrap font-sans">{entry.body}</pre>
+            ) : (
+              <p className="text-xs text-muted-foreground italic">No content.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/frontend/src/pages/KMSPage.tsx
+++ b/frontend/src/pages/KMSPage.tsx
@@ -1,0 +1,292 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { FileText, Library, Plus, RefreshCw, Search } from "lucide-react";
+
+import { useVaultStore } from "@/stores/useVaultStore";
+import { VaultSelector } from "@/components/vault/VaultSelector";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createKMSEntry,
+  listKMSEntries,
+  recompileVaultKMS,
+  type KMSEntry,
+} from "@/lib/api";
+
+const STATUS_OPTIONS = ["all", "draft", "published", "archived"] as const;
+
+function statusVariant(status: string): "default" | "secondary" | "outline" {
+  if (status === "published") return "default";
+  if (status === "archived") return "outline";
+  return "secondary";
+}
+
+export default function KMSPage() {
+  const { activeVaultId } = useVaultStore();
+  const navigate = useNavigate();
+
+  const [entries, setEntries] = useState<KMSEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newBody, setNewBody] = useState("");
+  const [newTags, setNewTags] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const fetchEntries = useCallback(async () => {
+    if (!activeVaultId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listKMSEntries({
+        vault_id: activeVaultId,
+        search: search.trim() || undefined,
+        status: statusFilter === "all" ? undefined : statusFilter,
+        per_page: 200,
+      });
+      setEntries(res.entries);
+      setTotal(res.total);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load KMS entries");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeVaultId, search, statusFilter]);
+
+  useEffect(() => {
+    if (!activeVaultId) return;
+    const t = setTimeout(fetchEntries, search ? 300 : 0);
+    return () => clearTimeout(t);
+  }, [activeVaultId, search, statusFilter, fetchEntries]);
+
+  async function handleCreate() {
+    if (!activeVaultId || !newTitle.trim()) return;
+    setSaving(true);
+    try {
+      const tags = newTags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      const entry = await createKMSEntry({
+        vault_id: activeVaultId,
+        title: newTitle.trim(),
+        body: newBody,
+        tags,
+      });
+      toast.success("Entry created");
+      setCreateOpen(false);
+      setNewTitle("");
+      setNewBody("");
+      setNewTags("");
+      navigate(`/kms/${entry.id}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to create entry");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRecompile() {
+    if (!activeVaultId) return;
+    try {
+      await recompileVaultKMS(activeVaultId);
+      toast.info("Recompile queued — document entries will refresh shortly");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to queue recompile");
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
+        <div className="flex items-center gap-3">
+          <Library className="w-5 h-5 text-muted-foreground" />
+          <h1 className="text-xl font-semibold">Knowledge Management</h1>
+          <VaultSelector />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRecompile}
+            disabled={!activeVaultId}
+            title="Recompile document entries for this vault"
+          >
+            <RefreshCw className="w-4 h-4 mr-1" />
+            Recompile
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => setCreateOpen(true)}
+            disabled={!activeVaultId}
+          >
+            <Plus className="w-4 h-4 mr-1" />
+            New entry
+          </Button>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 px-6 py-3 border-b border-border shrink-0">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-2 top-2.5 w-4 h-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search title and content…"
+            className="pl-8"
+            disabled={!activeVaultId}
+          />
+        </div>
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((s) => (
+              <SelectItem key={s} value={s}>
+                {s === "all" ? "All statuses" : s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Body */}
+      <ScrollArea className="flex-1">
+        <div className="p-6">
+          {!activeVaultId ? (
+            <p className="text-sm text-muted-foreground text-center py-12">
+              Select a vault to view its knowledge entries.
+            </p>
+          ) : loading ? (
+            <p className="text-sm text-muted-foreground py-8">Loading…</p>
+          ) : error ? (
+            <p className="text-sm text-destructive py-8">{error}</p>
+          ) : entries.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-12">
+              No entries yet. Create one, or upload documents to auto-generate
+              entries.
+            </p>
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground mb-3">
+                {total} {total === 1 ? "entry" : "entries"}
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {entries.map((entry) => (
+                  <button
+                    key={entry.id}
+                    onClick={() => navigate(`/kms/${entry.id}`)}
+                    className="text-left rounded-lg border border-border p-4 hover:border-primary hover:bg-accent/40 transition-colors"
+                  >
+                    <div className="flex items-start justify-between gap-2 mb-1">
+                      <h3 className="font-medium text-sm line-clamp-2">
+                        {entry.title}
+                      </h3>
+                      {entry.source_type === "document" && (
+                        <FileText
+                          className="w-4 h-4 text-muted-foreground shrink-0"
+                          aria-label="Document-sourced entry"
+                        />
+                      )}
+                    </div>
+                    {entry.summary && (
+                      <p className="text-xs text-muted-foreground line-clamp-3 mb-2">
+                        {entry.summary}
+                      </p>
+                    )}
+                    <div className="flex flex-wrap gap-1 items-center">
+                      <Badge variant={statusVariant(entry.status)} className="text-[10px]">
+                        {entry.status}
+                      </Badge>
+                      {entry.tags.slice(0, 3).map((tag) => (
+                        <Badge key={tag} variant="outline" className="text-[10px]">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </ScrollArea>
+
+      {/* Create dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New knowledge entry</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div>
+              <Label htmlFor="kms-title">Title</Label>
+              <Input
+                id="kms-title"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder="Entry title"
+                autoFocus
+              />
+            </div>
+            <div>
+              <Label htmlFor="kms-body">Body (markdown)</Label>
+              <Textarea
+                id="kms-body"
+                value={newBody}
+                onChange={(e) => setNewBody(e.target.value)}
+                placeholder="Write the entry content…"
+                rows={8}
+              />
+            </div>
+            <div>
+              <Label htmlFor="kms-tags">Tags (comma-separated)</Label>
+              <Input
+                id="kms-tags"
+                value={newTags}
+                onChange={(e) => setNewTags(e.target.value)}
+                placeholder="onboarding, policy"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={saving || !newTitle.trim()}>
+              {saving ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the KMS/DMS feasibility plan in #119: a vault-scoped, user-curated, full-text-searchable Knowledge Management layer, plus automatic compile-on-ingest that turns indexed documents into curatable KMS entries. Built on the proven wiki subsystem patterns (store + compile processor + settings flags), so it reuses rather than reinvents.

### Backend
- **Schema** (`database.py`): `kms_entries` + `kms_entries_fts` (FTS5 over title/summary/body/tags with sync triggers) + `kms_compile_jobs`, in `SCHEMA` and an idempotent `migrate_add_kms_tables` migration. `file_id` FK is `ON DELETE SET NULL` so deleting a document preserves the curated entry.
- **Services**: `KMSStore` (vault-scoped CRUD, content FTS search with malformed-query guard, tag filtering, idempotent `upsert_document_entry`, job lifecycle) and `KMSCompileProcessor` (5s poll, orphan recovery, retry/backoff).
- **Routes** (`/api/kms`): list/create/get/update/delete/search/compile/recompile/jobs — registered in `main.py`; processor started/stopped in `lifespan.py`.
- **Config/settings**: `kms_enabled` / `kms_compile_on_ingest` wired through config, `SettingsUpdate`, `ALLOWED_FIELDS`, `SettingsResponse`, the GET response, **and** the lifespan reload list (so the toggles persist across restart). Ingest hook in `document_processor.py` (gated, failure-isolated).

### Quality fixes from the audit
- **DD-C003**: confined on-disk file unlink when a document is deleted (path-contained to the vault's roots).
- **DD-C010**: best-effort HMAC audit logging on upload / delete / raw-read.
- **DD-C013**: allow `.pptx` uploads (+ magic-byte validation).

### Frontend
- `KMSEntry` types + API client, `KMSPage` (list/search/status filter/create) and `KMSDetailPage` (view/edit/delete/download source), `/kms` + `/kms/:entryId` routes and a sidebar nav item.
- **DD-C009**: document download button in the desktop table and the mobile `DocumentCard`.

### Out of scope (not in this PR)
Phases 1.5–4 from #119 (dedicated `files` content search, KMS→RAG retrieval, tags/sort/decompose, richer icons). Phase 1 only, as agreed.

## Test plan
- [x] Backend: 19 new KMS tests (auth, RBAC, CRUD, content search, cross-vault isolation, compile enqueue, store job lifecycle, settings reload) — all pass
- [x] No regressions in documents/wiki/settings/progress suites (pre-existing failures confirmed identical on `master`)
- [x] `ruff` clean on all changed/new backend files
- [x] Frontend `tsc` typecheck, ESLint (`--max-warnings 0`), and production build all pass
- [x] Two independent skeptical code reviews (backend security + cross-file wiring): APPROVED, no confirmed bugs
- [ ] Manual UI smoke test of KMS pages + document download (reviewer to verify in a running app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)