### PR TITLE
feat(skills): add python-async-sqlite, fastapi-rate-limiting, and council-advisory-triage agent skills

### DIFF
--- a/.opencode/skills/generated/council-advisory-triage/SKILL.md
+++ b/.opencode/skills/generated/council-advisory-triage/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: council-advisory-triage
+description: How to distinguish blocking vs advisory findings from council review, especially final council. Prevents unnecessary rework from misclassified advisory concerns.
+generated_from_knowledge:
+  - 44e08dfa-4e15-4667-b450-8e2e236c0405
+  - 728f248f-49b9-43ce-aed2-b5e971878b7e
+confidence: 0.65
+status: active
+---
+
+# Council Advisory Triage
+
+## Trigger
+
+Use this skill when:
+- Receiving council review findings (especially final council)
+- Determining if a council finding is blocking or advisory
+- Deciding whether to rework code based on council feedback
+- Writing phase council verdicts after reviewing findings
+
+## Required Procedure
+
+### 1. Classify each finding as BLOCKING or ADVISORY
+
+**BLOCKING findings (must fix):**
+- Security vulnerabilities (SQL injection, auth bypass, secret leakage)
+- Logic errors that cause incorrect behavior
+- Missing error handling for critical paths
+- API contract violations that break consumers
+- Race conditions in concurrent code
+- Memory leaks or resource exhaustion
+
+**ADVISORY findings (consider but not required):**
+- Code style suggestions beyond project conventions
+- "Could be more efficient" without performance impact
+- Edge cases with extremely low probability
+- Future-proofing suggestions without current need
+- Personal preference disguised as best practice
+- Minor naming or documentation improvements
+
+### 2. Verify with evidence
+
+For each BLOCKING finding, ask:
+- [ ] Can I demonstrate the bug with a test case?
+- [ ] Does this affect a critical user journey?
+- [ ] Would this fail in production?
+- [ ] Is there a security or data integrity risk?
+
+A finding is BLOCKING only if at least one of these is YES. If none are YES, the finding is likely ADVISORY.
+
+**Exception:** A council member may have identified a genuine blocking issue but phrased it as a suggestion. If a finding describes a real correctness or security defect — even if phrased softly — classify it as BLOCKING.
+
+### 3. Handle overly conservative councils
+
+Final council in particular tends to be conservative. When the council returns CONCERNS or REJECT:
+
+1. Count required fixes vs advisory suggestions
+2. If required fixes = 0, the verdict should be APPROVE with advisory notes
+3. Document the rationale for treating advisory findings as non-blocking
+4. Write the verdict honestly — don't upgrade advisory to blocking
+
+**Note:** The same triage applies whether the council returns CONCERNS or REJECT — both can contain advisory-only feedback.
+
+### 4. Escalation path
+
+If a council member insists on an advisory finding being blocking:
+- Request a specific test case that demonstrates the issue
+- Ask for the severity rating with justification
+- If no concrete evidence: mark as advisory and proceed
+
+## Forbidden Shortcuts
+
+- NEVER treat all council findings as blocking by default
+- NEVER ignore blocking findings just because they're hard to fix
+- NEVER let one council member's opinion override concrete evidence
+- NEVER skip the classification step — always categorize each finding
+
+## Delegation Template
+
+When delegating a task affected by this skill, include:
+
+```
+SKILLS: file:.opencode/skills/generated/council-advisory-triage/SKILL.md
+```
+
+## Reviewer Checks
+
+- [ ] Each council finding classified as BLOCKING or ADVISORY
+- [ ] BLOCKING findings have test cases or concrete evidence
+- [ ] Advisory findings documented but not blocking phase completion
+- [ ] Verdict reflects required fixes only — suggestion count is irrelevant to the blocking decision
+
+## Source Knowledge IDs
+
+- 44e08dfa-4e15-4667-b450-8e2e236c0405 — Final council may flag advisory concerns as blocking
+- 728f248f-49b9-43ce-aed2-b5e971878b7e — Council review catches cross-cutting anti-patterns

--- a/.opencode/skills/generated/fastapi-rate-limiting-integration/SKILL.md
+++ b/.opencode/skills/generated/fastapi-rate-limiting-integration/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: fastapi-rate-limiting-integration
+description: Patterns for integrating rate limiting into FastAPI applications using slowapi. Covers decorator signatures, dependency injection, and common pitfalls.
+generated_from_knowledge:
+  - 88cf3ffd-8d47-4521-9da8-b944de1f4add
+  - 9cc8ee05-12f6-465b-bb3d-0f6358f61036
+confidence: 0.75
+status: active
+---
+
+# FastAPI Rate Limiting Integration
+
+## Trigger
+
+Use this skill when:
+- Adding rate limiting to FastAPI endpoints
+- Using slowapi or similar rate limiting libraries
+- Reviewing endpoint code that includes rate limiting decorators
+- Debugging rate limits that appear to not be enforced
+
+## Required Procedure
+
+### 1. slowapi @limiter.limit() requires request: Request parameter
+
+**WRONG:**
+```python
+@router.post("/chat")
+@limiter.limit(settings.chat_rate_limit)
+async def chat_endpoint(message: str):  # MISSING request parameter!
+    ...
+```
+
+**RIGHT:**
+```python
+@router.post("/chat")
+@limiter.limit(settings.chat_rate_limit)
+async def chat_endpoint(
+    request: Request,  # MUST be present in the signature
+    message: str
+):
+    ...
+```
+
+`request: Request` can appear at any position in the signature — it does not need to be first. The only requirement is that it is present so slowapi can extract the request object for rate limit key generation.
+
+### 2. Use dependency injection for custom limiter logic
+
+```python
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from starlette.requests import Request
+import hmac
+
+class WhitelistLimiter(Limiter):
+    def __init__(self, default_limit: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_limit = default_limit
+
+    def _check_request_limit(self, request, endpoint_func, in_middleware=True):
+        key = request.headers.get("X-API-Key")
+        if key and hmac.compare_digest(key, settings.health_check_api_key):
+            return  # bypass rate limiting for whitelisted keys
+        super()._check_request_limit(request, endpoint_func, in_middleware)
+
+limiter = WhitelistLimiter(
+    default_limit="30/minute",
+    key_func=get_remote_address
+)
+```
+
+## Forbidden Shortcuts
+
+- NEVER omit request: Request parameter on rate-limited endpoints
+- NEVER assume rate limiting works without testing — silent failures are common
+- NEVER use plain `==` for API key comparison in whitelist logic — use `hmac.compare_digest`
+
+## Common Error Signatures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Rate limits not enforced | Missing request: Request parameter | Add request to endpoint signature |
+| "Request" not defined | Missing import | from starlette.requests import Request |
+| Whitelist bypass not working | Limiter not subclassed | Extend slowapi.Limiter and override _check_request_limit |
+| Timing attack on API key | Using `==` instead of hmac.compare_digest | Use hmac.compare_digest for key comparison |
+
+## Delegation Template
+
+When delegating a task affected by this skill, include:
+
+```
+SKILLS: file:.opencode/skills/generated/fastapi-rate-limiting-integration/SKILL.md
+```
+
+## Reviewer Checks
+
+- [ ] All rate-limited endpoints have request: Request present in signature
+- [ ] Request import is present (from starlette.requests import Request)
+- [ ] Rate limiting tested with both authenticated and unauthenticated requests
+- [ ] Whitelist logic uses hmac.compare_digest for key comparison
+- [ ] Custom limiter extends slowapi.Limiter (not a plain class)
+
+## Source Knowledge IDs
+
+- 88cf3ffd-8d47-4521-9da8-b944de1f4add — slowapi @limiter.limit() requires request: Request parameter
+- 9cc8ee05-12f6-465b-bb3d-0f6358f61036 — Always verify decorator signature requirements when adding rate limiting

--- a/.opencode/skills/generated/python-async-sqlite/SKILL.md
+++ b/.opencode/skills/generated/python-async-sqlite/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: python-async-sqlite
+description: Safe patterns for using SQLite with asyncio in FastAPI and other async Python applications. Covers the async-to-thread trap, cursor thread-safety, and transaction rollback handling.
+generated_from_knowledge:
+  - 43ddee40-0354-471b-9029-37b551c5fb3a
+  - b4bf4f8a-f45a-4e38-a80a-d4273fa888e7
+  - bce3ec82-583e-48f8-ba06-2ab5a7c41931
+confidence: 0.85
+status: active
+---
+
+# Python Async SQLite Patterns
+
+## Trigger
+
+Use this skill when:
+- Wrapping synchronous SQLite operations in asyncio.to_thread()
+- Refactoring sync database code to async in FastAPI/Starlette
+- Reviewing code that uses SQLite with asyncio
+- Debugging "coroutine object has no attribute" errors from database calls
+
+## Required Procedure
+
+### 1. NEVER pass async functions to asyncio.to_thread()
+
+**WRONG:**
+```python
+async def get_user(db, user_id):
+    return await asyncio.to_thread(_fetch_user, db, user_id)  # OK if _fetch_user is sync
+
+async def _fetch_user(db, user_id):  # async function!
+    cursor = db.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+    return cursor.fetchone()
+```
+
+**RIGHT:**
+```python
+def _fetch_user(db, user_id):  # MUST be sync
+    cursor = db.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+    return cursor.fetchone()
+
+async def get_user(db, user_id):
+    return await asyncio.to_thread(_fetch_user, db, user_id)
+```
+
+### 2. Consolidate execute + fetch in a single to_thread call
+
+This rule also applies to `executemany()` and any other operation that returns a cursor:
+
+```python
+# RIGHT — executemany consolidated
+def _bulk_insert(db, rows):
+    cursor = db.executemany("INSERT INTO users (name) VALUES (?)", rows)
+    return cursor.rowcount
+
+async def bulk_insert_users(db, rows):
+    return await asyncio.to_thread(_bulk_insert, db, rows)
+```
+
+**WRONG:**
+```python
+async def get_user(db, user_id):
+    # CURSOR IS NOT THREAD-SAFE — never do this
+    cursor = await asyncio.to_thread(db.execute, "SELECT * FROM users WHERE id = ?", (user_id,))
+    return await asyncio.to_thread(cursor.fetchone)  # cursor may be corrupted!
+```
+
+**RIGHT:**
+```python
+def _fetch_user(db, user_id):
+    cursor = db.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+    return cursor.fetchone()
+
+async def get_user(db, user_id):
+    return await asyncio.to_thread(_fetch_user, db, user_id)
+```
+
+**OR using lambda:**
+```python
+async def get_user(db, user_id):
+    return await asyncio.to_thread(
+        lambda: db.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+    )
+```
+
+### 3. Use named functions with internal rollback for transactions
+
+**WRONG:**
+```python
+async def create_user(db, user_data):
+    def _create():
+        db.execute("INSERT INTO users ...", user_data)
+        db.commit()
+    
+    try:
+        return await asyncio.to_thread(_create)
+    except sqlite3.IntegrityError:
+        # BUG: rollback runs in a NEW thread — not the same thread as the transaction!
+        await asyncio.to_thread(db.rollback)
+```
+
+**RIGHT:**
+```python
+async def create_user(db, user_data):
+    def _create():
+        try:
+            cursor = db.execute("INSERT INTO users ...", user_data)
+            db.commit()
+            return cursor.lastrowid
+        except sqlite3.IntegrityError:
+            db.rollback()
+            raise
+    
+    return await asyncio.to_thread(_create)
+```
+
+### 4. Set check_same_thread=False on connections used with to_thread
+
+```python
+db = sqlite3.connect(
+    database_path,
+    check_same_thread=False  # Required when connection is used across threads via to_thread
+)
+```
+
+### 5. Update ALL callers when changing sync → async signatures
+
+When you convert a sync function to async, every direct caller must be updated:
+
+**WRONG:**
+```python
+# deps.py — converted to async
+async def get_user_orgs(db, user_id):
+    return await asyncio.to_thread(lambda: ...)
+
+# vaults.py — caller NOT updated
+orgs = get_user_orgs(db, user_id)  # Returns coroutine object, not result!
+```
+
+**RIGHT:**
+```python
+# vaults.py — caller updated with await
+orgs = await get_user_orgs(db, user_id)
+```
+
+Always run a full-text search for the function name across the codebase after changing its signature.
+
+## Forbidden Shortcuts
+
+- NEVER split execute() and fetch*() across separate to_thread calls
+- NEVER pass async functions to asyncio.to_thread()
+- NEVER rely on exception handlers outside the to_thread lambda for rollback — the lambda runs in a different thread
+- NEVER forget check_same_thread=False when creating connections for async use
+
+## Known Existing Violations
+
+Some production codebases (including RAGAPPv3's `vaults.py`) may still use the split execute/fetch pattern. These are **known technical debt** — the skill's rules represent the target state. When reviewing code with existing violations, flag them for cleanup but do not block new features on unrelated existing debt.
+
+## Connection Pool Notes
+
+When using `SQLiteConnectionPool` or similar pool implementations:
+- Pool checkout (getting a connection) is typically sync and safe to wrap in `to_thread`
+- The same consolidation rule applies: all DB operations on a checked-out connection must be in a single lambda
+- `check_same_thread=False` should be set on connections created by the pool factory, not by consumers
+
+## Common Error Signatures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "coroutine object has no attribute 'fetchone'" | Async function passed to to_thread | Make the function synchronous |
+| "SQLite objects created in a thread can only be used in that same thread" | Cursor split across to_thread calls | Consolidate into single lambda |
+| "database is locked" | Multiple threads accessing connection without check_same_thread=False | Add check_same_thread=False |
+| Partial transaction state after exception | Rollback not handled inside lambda | Move rollback into named function |
+
+## Delegation Template
+
+When delegating a task affected by this skill, include:
+
+```
+SKILLS: file:.opencode/skills/generated/python-async-sqlite/SKILL.md
+```
+
+## Reviewer Checks
+
+- [ ] No async functions passed to asyncio.to_thread()
+- [ ] All execute() + fetch*() pairs consolidated in single to_thread call
+- [ ] Transaction rollbacks handled inside the lambda/function, not outside
+- [ ] check_same_thread=False set on connections used with to_thread
+- [ ] All callers updated when function signature changes sync→async
+
+## Source Knowledge IDs
+
+- 43ddee40-0354-471b-9029-37b551c5fb3a (hive) — NEVER pass async functions to asyncio.to_thread()
+- b4bf4f8a-f45a-4e38-a80a-d4273fa888e7 (hive) — SQLite cursor objects are NOT thread-safe
+- bce3ec82-583e-48f8-ba06-2ab5a7c41931 (swarm) — RAGAPPv3 SQLite async pattern with named rollback functions


### PR DESCRIPTION
﻿## Summary
- Add three new agent skills generated from lessons learned during the concurrency and scalability hardening project (PR #123)
- python-async-sqlite: Safe patterns for SQLite with asyncio -- covers async-to-thread trap, cursor thread-safety, rollback handling, and check_same_thread=False
- astapi-rate-limiting-integration: Patterns for slowapi rate limiting -- covers Request parameter requirement, WhitelistLimiter subclassing, and hmac.compare_digest
- council-advisory-triage: Framework for distinguishing blocking vs advisory council findings -- prevents unnecessary rework from misclassified advisory concerns

## Test plan
- [x] Skills reviewed by paid_reviewer agent -- all three approved after fixes
- [x] python-async-sqlite: 6 initial issues fixed (undefined variables, misrepresented failure mode, missing executemany coverage, knowledge tier labels)
- [x] fastapi-rate-limiting-integration: 4 initial issues fixed (decorator ordering, Limiter subclassing, parameter position claim, import convention)
- [x] council-advisory-triage: 3 advisory issues fixed (false-negative trap, absolute required-fix rule, REJECT verdict coverage)
- [x] Knowledge entries promoted to hive tier (6 cross-project lessons)

## Known warnings
- LF will be replaced by CRLF on next Git touch (Windows platform normalization)
