### PR TITLE
feat(phase4): file icons, test dedup, KMS route tests, and folder hierarchy

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -324,6 +324,7 @@ class DocumentResponse(BaseModel):
     enrichment_error: Optional[str] = None
     metadata: Optional[dict] = None  # Frontend expects metadata
     tags: List[dict] = Field(default_factory=list)  # Assigned organization tags
+    folder_id: Optional[int] = None  # Folder the document is filed in (null = unfiled)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -450,6 +451,7 @@ def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
     )
     enrichment_status = row["enrichment_status"] if "enrichment_status" in keys else None
     enrichment_error = row["enrichment_error"] if "enrichment_error" in keys else None
+    folder_id = row["folder_id"] if "folder_id" in keys else None
     return DocumentResponse(
         id=row["id"],
         file_name=file_name,
@@ -474,6 +476,7 @@ def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
         processing_started_at=processing_started_at,
         enrichment_status=enrichment_status,
         enrichment_error=enrichment_error,
+        folder_id=folder_id,
         metadata={
             "status": status,
             "chunk_count": chunk_count,
@@ -516,6 +519,9 @@ async def list_documents(
     ),
     status: Optional[str] = Query(None, description="Filter by processing status"),
     tag_id: Optional[int] = Query(None, description="Filter by assigned tag ID"),
+    folder_id: Optional[int] = Query(
+        None, description="Filter to documents directly in this folder ID"
+    ),
     sort_by: str = Query(
         "created_at",
         description="Sort column: created_at, file_name, file_size, status",
@@ -597,6 +603,9 @@ async def list_documents(
             "id IN (SELECT dt.file_id FROM document_tags dt WHERE dt.tag_id = ?)"
         )
         extra_params.append(tag_id)
+    if folder_id is not None:
+        extra_where.append("folder_id = ?")
+        extra_params.append(folder_id)
 
     def _extra_clause(prefix: str = "AND") -> str:
         if not extra_where:
@@ -622,7 +631,7 @@ async def list_documents(
                    created_at, processed_at, error_message, phase, phase_message,
                    progress_percent, processed_units, total_units, unit_label,
                    phase_started_at, processing_started_at, enrichment_status,
-                   enrichment_error, vault_id
+                   enrichment_error, vault_id, folder_id
             FROM files
             WHERE vault_id = ?{_extra_clause()}
             {order_clause}
@@ -652,7 +661,7 @@ async def list_documents(
                        created_at, processed_at, error_message, phase, phase_message,
                        progress_percent, processed_units, total_units, unit_label,
                        phase_started_at, processing_started_at, enrichment_status,
-                       enrichment_error, vault_id
+                       enrichment_error, vault_id, folder_id
                 FROM files
                 WHERE vault_id IN ({placeholders}){_extra_clause()}
                 {order_clause}
@@ -676,7 +685,7 @@ async def list_documents(
                        created_at, processed_at, error_message, phase, phase_message,
                        progress_percent, processed_units, total_units, unit_label,
                        phase_started_at, processing_started_at, enrichment_status,
-                       enrichment_error, vault_id
+                       enrichment_error, vault_id, folder_id
                 FROM files{base_where}
                 {order_clause}
                 LIMIT ? OFFSET ?

--- a/backend/app/api/routes/folders.py
+++ b/backend/app/api/routes/folders.py
@@ -1,0 +1,198 @@
+"""
+Folder API routes for document organization.
+
+User-curated, vault-scoped folder hierarchy (nested via parent_folder_id) and
+moving documents between folders. All endpoints enforce vault read/write
+permissions, mirroring the tag routes. Mutating endpoints are CSRF-protected.
+"""
+
+import logging
+import sqlite3
+from dataclasses import asdict
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.api.deps import evaluate_policy, get_current_active_user, get_db
+from app.security import csrf_protect
+from app.services.folder_store import (
+    _UNSET,
+    FolderCycleError,
+    FolderDuplicateError,
+    FolderNotFoundError,
+    FolderStore,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/folders", tags=["folders"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _require_vault_read(user: dict, vault_id: int) -> None:
+    if not await evaluate_policy(user, "vault", vault_id, "read"):
+        raise HTTPException(status_code=403, detail="No read access to this vault")
+
+
+async def _require_vault_write(user: dict, vault_id: int) -> None:
+    if not await evaluate_policy(user, "vault", vault_id, "write"):
+        raise HTTPException(status_code=403, detail="No write access to this vault")
+
+
+def _folder_vault_id(db: sqlite3.Connection, folder_id: int) -> Optional[int]:
+    db.row_factory = sqlite3.Row
+    row = db.execute(
+        "SELECT vault_id FROM folders WHERE id = ?", (folder_id,)
+    ).fetchone()
+    return row["vault_id"] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class FolderCreateRequest(BaseModel):
+    vault_id: int
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str = Field("", max_length=2000)
+    parent_folder_id: Optional[int] = None
+
+
+class FolderUpdateRequest(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    description: Optional[str] = Field(None, max_length=2000)
+    # parent_folder_id is intentionally nullable: a client may set it to null to
+    # move the folder to the root. We distinguish "field omitted" from
+    # "explicit null" via model_fields_set in the handler.
+    parent_folder_id: Optional[int] = None
+
+
+class FolderMoveRequest(BaseModel):
+    vault_id: int
+    file_ids: list[int] = Field(..., min_length=1)
+    # null => move the documents to the root (unfiled).
+    folder_id: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Folder CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+async def list_folders(
+    vault_id: int = Query(..., description="Vault ID"),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = FolderStore(db)
+    return {"folders": [asdict(f) for f in store.list_folders(vault_id)]}
+
+
+@router.post("", status_code=201)
+async def create_folder(
+    request: FolderCreateRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    await _require_vault_write(user, request.vault_id)
+    store = FolderStore(db)
+    try:
+        folder = store.create_folder(
+            request.vault_id,
+            request.name,
+            request.description,
+            request.parent_folder_id,
+        )
+    except FolderNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except FolderDuplicateError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    return asdict(folder)
+
+
+@router.put("/{folder_id}")
+async def update_folder(
+    folder_id: int,
+    request: FolderUpdateRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    vault_id = _folder_vault_id(db, folder_id)
+    if vault_id is None:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    await _require_vault_write(user, vault_id)
+    store = FolderStore(db)
+    # Only reparent when the caller actually included parent_folder_id.
+    reparent = "parent_folder_id" in request.model_fields_set
+    parent_arg = request.parent_folder_id if reparent else _UNSET
+    try:
+        updated = store.update_folder(
+            folder_id,
+            vault_id,
+            name=request.name,
+            description=request.description,
+            parent_folder_id=parent_arg,
+        )
+    except FolderNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except FolderCycleError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except FolderDuplicateError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    return asdict(updated)
+
+
+@router.delete("/{folder_id}", status_code=204)
+async def delete_folder(
+    folder_id: int,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    vault_id = _folder_vault_id(db, folder_id)
+    if vault_id is None:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    await _require_vault_write(user, vault_id)
+    store = FolderStore(db)
+    store.delete_folder(folder_id, vault_id)
+
+
+# ---------------------------------------------------------------------------
+# Document assignment
+# ---------------------------------------------------------------------------
+
+
+@router.post("/move")
+async def move_documents(
+    request: FolderMoveRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    """Move one or more documents into a folder (or to root when folder_id is
+    null). Both the target folder and the files are scoped to the vault."""
+    await _require_vault_write(user, request.vault_id)
+    store = FolderStore(db)
+    try:
+        moved = store.move_documents(
+            request.vault_id, request.file_ids, request.folder_id
+        )
+    except FolderNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return {"moved": moved}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api.routes.documents import (
 )
 from app.api.routes.email import router as email_router
 from app.api.routes.eval import router as eval_router
+from app.api.routes.folders import router as folders_router
 from app.api.routes.groups import router as groups_router
 from app.api.routes.health import router as health_router
 from app.api.routes.kms import router as kms_router
@@ -125,6 +126,7 @@ app.include_router(groups_router, prefix="/api")
 app.include_router(wiki_router, prefix="/api")
 app.include_router(kms_router, prefix="/api")
 app.include_router(tags_router, prefix="/api")
+app.include_router(folders_router, prefix="/api")
 
 # Register exception handler for validation errors (empty filename)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -65,6 +65,7 @@ CREATE TABLE IF NOT EXISTS files (
     enrichment_status TEXT,
     enrichment_error TEXT,
     enrichment_updated_at TIMESTAMP,
+    folder_id INTEGER REFERENCES folders(id) ON DELETE SET NULL,
     FOREIGN KEY (vault_id) REFERENCES vaults(id)
 );
 
@@ -615,6 +616,29 @@ CREATE TABLE IF NOT EXISTS document_tags (
 
 CREATE INDEX IF NOT EXISTS idx_tags_vault ON tags(vault_id);
 CREATE INDEX IF NOT EXISTS idx_document_tags_tag_id ON document_tags(tag_id);
+
+-- ============================================================
+-- Document folders (user-curated hierarchy, vault-scoped)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS folders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    vault_id INTEGER NOT NULL,
+    parent_folder_id INTEGER,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (vault_id) REFERENCES vaults(id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_folder_id) REFERENCES folders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_folders_vault ON folders(vault_id);
+CREATE INDEX IF NOT EXISTS idx_folders_parent ON folders(parent_folder_id);
+-- NOTE: the idx_files_folder_id index is created by migrate_add_folders(), not
+-- here. The files table's executescript path also runs against pre-existing
+-- (legacy) databases where files.folder_id may not exist yet; indexing it here
+-- would raise "no such column: folder_id" before the migration adds the column.
 """
 
 
@@ -750,6 +774,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_kms_tables(sqlite_path)
     migrate_add_kms_refs(sqlite_path)
     migrate_add_tags_tables(sqlite_path)
+    migrate_add_folders(sqlite_path)
     migrate_add_files_parsed_text(sqlite_path)
     migrate_add_files_processing_progress(sqlite_path)
     migrate_add_files_enrichment_status(sqlite_path)
@@ -1596,6 +1621,54 @@ def migrate_add_tags_tables(sqlite_path: str) -> None:
             CREATE INDEX IF NOT EXISTS idx_tags_vault ON tags(vault_id);
             CREATE INDEX IF NOT EXISTS idx_document_tags_tag_id ON document_tags(tag_id);
         """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_folders(sqlite_path: str) -> None:
+    """
+    Migration: Add document folder hierarchy for existing databases.
+
+    Idempotent — safe to run multiple times. The folders table and indexes use
+    IF NOT EXISTS guards; files.folder_id is added only when absent. Deleting a
+    folder unfiles its documents (files.folder_id ON DELETE SET NULL) and
+    cascade-deletes its subfolders (parent_folder_id ON DELETE CASCADE);
+    deleting a vault cascade-deletes all of its folders.
+
+    Args:
+        sqlite_path: Path to the SQLite database file.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS folders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL,
+                parent_folder_id INTEGER,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (vault_id) REFERENCES vaults(id) ON DELETE CASCADE,
+                FOREIGN KEY (parent_folder_id) REFERENCES folders(id) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_folders_vault ON folders(vault_id);
+            CREATE INDEX IF NOT EXISTS idx_folders_parent ON folders(parent_folder_id);
+        """)
+        existing_cols = [
+            row[1] for row in conn.execute("PRAGMA table_info(files)").fetchall()
+        ]
+        if "folder_id" not in existing_cols:
+            conn.execute(
+                "ALTER TABLE files ADD COLUMN folder_id INTEGER "
+                "REFERENCES folders(id) ON DELETE SET NULL"
+            )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_files_folder_id ON files(folder_id)"
+        )
         conn.commit()
     finally:
         conn.close()

--- a/backend/app/services/folder_store.py
+++ b/backend/app/services/folder_store.py
@@ -150,18 +150,25 @@ class FolderStore:
             raise ValueError("Folder name must not be empty")
         if parent_folder_id is not None:
             self._require_folder_in_vault(vault_id, parent_folder_id)
-        if self._name_exists(vault_id, parent_folder_id, name):
-            raise FolderDuplicateError(
-                f"Folder {name!r} already exists in this location"
+        # BEGIN IMMEDIATE: name-uniqueness check + INSERT must be atomic so two
+        # concurrent creates cannot both pass the check before either commits.
+        self._db.execute("BEGIN IMMEDIATE")
+        try:
+            if self._name_exists(vault_id, parent_folder_id, name):
+                raise FolderDuplicateError(
+                    f"Folder {name!r} already exists in this location"
+                )
+            now = datetime.utcnow().isoformat()
+            cur = self._db.execute(
+                """INSERT INTO folders
+                       (vault_id, parent_folder_id, name, description, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (vault_id, parent_folder_id, name, description, now, now),
             )
-        now = datetime.utcnow().isoformat()
-        cur = self._db.execute(
-            """INSERT INTO folders
-                   (vault_id, parent_folder_id, name, description, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (vault_id, parent_folder_id, name, description, now, now),
-        )
-        self._db.commit()
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
         return self.get_folder(cur.lastrowid, vault_id)  # type: ignore[return-value]
 
     def get_folder(self, folder_id: int, vault_id: int) -> Optional[Folder]:
@@ -222,25 +229,39 @@ class FolderStore:
         if description is not None:
             updates["description"] = description
 
-        if "name" in updates or "parent_folder_id" in updates:
-            if self._name_exists(
-                vault_id, new_parent, new_name, exclude_id=folder_id
-            ):
-                raise FolderDuplicateError(
-                    f"Folder {new_name!r} already exists in this location"
-                )
-
         if not updates:
             return current
 
         updates["updated_at"] = datetime.utcnow().isoformat()
         set_clause = ", ".join(f"{k} = ?" for k in updates)
         values = list(updates.values()) + [folder_id, vault_id]
-        self._db.execute(
-            f"UPDATE folders SET {set_clause} WHERE id = ? AND vault_id = ?",
-            values,
-        )
-        self._db.commit()
+
+        if "name" in updates or "parent_folder_id" in updates:
+            # BEGIN IMMEDIATE: name-uniqueness check + UPDATE must be atomic so two
+            # concurrent renames/reparents cannot both pass the check before either
+            # commits.
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                if self._name_exists(
+                    vault_id, new_parent, new_name, exclude_id=folder_id
+                ):
+                    raise FolderDuplicateError(
+                        f"Folder {new_name!r} already exists in this location"
+                    )
+                self._db.execute(
+                    f"UPDATE folders SET {set_clause} WHERE id = ? AND vault_id = ?",
+                    values,
+                )
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
+        else:
+            self._db.execute(
+                f"UPDATE folders SET {set_clause} WHERE id = ? AND vault_id = ?",
+                values,
+            )
+            self._db.commit()
         return self.get_folder(folder_id, vault_id)
 
     def delete_folder(self, folder_id: int, vault_id: int) -> bool:

--- a/backend/app/services/folder_store.py
+++ b/backend/app/services/folder_store.py
@@ -1,0 +1,290 @@
+"""
+FolderStore: vault-scoped CRUD for the document folder hierarchy and moving
+documents between folders.
+
+All operations are vault-scoped. Folder names are unique within their parent
+(enforced here because SQLite treats NULL parents as distinct in UNIQUE
+constraints). Reparenting rejects cycles — a folder can never become its own
+descendant. Moving documents only affects files that belong to the same vault
+as the target folder, so a document can never be filed into another vault's
+folder.
+"""
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+# Sentinel distinguishing "parent not provided" from "parent explicitly set to
+# NULL (move to root)" in update_folder.
+_UNSET: Any = object()
+
+
+@dataclass
+class Folder:
+    id: int
+    vault_id: int
+    parent_folder_id: Optional[int]
+    name: str
+    description: str
+    created_at: str
+    updated_at: str
+    document_count: int = 0
+
+
+def _to_folder(row: sqlite3.Row) -> Folder:
+    d = dict(row)
+    return Folder(
+        id=d["id"],
+        vault_id=d["vault_id"],
+        parent_folder_id=d["parent_folder_id"],
+        name=d["name"],
+        description=d.get("description") or "",
+        created_at=d["created_at"],
+        updated_at=d["updated_at"],
+        document_count=d.get("document_count") or 0,
+    )
+
+
+class FolderDuplicateError(Exception):
+    """Raised when a folder name already exists within the same parent."""
+
+
+class FolderCycleError(Exception):
+    """Raised when a reparent would make a folder its own descendant."""
+
+
+class FolderNotFoundError(Exception):
+    """Raised when a referenced folder doesn't exist in the vault."""
+
+
+class FolderStore:
+    """Vault-scoped CRUD for folders + moving documents between folders."""
+
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+        self._db.row_factory = sqlite3.Row
+
+    # -----------------------------------------------------------------------
+    # Internal helpers
+    # -----------------------------------------------------------------------
+
+    def _name_exists(
+        self,
+        vault_id: int,
+        parent_folder_id: Optional[int],
+        name: str,
+        exclude_id: Optional[int] = None,
+    ) -> bool:
+        """True if a sibling folder with the same name already exists.
+
+        NULL parents are matched with IS NULL so root-level names are also
+        deduplicated (a plain UNIQUE index would treat NULL parents as
+        distinct and let duplicates through).
+        """
+        if parent_folder_id is None:
+            sql = (
+                "SELECT id FROM folders WHERE vault_id = ? "
+                "AND parent_folder_id IS NULL AND name = ? COLLATE NOCASE"
+            )
+            params: list = [vault_id, name]
+        else:
+            sql = (
+                "SELECT id FROM folders WHERE vault_id = ? "
+                "AND parent_folder_id = ? AND name = ? COLLATE NOCASE"
+            )
+            params = [vault_id, parent_folder_id, name]
+        if exclude_id is not None:
+            sql += " AND id != ?"
+            params.append(exclude_id)
+        return self._db.execute(sql, params).fetchone() is not None
+
+    def _require_folder_in_vault(self, vault_id: int, folder_id: int) -> None:
+        row = self._db.execute(
+            "SELECT id FROM folders WHERE id = ? AND vault_id = ?",
+            (folder_id, vault_id),
+        ).fetchone()
+        if not row:
+            raise FolderNotFoundError("Folder not found in this vault")
+
+    def _descendant_ids(self, vault_id: int, folder_id: int) -> set[int]:
+        """Return all descendant folder ids (children, grandchildren, ...)."""
+        result: set[int] = set()
+        frontier = [folder_id]
+        while frontier:
+            placeholders = ",".join("?" * len(frontier))
+            rows = self._db.execute(
+                f"""SELECT id FROM folders
+                    WHERE vault_id = ? AND parent_folder_id IN ({placeholders})""",
+                (vault_id, *frontier),
+            ).fetchall()
+            children = [r["id"] for r in rows if r["id"] not in result]
+            result.update(children)
+            frontier = children
+        return result
+
+    def _vault_file_ids(self, vault_id: int, file_ids: list[int]) -> list[int]:
+        """Return the subset of file_ids that belong to vault_id."""
+        if not file_ids:
+            return []
+        placeholders = ",".join("?" * len(file_ids))
+        rows = self._db.execute(
+            f"SELECT id FROM files WHERE vault_id = ? AND id IN ({placeholders})",
+            (vault_id, *file_ids),
+        ).fetchall()
+        return [r["id"] for r in rows]
+
+    # -----------------------------------------------------------------------
+    # Folder CRUD
+    # -----------------------------------------------------------------------
+
+    def create_folder(
+        self,
+        vault_id: int,
+        name: str,
+        description: str = "",
+        parent_folder_id: Optional[int] = None,
+    ) -> Folder:
+        name = name.strip()
+        if not name:
+            raise ValueError("Folder name must not be empty")
+        if parent_folder_id is not None:
+            self._require_folder_in_vault(vault_id, parent_folder_id)
+        if self._name_exists(vault_id, parent_folder_id, name):
+            raise FolderDuplicateError(
+                f"Folder {name!r} already exists in this location"
+            )
+        now = datetime.utcnow().isoformat()
+        cur = self._db.execute(
+            """INSERT INTO folders
+                   (vault_id, parent_folder_id, name, description, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (vault_id, parent_folder_id, name, description, now, now),
+        )
+        self._db.commit()
+        return self.get_folder(cur.lastrowid, vault_id)  # type: ignore[return-value]
+
+    def get_folder(self, folder_id: int, vault_id: int) -> Optional[Folder]:
+        row = self._db.execute(
+            """SELECT f.*,
+                      (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id)
+                          AS document_count
+               FROM folders f WHERE f.id = ? AND f.vault_id = ?""",
+            (folder_id, vault_id),
+        ).fetchone()
+        return _to_folder(row) if row else None
+
+    def list_folders(self, vault_id: int) -> list[Folder]:
+        rows = self._db.execute(
+            """SELECT f.*,
+                      (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id)
+                          AS document_count
+               FROM folders f WHERE f.vault_id = ?
+               ORDER BY f.name COLLATE NOCASE ASC""",
+            (vault_id,),
+        ).fetchall()
+        return [_to_folder(r) for r in rows]
+
+    def update_folder(
+        self,
+        folder_id: int,
+        vault_id: int,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        parent_folder_id: Any = _UNSET,
+    ) -> Optional[Folder]:
+        current = self.get_folder(folder_id, vault_id)
+        if not current:
+            return None
+
+        updates: dict = {}
+        new_parent = current.parent_folder_id
+        if parent_folder_id is not _UNSET:
+            if parent_folder_id == folder_id:
+                raise FolderCycleError("A folder cannot be its own parent")
+            if parent_folder_id is not None:
+                self._require_folder_in_vault(vault_id, parent_folder_id)
+                if parent_folder_id in self._descendant_ids(vault_id, folder_id):
+                    raise FolderCycleError(
+                        "Cannot move a folder into its own descendant"
+                    )
+            updates["parent_folder_id"] = parent_folder_id
+            new_parent = parent_folder_id
+
+        new_name = current.name
+        if name is not None:
+            name = name.strip()
+            if not name:
+                raise ValueError("Folder name must not be empty")
+            updates["name"] = name
+            new_name = name
+
+        if description is not None:
+            updates["description"] = description
+
+        if "name" in updates or "parent_folder_id" in updates:
+            if self._name_exists(
+                vault_id, new_parent, new_name, exclude_id=folder_id
+            ):
+                raise FolderDuplicateError(
+                    f"Folder {new_name!r} already exists in this location"
+                )
+
+        if not updates:
+            return current
+
+        updates["updated_at"] = datetime.utcnow().isoformat()
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [folder_id, vault_id]
+        self._db.execute(
+            f"UPDATE folders SET {set_clause} WHERE id = ? AND vault_id = ?",
+            values,
+        )
+        self._db.commit()
+        return self.get_folder(folder_id, vault_id)
+
+    def delete_folder(self, folder_id: int, vault_id: int) -> bool:
+        """Delete a folder. Subfolders cascade-delete; documents in the folder
+        (and its subfolders) become unfiled via ON DELETE SET NULL."""
+        cur = self._db.execute(
+            "DELETE FROM folders WHERE id = ? AND vault_id = ?",
+            (folder_id, vault_id),
+        )
+        self._db.commit()
+        return cur.rowcount > 0
+
+    # -----------------------------------------------------------------------
+    # Document assignment
+    # -----------------------------------------------------------------------
+
+    def move_documents(
+        self, vault_id: int, file_ids: list[int], folder_id: Optional[int]
+    ) -> int:
+        """Move documents into a folder (or to root when folder_id is None).
+
+        Both the target folder and the files are scoped to the vault; files
+        from another vault are silently dropped. Returns the number of files
+        moved. Raises FolderNotFoundError when the target folder isn't in the
+        vault.
+        """
+        if folder_id is not None:
+            self._require_folder_in_vault(vault_id, folder_id)
+        valid_files = self._vault_file_ids(vault_id, file_ids)
+        if not valid_files:
+            return 0
+        placeholders = ",".join("?" * len(valid_files))
+        cur = self._db.execute(
+            f"UPDATE files SET folder_id = ? WHERE id IN ({placeholders})",
+            (folder_id, *valid_files),
+        )
+        self._db.commit()
+        return cur.rowcount
+
+
+__all__ = [
+    "Folder",
+    "FolderStore",
+    "FolderDuplicateError",
+    "FolderCycleError",
+    "FolderNotFoundError",
+]

--- a/backend/tests/_db_pool.py
+++ b/backend/tests/_db_pool.py
@@ -1,0 +1,61 @@
+"""Shared test connection pool.
+
+A minimal thread-safe SQLite connection pool used by route tests to back the
+`get_db` dependency override. This was previously copy-pasted into every test
+module; it now lives here so there is a single definition (DD-C014).
+
+It is intentionally importable by bare module name (`from _db_pool import
+SimpleConnectionPool`): the test files prepend the backend directory to
+sys.path, and there are two `conftest.py` modules in the tree (backend root and
+backend/tests), so importing from `conftest` would be ambiguous. A uniquely
+named helper module avoids that collision.
+"""
+
+import sqlite3
+import threading
+from queue import Empty, Queue
+
+
+class SimpleConnectionPool:
+    """Thread-safe SQLite pool with the get/release/close_all interface the
+    route tests expect. Connections enable foreign keys and use Row factory."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._pool: Queue = Queue(maxsize=5)
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def get_connection(self) -> sqlite3.Connection:
+        if self._closed:
+            raise RuntimeError("Pool closed")
+        try:
+            return self._pool.get_nowait()
+        except Empty:
+            return self._create_connection()
+
+    def _create_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def release_connection(self, conn: sqlite3.Connection) -> None:
+        if self._closed:
+            conn.close()
+            return
+        try:
+            self._pool.put_nowait(conn)
+        except Exception:
+            conn.close()
+
+    def close_all(self) -> None:
+        self._closed = True
+        while True:
+            try:
+                self._pool.get_nowait().close()
+            except Empty:
+                break
+
+
+__all__ = ["SimpleConnectionPool"]

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -60,6 +60,7 @@ except ImportError:
     sys.modules["unstructured.documents"] = _unstructured.documents
     sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_llm_health_checker, get_model_checker
@@ -291,47 +292,7 @@ class TestMemoriesEndpoints(unittest.TestCase):
 
         # Override get_db to use a pool that allows cross-thread usage
         # Create a simple pool for testing
-        import threading
-        from queue import Empty, Queue
-
         from app.api.deps import get_db, get_memory_store
-
-        class SimpleConnectionPool:
-            def __init__(self, db_path):
-                self.db_path = db_path
-                self._pool = Queue(maxsize=5)
-                self._lock = threading.Lock()
-                self._closed = False
-
-            def get_connection(self):
-                if self._closed:
-                    raise RuntimeError("Pool closed")
-                try:
-                    return self._pool.get_nowait()
-                except Empty:
-                    return self._create_connection()
-
-            def _create_connection(self):
-                conn = sqlite3.connect(self.db_path, check_same_thread=False)
-                conn.row_factory = sqlite3.Row
-                conn.execute("PRAGMA foreign_keys = ON;")
-                return conn
-
-            def release_connection(self, conn):
-                if not self._closed:
-                    try:
-                        self._pool.put_nowait(conn)
-                    except:
-                        conn.close()
-
-            def close_all(self):
-                self._closed = True
-                while True:
-                    try:
-                        conn = self._pool.get_nowait()
-                        conn.close()
-                    except Empty:
-                        break
 
         self._connection_pool = SimpleConnectionPool(db_path)
 
@@ -481,47 +442,7 @@ class TestDocumentsEndpoints(unittest.TestCase):
 
         # Override get_db to use a pool that allows cross-thread usage
         # Create a simple pool for testing
-        import threading
-        from queue import Empty, Queue
-
         from app.api.deps import get_current_active_user, get_db, get_evaluate_policy
-
-        class SimpleConnectionPool:
-            def __init__(self, db_path):
-                self.db_path = db_path
-                self._pool = Queue(maxsize=5)
-                self._lock = threading.Lock()
-                self._closed = False
-
-            def get_connection(self):
-                if self._closed:
-                    raise RuntimeError("Pool closed")
-                try:
-                    return self._pool.get_nowait()
-                except Empty:
-                    return self._create_connection()
-
-            def _create_connection(self):
-                conn = sqlite3.connect(self.db_path, check_same_thread=False)
-                conn.row_factory = sqlite3.Row
-                conn.execute("PRAGMA foreign_keys = ON;")
-                return conn
-
-            def release_connection(self, conn):
-                if not self._closed:
-                    try:
-                        self._pool.put_nowait(conn)
-                    except:
-                        conn.close()
-
-            def close_all(self):
-                self._closed = True
-                while True:
-                    try:
-                        conn = self._pool.get_nowait()
-                        conn.close()
-                    except Empty:
-                        break
 
         self._connection_pool = SimpleConnectionPool(db_path)
 

--- a/backend/tests/test_chat_auth.py
+++ b/backend/tests/test_chat_auth.py
@@ -12,10 +12,8 @@ This test suite verifies:
 import os
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 # Add parent directory to path for imports
@@ -67,50 +65,13 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_rag_engine, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestChatAuthBase(unittest.TestCase):

--- a/backend/tests/test_chat_list_sessions_user_filter.py
+++ b/backend/tests/test_chat_list_sessions_user_filter.py
@@ -8,10 +8,8 @@ Verifies FR-003 / task 1.2:
 import os
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -57,50 +55,13 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_rag_engine, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestListSessionsUserFilter(unittest.TestCase):

--- a/backend/tests/test_chat_sessions_adversarial.py
+++ b/backend/tests/test_chat_sessions_adversarial.py
@@ -13,10 +13,8 @@ These tests attempt to BREAK the user_id filter or admin bypass logic.
 import os
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -62,50 +60,13 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_rag_engine, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestAdversarialSessionSecurity(unittest.TestCase):

--- a/backend/tests/test_documents_auth.py
+++ b/backend/tests/test_documents_auth.py
@@ -9,10 +9,8 @@ import os
 import shutil
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import AsyncMock, MagicMock
 
 # Add parent directory to path for imports
@@ -64,6 +62,7 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import (
@@ -77,44 +76,6 @@ from app.api.routes.documents import _allowed_document_roots, _path_is_within
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestDocumentAuthBase(unittest.TestCase):

--- a/backend/tests/test_documents_delete_audit.py
+++ b/backend/tests/test_documents_delete_audit.py
@@ -11,10 +11,8 @@ import shutil
 import sqlite3
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import AsyncMock, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -32,50 +30,13 @@ except ImportError:
     import types
     sys.modules["pyarrow"] = types.ModuleType("pyarrow")
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except Exception:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class DocumentsDeleteAuditTestBase(unittest.TestCase):

--- a/backend/tests/test_folders_routes.py
+++ b/backend/tests/test_folders_routes.py
@@ -1,0 +1,274 @@
+"""Route coverage for the folder hierarchy endpoints.
+
+Covers CRUD, nesting, name-uniqueness, cycle prevention, document moves,
+vault-scoped cascade/unfile behavior, the /documents folder_id filter, and
+auth (401 unauthenticated, 403 wrong vault, CSRF 403). Reuses KMSFixTestBase
+for the users/vault/pool fixture (member1 has write on vault 2).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from test_kms_routes import KMSFixTestBase
+
+from app.main import app
+from app.security import csrf_protect
+
+
+class FoldersTestBase(KMSFixTestBase):
+    def setUp(self):
+        super().setUp()
+        conn = self._connection_pool.get_connection()
+        try:
+            # Vault 3: member1 has no membership (403 cases).
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (3,'No Access','x')"
+            )
+            # Two indexed files in the writable vault for move/filter tests.
+            for fid in (600, 601):
+                conn.execute(
+                    "INSERT OR IGNORE INTO files (id, vault_id, file_path, file_name, "
+                    "file_size, status) VALUES (?, 2, ?, ?, 10, 'indexed')",
+                    (fid, f"/tmp/f{fid}.txt", f"f{fid}.txt"),
+                )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def _create(self, name, parent=None, vault_id=2):
+        body = {"vault_id": vault_id, "name": name}
+        if parent is not None:
+            body["parent_folder_id"] = parent
+        return self.client.post(
+            "/api/folders", json=body, headers=self._write_headers()
+        )
+
+
+class TestFolderCrud(FoldersTestBase):
+    def test_create_root_folder(self):
+        resp = self._create("Reports")
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["name"], "Reports")
+        self.assertEqual(data["vault_id"], 2)
+        self.assertIsNone(data["parent_folder_id"])
+        self.assertEqual(data["document_count"], 0)
+
+    def test_create_subfolder(self):
+        parent = self._create("Parent").json()
+        child = self._create("Child", parent=parent["id"])
+        self.assertEqual(child.status_code, 201)
+        self.assertEqual(child.json()["parent_folder_id"], parent["id"])
+
+    def test_duplicate_name_in_same_parent_returns_409(self):
+        self._create("Dup")
+        again = self._create("Dup")
+        self.assertEqual(again.status_code, 409)
+
+    def test_same_name_in_different_parents_allowed(self):
+        a = self._create("A").json()
+        b = self._create("B").json()
+        self.assertEqual(self._create("Shared", parent=a["id"]).status_code, 201)
+        self.assertEqual(self._create("Shared", parent=b["id"]).status_code, 201)
+
+    def test_list_folders(self):
+        self._create("L1")
+        resp = self.client.get("/api/folders?vault_id=2", headers=self._write_headers())
+        self.assertEqual(resp.status_code, 200)
+        names = [f["name"] for f in resp.json()["folders"]]
+        self.assertIn("L1", names)
+
+    def test_rename_folder(self):
+        f = self._create("Old").json()
+        resp = self.client.put(
+            f"/api/folders/{f['id']}",
+            json={"name": "New"},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["name"], "New")
+
+    def test_create_with_missing_parent_returns_404(self):
+        resp = self._create("Orphan", parent=999999)
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestFolderReparentAndCycles(FoldersTestBase):
+    def test_reparent_to_root(self):
+        parent = self._create("P").json()
+        child = self._create("C", parent=parent["id"]).json()
+        resp = self.client.put(
+            f"/api/folders/{child['id']}",
+            json={"parent_folder_id": None},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.json()["parent_folder_id"])
+
+    def test_self_parent_rejected(self):
+        f = self._create("Self").json()
+        resp = self.client.put(
+            f"/api/folders/{f['id']}",
+            json={"parent_folder_id": f["id"]},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 409)
+
+    def test_descendant_cycle_rejected(self):
+        a = self._create("A").json()
+        b = self._create("B", parent=a["id"]).json()
+        # Moving A under its own child B would create a cycle.
+        resp = self.client.put(
+            f"/api/folders/{a['id']}",
+            json={"parent_folder_id": b["id"]},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 409)
+
+
+class TestFolderDeleteCascade(FoldersTestBase):
+    def test_delete_cascades_subfolders_and_unfiles_documents(self):
+        parent = self._create("Top").json()
+        child = self._create("Sub", parent=parent["id"]).json()
+        # File 600 lives in the child folder.
+        self.client.post(
+            "/api/folders/move",
+            json={"vault_id": 2, "file_ids": [600], "folder_id": child["id"]},
+            headers=self._write_headers(),
+        )
+        resp = self.client.delete(
+            f"/api/folders/{parent['id']}", headers=self._write_headers()
+        )
+        self.assertEqual(resp.status_code, 204)
+
+        # Both folders are gone, and the file is unfiled (not deleted).
+        folders = self.client.get(
+            "/api/folders?vault_id=2", headers=self._write_headers()
+        ).json()["folders"]
+        self.assertEqual(folders, [])
+
+        conn = self._connection_pool.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT folder_id FROM files WHERE id = 600"
+            ).fetchone()
+        finally:
+            self._connection_pool.release_connection(conn)
+        self.assertIsNotNone(row)
+        self.assertIsNone(row["folder_id"])
+
+
+class TestFolderMoveAndFilter(FoldersTestBase):
+    def test_move_documents_into_folder_and_filter(self):
+        folder = self._create("Filed").json()
+        move = self.client.post(
+            "/api/folders/move",
+            json={"vault_id": 2, "file_ids": [600, 601], "folder_id": folder["id"]},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(move.status_code, 200)
+        self.assertEqual(move.json()["moved"], 2)
+
+        # The /documents folder_id filter returns only the filed documents.
+        listing = self.client.get(
+            f"/api/documents?vault_id=2&folder_id={folder['id']}",
+            headers=self._write_headers(),
+        )
+        self.assertEqual(listing.status_code, 200)
+        ids = sorted(d["id"] for d in listing.json()["documents"])
+        self.assertEqual(ids, [600, 601])
+        for doc in listing.json()["documents"]:
+            self.assertEqual(doc["folder_id"], folder["id"])
+
+    def test_move_to_root_unfiles(self):
+        folder = self._create("Tmp").json()
+        self.client.post(
+            "/api/folders/move",
+            json={"vault_id": 2, "file_ids": [600], "folder_id": folder["id"]},
+            headers=self._write_headers(),
+        )
+        resp = self.client.post(
+            "/api/folders/move",
+            json={"vault_id": 2, "file_ids": [600], "folder_id": None},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        conn = self._connection_pool.get_connection()
+        try:
+            row = conn.execute("SELECT folder_id FROM files WHERE id = 600").fetchone()
+        finally:
+            self._connection_pool.release_connection(conn)
+        self.assertIsNone(row["folder_id"])
+
+    def test_move_into_other_vault_folder_returns_404(self):
+        # A folder that belongs to vault 3 cannot be a move target for vault 2.
+        conn = self._connection_pool.get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO folders (vault_id, name) VALUES (3, 'Foreign')"
+            )
+            foreign_id = cur.lastrowid
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+        resp = self.client.post(
+            "/api/folders/move",
+            json={"vault_id": 2, "file_ids": [600], "folder_id": foreign_id},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestFolderAuth(FoldersTestBase):
+    def test_unauthenticated_returns_401(self):
+        self.assertEqual(self.client.get("/api/folders?vault_id=2").status_code, 401)
+        self.assertEqual(
+            self.client.post("/api/folders", json={"vault_id": 2, "name": "x"}).status_code,
+            401,
+        )
+
+    def test_forbidden_on_inaccessible_vault(self):
+        self.assertEqual(
+            self.client.get(
+                "/api/folders?vault_id=3", headers=self._write_headers()
+            ).status_code,
+            403,
+        )
+        self.assertEqual(
+            self.client.post(
+                "/api/folders",
+                json={"vault_id": 3, "name": "Nope"},
+                headers=self._write_headers(),
+            ).status_code,
+            403,
+        )
+
+    def test_create_without_csrf_returns_403(self):
+        # Remove the CSRF bypass installed by the base fixture and install a
+        # CSRF manager so csrf_protect reaches the token check (403, not 503).
+        # Restore prior global state afterward to avoid leaking into other files.
+        prev_manager = getattr(app.state, "csrf_manager", None)
+        app.dependency_overrides.pop(csrf_protect, None)
+
+        class MockCSRFManager:
+            def validate_token(self, token):
+                return True
+
+        app.state.csrf_manager = MockCSRFManager()
+        try:
+            resp = self.client.post(
+                "/api/folders",
+                json={"vault_id": 2, "name": "NoCsrf"},
+                headers=self._write_headers(),
+                # No X-CSRF-Token header and no CSRF cookie.
+            )
+            self.assertEqual(resp.status_code, 403)
+        finally:
+            app.dependency_overrides[csrf_protect] = lambda: "test-csrf"
+            if prev_manager is None:
+                if hasattr(app.state, "csrf_manager"):
+                    delattr(app.state, "csrf_manager")
+            else:
+                app.state.csrf_manager = prev_manager

--- a/backend/tests/test_folders_routes.py
+++ b/backend/tests/test_folders_routes.py
@@ -94,6 +94,18 @@ class TestFolderCrud(FoldersTestBase):
         resp = self._create("Orphan", parent=999999)
         self.assertEqual(resp.status_code, 404)
 
+    def test_rename_to_existing_sibling_returns_409(self):
+        # F-002: PUT /folders/{id} must 409 when the new name collides with an
+        # existing sibling at the same level.
+        self._create("Alpha")
+        beta = self._create("Beta").json()
+        resp = self.client.put(
+            f"/api/folders/{beta['id']}",
+            json={"name": "Alpha"},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 409)
+
 
 class TestFolderReparentAndCycles(FoldersTestBase):
     def test_reparent_to_root(self):
@@ -123,6 +135,19 @@ class TestFolderReparentAndCycles(FoldersTestBase):
         resp = self.client.put(
             f"/api/folders/{a['id']}",
             json={"parent_folder_id": b["id"]},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 409)
+
+    def test_deep_descendant_cycle_rejected(self):
+        # F-003: Three-node chain A → B → C; moving A under C (grandchild)
+        # must also 409 — the BFS in _descendant_ids must traverse all depths.
+        a = self._create("A").json()
+        b = self._create("B", parent=a["id"]).json()
+        c = self._create("C", parent=b["id"]).json()
+        resp = self.client.put(
+            f"/api/folders/{a['id']}",
+            json={"parent_folder_id": c["id"]},
             headers=self._write_headers(),
         )
         self.assertEqual(resp.status_code, 409)

--- a/backend/tests/test_kms_routes.py
+++ b/backend/tests/test_kms_routes.py
@@ -13,10 +13,8 @@ import shutil
 import sqlite3
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -34,6 +32,7 @@ except ImportError:
     import types
     sys.modules["pyarrow"] = types.ModuleType("pyarrow")
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db
@@ -41,44 +40,6 @@ from app.config import settings
 from app.main import app
 from app.security import csrf_protect
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except Exception:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class KMSFixTestBase(unittest.TestCase):

--- a/backend/tests/test_kms_routes_crud.py
+++ b/backend/tests/test_kms_routes_crud.py
@@ -1,0 +1,239 @@
+"""Route coverage for the KMS endpoints (DD-C008).
+
+Complements test_kms_routes.py (which covers the 503 master switch, blank-slug
+422, and CSRF 403) with the previously-untested surface:
+
+- Entry CRUD happy paths (create / list / get / update / delete)
+- Search endpoint
+- Compile + recompile job creation (202) and job listing/get
+- Authentication (401 unauthenticated) and authorization (403 wrong vault)
+
+Reuses KMSFixTestBase from test_kms_routes (CSRF is bypassed there; CSRF is
+exercised separately in test_kms_routes.py).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from test_kms_routes import KMSFixTestBase
+
+from app.services.kms_store import KMSStore
+
+
+class KMSCrudBase(KMSFixTestBase):
+    """Adds a no-access vault (id=3) and an indexed file in the write vault."""
+
+    def setUp(self):
+        super().setUp()
+        conn = self._connection_pool.get_connection()
+        try:
+            # Vault 3 exists but member1 has no membership -> 403 on access.
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (3,'No Access','x')"
+            )
+            # An indexed file in the writable vault (2) for compile tests.
+            conn.execute(
+                "INSERT OR IGNORE INTO files (id, vault_id, file_path, file_name, "
+                "file_size, status) VALUES (500, 2, '/tmp/f.txt', 'f.txt', 10, 'indexed')"
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def _create_entry(self, **overrides):
+        payload = {"vault_id": 2, "title": "Hello", "body": "world body"}
+        payload.update(overrides)
+        return self.client.post(
+            "/api/kms/entries", json=payload, headers=self._write_headers()
+        )
+
+
+class TestKMSEntryCrud(KMSCrudBase):
+    def test_create_entry_returns_201_with_fields(self):
+        resp = self._create_entry(title="Runbook", tags=["ops", "oncall"])
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["title"], "Runbook")
+        self.assertEqual(data["vault_id"], 2)
+        self.assertEqual(data["source_type"], "manual")
+        self.assertIn("id", data)
+        self.assertEqual(sorted(data["tags"]), ["oncall", "ops"])
+
+    def test_list_entries_includes_created(self):
+        self._create_entry(title="Listed Entry")
+        resp = self.client.get(
+            "/api/kms/entries?vault_id=2", headers=self._write_headers()
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertGreaterEqual(data["total"], 1)
+        titles = [e["title"] for e in data["entries"]]
+        self.assertIn("Listed Entry", titles)
+
+    def test_get_entry_returns_entry_and_404_for_missing(self):
+        created = self._create_entry(title="Fetch Me").json()
+        ok = self.client.get(
+            f"/api/kms/entries/{created['id']}", headers=self._write_headers()
+        )
+        self.assertEqual(ok.status_code, 200)
+        self.assertEqual(ok.json()["title"], "Fetch Me")
+
+        missing = self.client.get(
+            "/api/kms/entries/999999", headers=self._write_headers()
+        )
+        self.assertEqual(missing.status_code, 404)
+
+    def test_update_entry_changes_fields(self):
+        created = self._create_entry(title="Before").json()
+        resp = self.client.put(
+            f"/api/kms/entries/{created['id']}",
+            json={"title": "After", "status": "published"},
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["title"], "After")
+        self.assertEqual(data["status"], "published")
+
+    def test_delete_entry_returns_204_then_404(self):
+        created = self._create_entry(title="Delete Me").json()
+        resp = self.client.delete(
+            f"/api/kms/entries/{created['id']}", headers=self._write_headers()
+        )
+        self.assertEqual(resp.status_code, 204)
+        after = self.client.get(
+            f"/api/kms/entries/{created['id']}", headers=self._write_headers()
+        )
+        self.assertEqual(after.status_code, 404)
+
+
+class TestKMSSearch(KMSCrudBase):
+    def test_search_matches_entry_body(self):
+        self._create_entry(title="Searchable", body="pineapple deployment guide")
+        resp = self.client.get(
+            "/api/kms/search?vault_id=2&q=pineapple", headers=self._write_headers()
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["query"], "pineapple")
+        titles = [e["title"] for e in data["entries"]]
+        self.assertIn("Searchable", titles)
+
+
+class TestKMSCompileJobs(KMSCrudBase):
+    def test_compile_document_creates_job(self):
+        resp = self.client.post(
+            "/api/kms/documents/500/compile?vault_id=2",
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 202)
+        data = resp.json()
+        self.assertIn("job_id", data)
+        self.assertEqual(data["status"], "pending")
+
+        # The job shows up in the vault's job list and is individually fetchable.
+        jobs = self.client.get(
+            "/api/kms/jobs?vault_id=2", headers=self._write_headers()
+        ).json()["jobs"]
+        self.assertTrue(any(j["id"] == data["job_id"] for j in jobs))
+
+        one = self.client.get(
+            f"/api/kms/jobs/{data['job_id']}?vault_id=2",
+            headers=self._write_headers(),
+        )
+        self.assertEqual(one.status_code, 200)
+        self.assertEqual(one.json()["trigger_type"], "ingest")
+
+    def test_compile_missing_file_returns_404(self):
+        resp = self.client.post(
+            "/api/kms/documents/999999/compile?vault_id=2",
+            headers=self._write_headers(),
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_recompile_vault_creates_job(self):
+        resp = self.client.post(
+            "/api/kms/recompile?vault_id=2", headers=self._write_headers()
+        )
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.json()["status"], "pending")
+
+    def test_get_missing_job_returns_404(self):
+        resp = self.client.get(
+            "/api/kms/jobs/999999?vault_id=2", headers=self._write_headers()
+        )
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestKMSAuthentication(KMSCrudBase):
+    def test_endpoints_require_authentication(self):
+        # No Authorization header -> 401 across representative endpoints.
+        self.assertEqual(self.client.get("/api/kms/entries?vault_id=2").status_code, 401)
+        self.assertEqual(
+            self.client.post("/api/kms/entries", json={"vault_id": 2, "title": "x"}).status_code,
+            401,
+        )
+        self.assertEqual(
+            self.client.get("/api/kms/search?vault_id=2&q=a").status_code, 401
+        )
+        self.assertEqual(self.client.get("/api/kms/jobs?vault_id=2").status_code, 401)
+
+
+class TestKMSAuthorization(KMSCrudBase):
+    def test_list_create_forbidden_on_inaccessible_vault(self):
+        # member1 has no access to vault 3.
+        self.assertEqual(
+            self.client.get(
+                "/api/kms/entries?vault_id=3", headers=self._write_headers()
+            ).status_code,
+            403,
+        )
+        self.assertEqual(
+            self.client.post(
+                "/api/kms/entries",
+                json={"vault_id": 3, "title": "Nope"},
+                headers=self._write_headers(),
+            ).status_code,
+            403,
+        )
+
+    def test_get_update_delete_forbidden_for_other_vault_entry(self):
+        # Seed an entry directly in vault 3, then member1 must be denied.
+        conn = self._connection_pool.get_connection()
+        try:
+            entry = KMSStore(conn).create_entry(
+                vault_id=3, title="Secret", body="b", source_type="manual"
+            )
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        self.assertEqual(
+            self.client.get(
+                f"/api/kms/entries/{entry.id}", headers=self._write_headers()
+            ).status_code,
+            403,
+        )
+        self.assertEqual(
+            self.client.put(
+                f"/api/kms/entries/{entry.id}",
+                json={"title": "hack"},
+                headers=self._write_headers(),
+            ).status_code,
+            403,
+        )
+        self.assertEqual(
+            self.client.delete(
+                f"/api/kms/entries/{entry.id}", headers=self._write_headers()
+            ).status_code,
+            403,
+        )
+
+    def test_jobs_forbidden_on_inaccessible_vault(self):
+        self.assertEqual(
+            self.client.get(
+                "/api/kms/jobs?vault_id=3", headers=self._write_headers()
+            ).status_code,
+            403,
+        )

--- a/backend/tests/test_memories_auth.py
+++ b/backend/tests/test_memories_auth.py
@@ -10,10 +10,8 @@ This test suite verifies:
 import os
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 # Add parent directory to path for imports
@@ -65,50 +63,13 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_memory_store, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token, hash_password
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestMemoriesAuthBase(unittest.TestCase):

--- a/backend/tests/test_scan_directories_auth_change.py
+++ b/backend/tests/test_scan_directories_auth_change.py
@@ -14,10 +14,8 @@ import os
 import shutil
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import AsyncMock, MagicMock
 
 # Add parent directory to path for imports
@@ -69,6 +67,7 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import (
@@ -81,44 +80,6 @@ from app.api.deps import (
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestScanDirectoriesAuthBase(unittest.TestCase):

--- a/backend/tests/test_tags_routes.py
+++ b/backend/tests/test_tags_routes.py
@@ -10,10 +10,8 @@ import shutil
 import sqlite3
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import AsyncMock, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -25,6 +23,7 @@ except ImportError:
 
     sys.modules["lancedb"] = types.ModuleType("lancedb")
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_vector_store
@@ -32,44 +31,6 @@ from app.config import settings
 from app.main import app
 from app.security import csrf_protect
 from app.services.auth_service import create_access_token
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except Exception:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TagsTestBase(unittest.TestCase):

--- a/backend/tests/test_vault_create_permission.py
+++ b/backend/tests/test_vault_create_permission.py
@@ -9,9 +9,7 @@ import os
 import sqlite3
 import sys
 import tempfile
-import threading
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -62,48 +60,11 @@ except ImportError:
 
 import unittest
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_current_active_user, get_db, get_vector_store
 from app.main import app
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 def _make_member_user_dep(user_id=42, username="member1", role="member"):

--- a/backend/tests/test_vault_document_permissions_regression.py
+++ b/backend/tests/test_vault_document_permissions_regression.py
@@ -5,56 +5,16 @@ from __future__ import annotations
 import shutil
 import sqlite3
 import tempfile
-import threading
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_current_active_user, get_db, get_vector_store
 from app.main import app
 from app.models.database import init_db, run_migrations
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path: str):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._closed = False
-        self._lock = threading.Lock()
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON")
-        return conn
-
-    def release_connection(self, conn):
-        if self._closed:
-            conn.close()
-            return
-        try:
-            self._pool.put_nowait(conn)
-        except Exception:
-            conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                self._pool.get_nowait().close()
-            except Empty:
-                break
 
 
 @pytest.fixture()

--- a/backend/tests/test_vault_list_endpoint_distinction.py
+++ b/backend/tests/test_vault_list_endpoint_distinction.py
@@ -9,10 +9,8 @@ Verifies:
 import os
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 # Add parent directory to path for imports
@@ -64,50 +62,13 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token, hash_password
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestVaultListEndpointDistinction(unittest.TestCase):

--- a/backend/tests/test_vault_transaction_fix.py
+++ b/backend/tests/test_vault_transaction_fix.py
@@ -12,10 +12,8 @@ import os
 import sqlite3
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 # Add parent directory to path for imports
@@ -78,51 +76,14 @@ def setup_test_db():
 
 setup_test_db()
 
+from _db_pool import SimpleConnectionPool
+
 from app.api.deps import (
     get_current_active_user,
     get_db,
     get_vector_store,
 )
 from app.main import app
-
-
-class SimpleConnectionPool:
-    """Connection pool for test database access."""
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestVaultTransactionBehavior(unittest.TestCase):

--- a/backend/tests/test_vaults.py
+++ b/backend/tests/test_vaults.py
@@ -6,10 +6,8 @@ import os
 import sqlite3
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock, patch
 
 # Add parent directory to path for imports
@@ -72,6 +70,8 @@ def setup_test_db():
 
 setup_test_db()
 
+from _db_pool import SimpleConnectionPool
+
 from app.api.deps import (
     get_current_active_user,
     get_db,
@@ -82,44 +82,6 @@ from app.api.deps import (
     get_vector_store,
 )
 from app.main import app
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestVaultEndpoints(unittest.TestCase):

--- a/backend/tests/test_vaults_auth.py
+++ b/backend/tests/test_vaults_auth.py
@@ -11,10 +11,8 @@ This test suite verifies:
 import os
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
-from queue import Empty, Queue
 from unittest.mock import MagicMock
 
 # Add parent directory to path for imports
@@ -66,50 +64,13 @@ except ImportError:
 
 import sqlite3
 
+from _db_pool import SimpleConnectionPool
 from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, get_vector_store
 from app.config import settings
 from app.main import app
 from app.services.auth_service import create_access_token, hash_password
-
-
-class SimpleConnectionPool:
-    def __init__(self, db_path):
-        self.db_path = db_path
-        self._pool = Queue(maxsize=5)
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def get_connection(self):
-        if self._closed:
-            raise RuntimeError("Pool closed")
-        try:
-            return self._pool.get_nowait()
-        except Empty:
-            return self._create_connection()
-
-    def _create_connection(self):
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON;")
-        return conn
-
-    def release_connection(self, conn):
-        if not self._closed:
-            try:
-                self._pool.put_nowait(conn)
-            except:
-                conn.close()
-
-    def close_all(self):
-        self._closed = True
-        while True:
-            try:
-                conn = self._pool.get_nowait()
-                conn.close()
-            except Empty:
-                break
 
 
 class TestVaultAuthBase(unittest.TestCase):

--- a/frontend/src/components/documents/FolderTree.tsx
+++ b/frontend/src/components/documents/FolderTree.tsx
@@ -3,6 +3,7 @@ import {
   ChevronRight,
   ChevronDown,
   Folder as FolderIcon,
+  FolderInput,
   FolderPlus,
   Library,
   MoreVertical,
@@ -30,6 +31,7 @@ interface FolderTreeProps {
   onCreate: (name: string, parentFolderId: number | null) => Promise<void>;
   onRename: (folderId: number, name: string) => Promise<void>;
   onDelete: (folder: Folder) => void;
+  onMove?: (folder: Folder) => void;
 }
 
 interface FolderNodeData extends Folder {
@@ -136,6 +138,7 @@ function FolderNode({
   onCreate,
   onRename,
   onDelete,
+  onMove,
 }: {
   node: FolderNodeData;
   depth: number;
@@ -151,6 +154,7 @@ function FolderNode({
   onCreate: (name: string, parentFolderId: number | null) => Promise<void>;
   onRename: (folderId: number, name: string) => Promise<void>;
   onDelete: (folder: Folder) => void;
+  onMove?: (folder: Folder) => void;
 }) {
   const hasChildren = node.children.length > 0;
   const isOpen = expanded.has(node.id);
@@ -232,6 +236,12 @@ function FolderNode({
                 <Pencil className="mr-2 h-4 w-4" />
                 Rename
               </DropdownMenuItem>
+              {onMove && (
+                <DropdownMenuItem onClick={() => onMove(node)}>
+                  <FolderInput className="mr-2 h-4 w-4" />
+                  Move to...
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 className="text-destructive focus:text-destructive"
                 onClick={() => onDelete(node)}
@@ -263,6 +273,7 @@ function FolderNode({
               onCreate={onCreate}
               onRename={onRename}
               onDelete={onDelete}
+              onMove={onMove}
             />
           ))}
           {addingChildId === node.id && (
@@ -292,6 +303,7 @@ export function FolderTree({
   onCreate,
   onRename,
   onDelete,
+  onMove,
 }: FolderTreeProps) {
   const tree = useMemo(() => buildTree(folders), [folders]);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
@@ -355,6 +367,7 @@ export function FolderTree({
           onCreate={onCreate}
           onRename={onRename}
           onDelete={onDelete}
+          onMove={onMove}
         />
       ))}
 

--- a/frontend/src/components/documents/FolderTree.tsx
+++ b/frontend/src/components/documents/FolderTree.tsx
@@ -1,0 +1,380 @@
+import { useMemo, useState } from "react";
+import {
+  ChevronRight,
+  ChevronDown,
+  Folder as FolderIcon,
+  FolderPlus,
+  Library,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  Check,
+  X,
+  Loader2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Folder } from "@/lib/api";
+
+interface FolderTreeProps {
+  folders: Folder[];
+  selectedFolderId: number | null;
+  onSelect: (folderId: number | null) => void;
+  canMutate: boolean;
+  onCreate: (name: string, parentFolderId: number | null) => Promise<void>;
+  onRename: (folderId: number, name: string) => Promise<void>;
+  onDelete: (folder: Folder) => void;
+}
+
+interface FolderNodeData extends Folder {
+  children: FolderNodeData[];
+}
+
+/** Build a parent→children tree from the flat folder list. */
+function buildTree(folders: Folder[]): FolderNodeData[] {
+  const byId = new Map<number, FolderNodeData>();
+  folders.forEach((f) => byId.set(f.id, { ...f, children: [] }));
+  const roots: FolderNodeData[] = [];
+  byId.forEach((node) => {
+    if (node.parent_folder_id != null && byId.has(node.parent_folder_id)) {
+      byId.get(node.parent_folder_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+  return roots;
+}
+
+/** Inline text field used for both creating and renaming folders. */
+function FolderNameInput({
+  initial,
+  placeholder,
+  onSubmit,
+  onCancel,
+}: {
+  initial: string;
+  placeholder: string;
+  onSubmit: (name: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+  const [saving, setSaving] = useState(false);
+
+  const submit = async () => {
+    const name = value.trim();
+    if (!name || saving) return;
+    setSaving(true);
+    try {
+      await onSubmit(name);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1 py-1">
+      <Input
+        autoFocus
+        className="h-7 text-sm"
+        placeholder={placeholder}
+        value={value}
+        disabled={saving}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            submit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        aria-label={placeholder}
+      />
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7"
+        onClick={submit}
+        disabled={saving || !value.trim()}
+        aria-label="Confirm folder name"
+      >
+        {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7"
+        onClick={onCancel}
+        disabled={saving}
+        aria-label="Cancel"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+function FolderNode({
+  node,
+  depth,
+  selectedFolderId,
+  expanded,
+  toggleExpanded,
+  onSelect,
+  canMutate,
+  renamingId,
+  setRenamingId,
+  addingChildId,
+  setAddingChildId,
+  onCreate,
+  onRename,
+  onDelete,
+}: {
+  node: FolderNodeData;
+  depth: number;
+  selectedFolderId: number | null;
+  expanded: Set<number>;
+  toggleExpanded: (id: number) => void;
+  onSelect: (folderId: number | null) => void;
+  canMutate: boolean;
+  renamingId: number | null;
+  setRenamingId: (id: number | null) => void;
+  addingChildId: number | null;
+  setAddingChildId: (id: number | null) => void;
+  onCreate: (name: string, parentFolderId: number | null) => Promise<void>;
+  onRename: (folderId: number, name: string) => Promise<void>;
+  onDelete: (folder: Folder) => void;
+}) {
+  const hasChildren = node.children.length > 0;
+  const isOpen = expanded.has(node.id);
+  const isSelected = selectedFolderId === node.id;
+
+  if (renamingId === node.id) {
+    return (
+      <div style={{ paddingLeft: depth * 16 }}>
+        <FolderNameInput
+          initial={node.name}
+          placeholder="Folder name"
+          onCancel={() => setRenamingId(null)}
+          onSubmit={async (name) => {
+            await onRename(node.id, name);
+            setRenamingId(null);
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className={`group flex items-center gap-1 rounded-md pr-1 ${
+          isSelected ? "bg-accent" : "hover:bg-accent/50"
+        }`}
+        style={{ paddingLeft: depth * 16 }}
+      >
+        <button
+          type="button"
+          className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground"
+          onClick={() => hasChildren && toggleExpanded(node.id)}
+          aria-label={hasChildren ? (isOpen ? "Collapse folder" : "Expand folder") : undefined}
+          tabIndex={hasChildren ? 0 : -1}
+        >
+          {hasChildren ? (
+            isOpen ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )
+          ) : null}
+        </button>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 py-1.5 text-left text-sm"
+          onClick={() => onSelect(node.id)}
+        >
+          <FolderIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="truncate">{node.name}</span>
+          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+            {node.document_count}
+          </span>
+        </button>
+        {canMutate && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100"
+                aria-label={`Folder actions for ${node.name}`}
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => {
+                  setAddingChildId(node.id);
+                  if (!isOpen) toggleExpanded(node.id);
+                }}
+              >
+                <FolderPlus className="mr-2 h-4 w-4" />
+                New subfolder
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setRenamingId(node.id)}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => onDelete(node)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {isOpen && (
+        <div>
+          {node.children.map((child) => (
+            <FolderNode
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              selectedFolderId={selectedFolderId}
+              expanded={expanded}
+              toggleExpanded={toggleExpanded}
+              onSelect={onSelect}
+              canMutate={canMutate}
+              renamingId={renamingId}
+              setRenamingId={setRenamingId}
+              addingChildId={addingChildId}
+              setAddingChildId={setAddingChildId}
+              onCreate={onCreate}
+              onRename={onRename}
+              onDelete={onDelete}
+            />
+          ))}
+          {addingChildId === node.id && (
+            <div style={{ paddingLeft: (depth + 1) * 16 }}>
+              <FolderNameInput
+                initial=""
+                placeholder="New subfolder name"
+                onCancel={() => setAddingChildId(null)}
+                onSubmit={async (name) => {
+                  await onCreate(name, node.id);
+                  setAddingChildId(null);
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FolderTree({
+  folders,
+  selectedFolderId,
+  onSelect,
+  canMutate,
+  onCreate,
+  onRename,
+  onDelete,
+}: FolderTreeProps) {
+  const tree = useMemo(() => buildTree(folders), [folders]);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [renamingId, setRenamingId] = useState<number | null>(null);
+  const [addingChildId, setAddingChildId] = useState<number | null>(null);
+  const [addingRoot, setAddingRoot] = useState(false);
+
+  const toggleExpanded = (id: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="w-60 shrink-0 space-y-1" aria-label="Folders">
+      <div className="flex items-center justify-between px-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Folders
+        </span>
+        {canMutate && (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-6 w-6"
+            onClick={() => setAddingRoot(true)}
+            aria-label="New folder"
+          >
+            <FolderPlus className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <button
+        type="button"
+        className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
+          selectedFolderId == null ? "bg-accent" : "hover:bg-accent/50"
+        }`}
+        onClick={() => onSelect(null)}
+      >
+        <Library className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span>All documents</span>
+      </button>
+
+      {tree.map((node) => (
+        <FolderNode
+          key={node.id}
+          node={node}
+          depth={0}
+          selectedFolderId={selectedFolderId}
+          expanded={expanded}
+          toggleExpanded={toggleExpanded}
+          onSelect={onSelect}
+          canMutate={canMutate}
+          renamingId={renamingId}
+          setRenamingId={setRenamingId}
+          addingChildId={addingChildId}
+          setAddingChildId={setAddingChildId}
+          onCreate={onCreate}
+          onRename={onRename}
+          onDelete={onDelete}
+        />
+      ))}
+
+      {addingRoot && (
+        <FolderNameInput
+          initial=""
+          placeholder="New folder name"
+          onCancel={() => setAddingRoot(false)}
+          onSubmit={async (name) => {
+            await onCreate(name, null);
+            setAddingRoot(false);
+          }}
+        />
+      )}
+
+      {tree.length === 0 && !addingRoot && (
+        <p className="px-2 py-1 text-xs text-muted-foreground">
+          {canMutate ? "No folders yet. Create one above." : "No folders yet."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/documents/MoveFolderDialog.tsx
+++ b/frontend/src/components/documents/MoveFolderDialog.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Folder as FolderIcon, Loader2 } from "lucide-react";
+import { updateFolder, type Folder } from "@/lib/api";
+
+interface MoveFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The folder being reparented. */
+  folder: Folder;
+  /** All folders in the vault (used to build the picker). */
+  folders: Folder[];
+  /** Called after a successful move so the parent can refresh its folder list. */
+  onMoved: () => void;
+}
+
+interface FolderOption {
+  id: number | null;
+  name: string;
+  depth: number;
+}
+
+/**
+ * Flatten the folder tree into a depth-ordered list for the picker,
+ * excluding the folder being moved (moving it into itself is meaningless, and
+ * deeper cycle cases are caught by the backend with a clear error toast).
+ */
+function flattenForPicker(folders: Folder[], excludeId: number): FolderOption[] {
+  const visible = folders.filter((f) => f.id !== excludeId);
+
+  const childrenByParent = new Map<number | null, Folder[]>();
+  visible.forEach((f) => {
+    const key = f.parent_folder_id ?? null;
+    const list = childrenByParent.get(key) ?? [];
+    list.push(f);
+    childrenByParent.set(key, list);
+  });
+
+  const ids = new Set(visible.map((f) => f.id));
+  const result: FolderOption[] = [];
+
+  const visit = (parentId: number | null, depth: number) => {
+    const children = (childrenByParent.get(parentId) ?? [])
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of children) {
+      result.push({ id: child.id, name: child.name, depth });
+      visit(child.id, depth + 1);
+    }
+  };
+  visit(null, 0);
+
+  // Append orphaned folders whose parent is not in the visible set.
+  visible
+    .filter((f) => f.parent_folder_id != null && !ids.has(f.parent_folder_id))
+    .forEach((f) => {
+      if (!result.some((o) => o.id === f.id)) {
+        result.push({ id: f.id, name: f.name, depth: 0 });
+      }
+    });
+
+  return result;
+}
+
+export function MoveFolderDialog({
+  open,
+  onOpenChange,
+  folder,
+  folders,
+  onMoved,
+}: MoveFolderDialogProps) {
+  // Default to the folder's current parent so the picker reflects where it already lives.
+  const [target, setTarget] = useState<number | null>(
+    folder.parent_folder_id ?? null
+  );
+  const [moving, setMoving] = useState(false);
+  const options = useMemo(
+    () => flattenForPicker(folders, folder.id),
+    [folders, folder.id]
+  );
+
+  const handleMove = async () => {
+    if (moving) return;
+    setMoving(true);
+    try {
+      await updateFolder(folder.id, { parent_folder_id: target });
+      toast.success(`Moved folder "${folder.name}"`);
+      onMoved();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to move folder");
+    } finally {
+      setMoving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move folder</DialogTitle>
+          <DialogDescription>
+            Choose a new parent for &ldquo;{folder.name}&rdquo;.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className="max-h-72 space-y-1 overflow-y-auto"
+          role="radiogroup"
+          aria-label="Target parent folder"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={target === null}
+            className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
+              target === null ? "bg-accent" : "hover:bg-accent/50"
+            }`}
+            onClick={() => setTarget(null)}
+          >
+            <FolderIcon className="h-4 w-4 text-muted-foreground" />
+            <span>No parent (root)</span>
+          </button>
+          {options.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              role="radio"
+              aria-checked={target === opt.id}
+              className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
+                target === opt.id ? "bg-accent" : "hover:bg-accent/50"
+              }`}
+              style={{ paddingLeft: 8 + opt.depth * 16 }}
+              onClick={() => setTarget(opt.id ?? null)}
+            >
+              <FolderIcon className="h-4 w-4 text-muted-foreground" />
+              <span className="truncate">{opt.name}</span>
+            </button>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleMove} disabled={moving}>
+            {moving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            Move
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/documents/MoveToFolderDialog.tsx
+++ b/frontend/src/components/documents/MoveToFolderDialog.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Folder as FolderIcon, Loader2 } from "lucide-react";
+import { moveDocumentsToFolder, type Folder } from "@/lib/api";
+
+interface MoveToFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vaultId: number;
+  selectedFileIds: number[];
+  folders: Folder[];
+  onMoved: () => void;
+}
+
+interface FolderOption {
+  id: number | null;
+  name: string;
+  depth: number;
+}
+
+/** Flatten the folder tree into a depth-ordered list for the picker. */
+function flattenForPicker(folders: Folder[]): FolderOption[] {
+  const childrenByParent = new Map<number | null, Folder[]>();
+  folders.forEach((f) => {
+    const key = f.parent_folder_id ?? null;
+    const list = childrenByParent.get(key) ?? [];
+    list.push(f);
+    childrenByParent.set(key, list);
+  });
+  // Orphans (parent not present) are treated as roots so they stay reachable.
+  const ids = new Set(folders.map((f) => f.id));
+  const result: FolderOption[] = [];
+  const visit = (parentId: number | null, depth: number) => {
+    const children = (childrenByParent.get(parentId) ?? []).slice().sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+    for (const child of children) {
+      result.push({ id: child.id, name: child.name, depth });
+      visit(child.id, depth + 1);
+    }
+  };
+  visit(null, 0);
+  // Append orphaned folders whose parent id isn't in the set.
+  folders
+    .filter((f) => f.parent_folder_id != null && !ids.has(f.parent_folder_id))
+    .forEach((f) => {
+      if (!result.some((o) => o.id === f.id)) {
+        result.push({ id: f.id, name: f.name, depth: 0 });
+      }
+    });
+  return result;
+}
+
+export function MoveToFolderDialog({
+  open,
+  onOpenChange,
+  vaultId,
+  selectedFileIds,
+  folders,
+  onMoved,
+}: MoveToFolderDialogProps) {
+  const [target, setTarget] = useState<number | null>(null);
+  const [moving, setMoving] = useState(false);
+  const options = useMemo(() => flattenForPicker(folders), [folders]);
+
+  const handleMove = async () => {
+    if (selectedFileIds.length === 0 || moving) return;
+    setMoving(true);
+    try {
+      const result = await moveDocumentsToFolder(vaultId, selectedFileIds, target);
+      toast.success(
+        `Moved ${result.moved} document${result.moved === 1 ? "" : "s"}`
+      );
+      onMoved();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to move documents");
+    } finally {
+      setMoving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move to folder</DialogTitle>
+          <DialogDescription>
+            Move {selectedFileIds.length} selected document
+            {selectedFileIds.length === 1 ? "" : "s"} into a folder.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-72 space-y-1 overflow-y-auto" role="radiogroup" aria-label="Target folder">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={target === null}
+            className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
+              target === null ? "bg-accent" : "hover:bg-accent/50"
+            }`}
+            onClick={() => setTarget(null)}
+          >
+            <FolderIcon className="h-4 w-4 text-muted-foreground" />
+            <span>No folder (root)</span>
+          </button>
+          {options.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              role="radio"
+              aria-checked={target === opt.id}
+              className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
+                target === opt.id ? "bg-accent" : "hover:bg-accent/50"
+              }`}
+              style={{ paddingLeft: 8 + opt.depth * 16 }}
+              onClick={() => setTarget(opt.id)}
+            >
+              <FolderIcon className="h-4 w-4 text-muted-foreground" />
+              <span className="truncate">{opt.name}</span>
+            </button>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleMove} disabled={moving}>
+            {moving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Move
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/documents/useDocumentPolling.ts
+++ b/frontend/src/components/documents/useDocumentPolling.ts
@@ -19,6 +19,7 @@ interface UseDocumentPollingArgs {
   sortBy: DocumentSortBy;
   sortOrder: SortOrder;
   tagFilterId: number | null;
+  folderFilterId: number | null;
   uploads: UploadFile[];
 }
 
@@ -37,6 +38,7 @@ export function useDocumentPolling({
   sortBy,
   sortOrder,
   tagFilterId,
+  folderFilterId,
   uploads,
 }: UseDocumentPollingArgs) {
   const [documents, setDocuments] = useState<Document[]>([]);
@@ -55,6 +57,7 @@ export function useDocumentPolling({
         sortBy,
         sortOrder,
         tagId: tagFilterId ?? undefined,
+        folderId: folderFilterId ?? undefined,
       });
       setDocuments(response?.documents || []);
     } catch (err) {
@@ -62,7 +65,7 @@ export function useDocumentPolling({
       toast.error(err instanceof Error ? err.message : "Failed to load documents");
       setDocuments([]);
     }
-  }, [activeVaultId, search, sortBy, sortOrder, tagFilterId]);
+  }, [activeVaultId, search, sortBy, sortOrder, tagFilterId, folderFilterId]);
 
   const fetchStats = useCallback(async () => {
     try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -537,6 +537,18 @@ export interface Document {
   enrichment_error?: string | null;
   metadata?: Record<string, unknown>;
   tags?: Tag[];
+  folder_id?: number | null;
+}
+
+export interface Folder {
+  id: number;
+  vault_id: number;
+  parent_folder_id: number | null;
+  name: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+  document_count: number;
 }
 
 export type DocumentSortBy = "created_at" | "file_name" | "file_size" | "status";
@@ -551,6 +563,7 @@ export interface ListDocumentsOptions {
   sortBy?: DocumentSortBy;
   sortOrder?: SortOrder;
   tagId?: number;
+  folderId?: number;
 }
 
 export interface ListDocumentsResponse {
@@ -956,7 +969,7 @@ export async function listMemories(vaultId?: number): Promise<{ memories: Memory
 }
 
 export async function listDocuments(options: ListDocumentsOptions = {}): Promise<ListDocumentsResponse> {
-  const { vaultId, search, status, page, perPage, sortBy, sortOrder, tagId } = options;
+  const { vaultId, search, status, page, perPage, sortBy, sortOrder, tagId, folderId } = options;
   const params: Record<string, unknown> = {};
   if (vaultId != null) params.vault_id = vaultId;
   if (search && search.trim()) params.search = search.trim();
@@ -966,6 +979,7 @@ export async function listDocuments(options: ListDocumentsOptions = {}): Promise
   if (sortBy) params.sort_by = sortBy;
   if (sortOrder) params.sort_order = sortOrder;
   if (tagId != null) params.tag_id = tagId;
+  if (folderId != null) params.folder_id = folderId;
   const response = await apiClient.get<ListDocumentsResponse>("/documents", { params });
   return response.data;
 }
@@ -1041,6 +1055,57 @@ export async function unassignTag(
   await apiClient.delete(`/tags/${tagId}/documents/${fileId}`, {
     params: { vault_id: vaultId },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Folders (document hierarchy)
+// ---------------------------------------------------------------------------
+
+export async function listFolders(vaultId: number): Promise<Folder[]> {
+  const response = await apiClient.get<{ folders: Folder[] }>("/folders", {
+    params: { vault_id: vaultId },
+  });
+  return response.data.folders;
+}
+
+export async function createFolder(
+  vaultId: number,
+  name: string,
+  parentFolderId: number | null = null,
+  description = ""
+): Promise<Folder> {
+  const response = await apiClient.post<Folder>("/folders", {
+    vault_id: vaultId,
+    name,
+    description,
+    parent_folder_id: parentFolderId,
+  });
+  return response.data;
+}
+
+export async function updateFolder(
+  folderId: number,
+  data: { name?: string; description?: string; parent_folder_id?: number | null }
+): Promise<Folder> {
+  const response = await apiClient.put<Folder>(`/folders/${folderId}`, data);
+  return response.data;
+}
+
+export async function deleteFolder(folderId: number): Promise<void> {
+  await apiClient.delete(`/folders/${folderId}`);
+}
+
+export async function moveDocumentsToFolder(
+  vaultId: number,
+  fileIds: number[],
+  folderId: number | null
+): Promise<{ moved: number }> {
+  const response = await apiClient.post<{ moved: number }>("/folders/move", {
+    vault_id: vaultId,
+    file_ids: fileIds,
+    folder_id: folderId,
+  });
+  return response.data;
 }
 
 export async function uploadDocument(

--- a/frontend/src/lib/fileIcon.test.tsx
+++ b/frontend/src/lib/fileIcon.test.tsx
@@ -21,21 +21,35 @@ describe("FileIcon", () => {
   it.each([
     ["proposal.doc", "#3b82f6"],
     ["proposal.docx", "#3b82f6"],
+    ["deck.pptx", "#f97316"],
     ["notes.md", "#14b8a6"],
     ["notes.mdx", "#14b8a6"],
     ["budget.xlsx", "#22c55e"],
     ["budget.xls", "#22c55e"],
     ["export.csv", "#22c55e"],
+    ["data.json", "#eab308"],
+    ["script.py", "#8b5cf6"],
+    ["app.js", "#8b5cf6"],
+    ["main.ts", "#8b5cf6"],
+    ["page.html", "#8b5cf6"],
+    ["style.css", "#8b5cf6"],
+    ["config.xml", "#8b5cf6"],
+    ["conf.yaml", "#8b5cf6"],
+    ["conf.yml", "#8b5cf6"],
+    ["query.sql", "#8b5cf6"],
   ])("renders the expected colored branch for %s", (filename, color) => {
     expect(renderIcon(filename)).toHaveStyle({ color });
   });
 
-  it("renders the neutral text icon branch for txt files", () => {
-    const svg = renderIcon("readme.txt");
+  it.each(["readme.txt", "server.log"])(
+    "renders the neutral text icon branch for %s",
+    (filename) => {
+      const svg = renderIcon(filename);
 
-    expect(svg).toHaveClass("lucide-file-text");
-    expect(svg.getAttribute("style") ?? "").not.toContain("color:");
-  });
+      expect(svg).toHaveClass("lucide-file-text");
+      expect(svg.getAttribute("style") ?? "").not.toContain("color:");
+    }
+  );
 
   it.each([null, undefined, "", "README", "archive.unknown"])(
     "falls back to the generic file icon for %s",

--- a/frontend/src/lib/fileIcon.tsx
+++ b/frontend/src/lib/fileIcon.tsx
@@ -1,7 +1,17 @@
-import { FileText, FileType, Sheet, File } from "lucide-react";
+import {
+  FileText,
+  FileType,
+  Sheet,
+  FileCode,
+  FileJson,
+  Presentation,
+  File,
+} from "lucide-react";
 
 /**
- * Returns a colored Lucide icon component for the given filename based on extension.
+ * Returns a colored Lucide icon component for the given filename based on
+ * extension. Covers every extension in the backend's allowed_extensions set
+ * (config.py); anything unrecognized falls back to the generic File icon.
  * Always use via JSX: <FileIcon filename={doc.filename} className="h-4 w-4" />
  */
 export function FileIcon({ filename, className }: { filename: string | null | undefined; className?: string }) {
@@ -13,13 +23,32 @@ export function FileIcon({ filename, className }: { filename: string | null | un
   if (ext === 'docx' || ext === 'doc') {
     return <FileType className={className} style={{ color: '#3b82f6' }} aria-hidden="true" />;
   }
+  if (ext === 'pptx' || ext === 'ppt') {
+    return <Presentation className={className} style={{ color: '#f97316' }} aria-hidden="true" />;
+  }
   if (ext === 'md' || ext === 'mdx') {
     return <FileText className={className} style={{ color: '#14b8a6' }} aria-hidden="true" />;
   }
   if (ext === 'xlsx' || ext === 'xls' || ext === 'csv') {
     return <Sheet className={className} style={{ color: '#22c55e' }} aria-hidden="true" />;
   }
-  if (ext === 'txt') {
+  if (ext === 'json') {
+    return <FileJson className={className} style={{ color: '#eab308' }} aria-hidden="true" />;
+  }
+  if (
+    ext === 'py' ||
+    ext === 'js' ||
+    ext === 'ts' ||
+    ext === 'html' ||
+    ext === 'css' ||
+    ext === 'xml' ||
+    ext === 'yaml' ||
+    ext === 'yml' ||
+    ext === 'sql'
+  ) {
+    return <FileCode className={className} style={{ color: '#8b5cf6' }} aria-hidden="true" />;
+  }
+  if (ext === 'txt' || ext === 'log') {
     return <FileText className={className} style={{ color: undefined }} aria-hidden="true" />;
   }
   return <File className={className} aria-hidden="true" />;

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   Trash,
   Tag as TagIcon,
+  FolderInput,
 } from "lucide-react";
 import {
   scanDocuments,
@@ -20,7 +21,12 @@ import {
   deleteAllDocumentsInVault,
   downloadDocument,
   listTags,
+  listFolders,
+  createFolder,
+  updateFolder,
+  deleteFolder,
   type Tag,
+  type Folder,
   type DocumentSortBy,
   type SortOrder,
 } from "@/lib/api";
@@ -40,6 +46,8 @@ import { DocumentTable } from "@/components/documents/DocumentTable";
 import { DocumentCardsList } from "@/components/documents/DocumentCardsList";
 import { TagFilter } from "@/components/documents/TagFilter";
 import { BulkTagDialog } from "@/components/documents/BulkTagDialog";
+import { FolderTree } from "@/components/documents/FolderTree";
+import { MoveToFolderDialog } from "@/components/documents/MoveToFolderDialog";
 import { ConfirmDialog, type ConfirmDialogState } from "@/components/documents/ConfirmDialog";
 
 const FILENAME_COL_WIDTH_KEY = "ragapp_doc_table_filename_col";
@@ -65,6 +73,11 @@ export default function DocumentsPage() {
   const [tagFilterId, setTagFilterId] = useState<number | null>(null);
   const [tags, setTags] = useState<Tag[]>([]);
   const [bulkTagOpen, setBulkTagOpen] = useState(false);
+
+  // Folder hierarchy state
+  const [folderFilterId, setFolderFilterId] = useState<number | null>(null);
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [moveFolderOpen, setMoveFolderOpen] = useState(false);
 
   // Persist the resizable filename column width across reloads.
   const [filenameColWidth, setFilenameColWidth] = useState<number>(() => {
@@ -135,6 +148,7 @@ export default function DocumentsPage() {
     sortBy,
     sortOrder,
     tagFilterId,
+    folderFilterId,
     uploads,
   });
 
@@ -168,6 +182,80 @@ export default function DocumentsPage() {
   useEffect(() => {
     setTagFilterId(null);
   }, [activeVaultId]);
+
+  // Load the vault's folders for the sidebar tree + move dialog.
+  const fetchFolders = useCallback(async () => {
+    if (activeVaultId == null) {
+      setFolders([]);
+      return;
+    }
+    try {
+      setFolders(await listFolders(activeVaultId));
+    } catch (err) {
+      console.error("Failed to load folders:", err);
+    }
+  }, [activeVaultId]);
+
+  useEffect(() => {
+    fetchFolders();
+  }, [fetchFolders]);
+
+  // Reset the folder filter when switching vaults (folder ids are vault-scoped).
+  useEffect(() => {
+    setFolderFilterId(null);
+  }, [activeVaultId]);
+
+  const handleCreateFolder = useCallback(
+    async (name: string, parentFolderId: number | null) => {
+      if (activeVaultId == null) return;
+      try {
+        await createFolder(activeVaultId, name, parentFolderId);
+        await fetchFolders();
+        toast.success(`Created folder "${name}"`);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to create folder");
+        throw err;
+      }
+    },
+    [activeVaultId, fetchFolders]
+  );
+
+  const handleRenameFolder = useCallback(
+    async (folderId: number, name: string) => {
+      try {
+        await updateFolder(folderId, { name });
+        await fetchFolders();
+        toast.success("Folder renamed");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to rename folder");
+        throw err;
+      }
+    },
+    [fetchFolders]
+  );
+
+  const handleDeleteFolder = useCallback(
+    (folder: Folder) => {
+      setConfirmDialog({
+        open: true,
+        title: "Delete Folder",
+        description: `Delete folder "${folder.name}"? Subfolders are also deleted; documents inside are moved out of the folder (not deleted).`,
+        variant: "destructive",
+        onConfirm: async () => {
+          try {
+            await deleteFolder(folder.id);
+            // If the active filter pointed at a removed folder, fall back to all.
+            setFolderFilterId((prev) => (prev === folder.id ? null : prev));
+            await Promise.all([fetchFolders(), fetchDocuments()]);
+            toast.success("Folder deleted");
+          } catch (err) {
+            toast.error(err instanceof Error ? err.message : "Failed to delete folder");
+          }
+        },
+      });
+    },
+    [fetchFolders, fetchDocuments]
+  );
 
   const handleSort = useCallback((column: DocumentSortBy) => {
     setSortBy((prevCol) => {
@@ -237,12 +325,13 @@ export default function DocumentsPage() {
         toast.error(`Failed to delete ${result.failed_ids.length} document${result.failed_ids.length > 1 ? "s" : ""}`);
       }
       clearSelection();
+      fetchFolders();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to delete documents");
     } finally {
       setIsBulkDeleting(false);
     }
-  }, [canMutateDocuments, selectedIds, setDocuments, setStats, clearSelection]);
+  }, [canMutateDocuments, selectedIds, setDocuments, setStats, clearSelection, fetchFolders]);
 
   const handleBulkDelete = useCallback(() => {
     if (selectedIds.size === 0) return;
@@ -264,13 +353,14 @@ export default function DocumentsPage() {
         toast.success(`Deleted ${result.deleted_count} document${result.deleted_count > 1 ? "s" : ""}`);
         setDocuments([]);
         setStats((prev) => (prev ? { ...prev, total_documents: 0 } : prev));
+        fetchFolders();
       }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to delete documents");
     } finally {
       setIsBulkDeletingAll(false);
     }
-  }, [activeVaultId, canMutateDocuments, setDocuments, setStats]);
+  }, [activeVaultId, canMutateDocuments, setDocuments, setStats, fetchFolders]);
 
   const handleDeleteAllInVault = useCallback(() => {
     if (!documents || documents.length === 0) return;
@@ -363,7 +453,7 @@ export default function DocumentsPage() {
           try {
             await deleteDocument(docId);
             toast.success("Document deleted successfully");
-            await Promise.all([fetchDocuments(), fetchStats()]);
+            await Promise.all([fetchDocuments(), fetchStats(), fetchFolders()]);
             setOptimisticallyDeletedIds((prev) => {
               const next = new Set(prev);
               next.delete(docId);
@@ -513,6 +603,10 @@ export default function DocumentsPage() {
                 <TagIcon className="w-4 h-4 mr-2" />
                 Tag
               </Button>
+              <Button variant="outline" size="sm" onClick={() => setMoveFolderOpen(true)}>
+                <FolderInput className="w-4 h-4 mr-2" />
+                Move
+              </Button>
               <Button variant="destructive" size="sm" onClick={handleBulkDelete} disabled={isBulkDeleting}>
                 {isBulkDeleting ? (
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
@@ -527,6 +621,19 @@ export default function DocumentsPage() {
         </div>
       </div>
 
+      <div className="flex gap-6">
+        {hasSelectedVault && (
+          <FolderTree
+            folders={folders}
+            selectedFolderId={folderFilterId}
+            onSelect={setFolderFilterId}
+            canMutate={canMutateDocuments}
+            onCreate={handleCreateFolder}
+            onRename={handleRenameFolder}
+            onDelete={handleDeleteFolder}
+          />
+        )}
+        <div className="flex-1 min-w-0">
       {loading ? (
         <DocumentsTableSkeleton />
       ) : isResolvingSearchEmptyState ? (
@@ -565,6 +672,8 @@ export default function DocumentsPage() {
           />
         </>
       )}
+        </div>
+      </div>
 
       {activeVaultId != null && (
         <BulkTagDialog
@@ -576,6 +685,21 @@ export default function DocumentsPage() {
           onTagsChanged={fetchTags}
           onAssigned={() => {
             fetchTags();
+            fetchDocuments();
+          }}
+        />
+      )}
+
+      {activeVaultId != null && (
+        <MoveToFolderDialog
+          open={moveFolderOpen}
+          onOpenChange={setMoveFolderOpen}
+          vaultId={activeVaultId}
+          selectedFileIds={selectedFileIds}
+          folders={folders}
+          onMoved={() => {
+            clearSelection();
+            fetchFolders();
             fetchDocuments();
           }}
         />

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -47,6 +47,7 @@ import { DocumentCardsList } from "@/components/documents/DocumentCardsList";
 import { TagFilter } from "@/components/documents/TagFilter";
 import { BulkTagDialog } from "@/components/documents/BulkTagDialog";
 import { FolderTree } from "@/components/documents/FolderTree";
+import { MoveFolderDialog } from "@/components/documents/MoveFolderDialog";
 import { MoveToFolderDialog } from "@/components/documents/MoveToFolderDialog";
 import { ConfirmDialog, type ConfirmDialogState } from "@/components/documents/ConfirmDialog";
 
@@ -78,6 +79,7 @@ export default function DocumentsPage() {
   const [folderFilterId, setFolderFilterId] = useState<number | null>(null);
   const [folders, setFolders] = useState<Folder[]>([]);
   const [moveFolderOpen, setMoveFolderOpen] = useState(false);
+  const [movingFolder, setMovingFolder] = useState<Folder | null>(null);
 
   // Persist the resizable filename column width across reloads.
   const [filenameColWidth, setFilenameColWidth] = useState<number>(() => {
@@ -256,6 +258,10 @@ export default function DocumentsPage() {
     },
     [fetchFolders, fetchDocuments]
   );
+
+  const handleMoveFolderTrigger = useCallback((folder: Folder) => {
+    setMovingFolder(folder);
+  }, []);
 
   const handleSort = useCallback((column: DocumentSortBy) => {
     setSortBy((prevCol) => {
@@ -631,6 +637,7 @@ export default function DocumentsPage() {
             onCreate={handleCreateFolder}
             onRename={handleRenameFolder}
             onDelete={handleDeleteFolder}
+            onMove={handleMoveFolderTrigger}
           />
         )}
         <div className="flex-1 min-w-0">
@@ -701,6 +708,22 @@ export default function DocumentsPage() {
             clearSelection();
             fetchFolders();
             fetchDocuments();
+          }}
+        />
+      )}
+
+      {movingFolder && (
+        <MoveFolderDialog
+          key={movingFolder.id}
+          open={movingFolder != null}
+          onOpenChange={(open) => {
+            if (!open) setMovingFolder(null);
+          }}
+          folder={movingFolder}
+          folders={folders}
+          onMoved={() => {
+            setMovingFolder(null);
+            fetchFolders();
           }}
         />
       )}

--- a/frontend/src/tests/folders.test.tsx
+++ b/frontend/src/tests/folders.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Folder hierarchy tests: FolderTree sidebar (tree building, selection,
  * expand/collapse, inline create) and MoveToFolderDialog (folder picker +
- * move call).
+ * move call) and MoveFolderDialog (folder reparent).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -12,12 +12,15 @@ vi.mock("sonner", () => ({
 }));
 
 const moveDocumentsToFolder = vi.fn();
+const updateFolder = vi.fn();
 vi.mock("@/lib/api", () => ({
   moveDocumentsToFolder: (...args: unknown[]) => moveDocumentsToFolder(...args),
+  updateFolder: (...args: unknown[]) => updateFolder(...args),
 }));
 
 import { FolderTree } from "@/components/documents/FolderTree";
 import { MoveToFolderDialog } from "@/components/documents/MoveToFolderDialog";
+import { MoveFolderDialog } from "@/components/documents/MoveFolderDialog";
 import type { Folder } from "@/lib/api";
 
 const folder = (id: number, name: string, parent: number | null = null): Folder => ({
@@ -123,5 +126,53 @@ describe("MoveToFolderDialog", () => {
     await waitFor(() =>
       expect(moveDocumentsToFolder).toHaveBeenCalledWith(1, [10, 11], null)
     );
+  });
+});
+
+describe("MoveFolderDialog", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const parentFolder = folder(1, "Parent");
+  const childFolder = folder(2, "Child", 1);
+
+  it("reparents a folder into a selected parent", async () => {
+    updateFolder.mockResolvedValue({ ...childFolder, parent_folder_id: null });
+    const onMoved = vi.fn();
+    // Moving "Child" — "Parent" should be available as an option.
+    render(
+      <MoveFolderDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        folder={childFolder}
+        folders={[parentFolder, childFolder]}
+        onMoved={onMoved}
+      />
+    );
+
+    // "No parent (root)" is pre-selected because childFolder.parent_folder_id is 1,
+    // not null, so the "No parent" radio is unchecked by default. We click it.
+    fireEvent.click(screen.getByRole("radio", { name: "No parent (root)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() =>
+      expect(updateFolder).toHaveBeenCalledWith(2, { parent_folder_id: null })
+    );
+    await waitFor(() => expect(onMoved).toHaveBeenCalled());
+  });
+
+  it("excludes the folder being moved from the picker options", () => {
+    render(
+      <MoveFolderDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        folder={parentFolder}
+        folders={[parentFolder, childFolder]}
+        onMoved={vi.fn()}
+      />
+    );
+    // "Parent" (id=1) is being moved, so it must not appear as an option.
+    // "Child" (id=2, child of Parent) appears as a pickable destination.
+    expect(screen.queryByRole("radio", { name: "Parent" })).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Child" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/folders.test.tsx
+++ b/frontend/src/tests/folders.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Folder hierarchy tests: FolderTree sidebar (tree building, selection,
+ * expand/collapse, inline create) and MoveToFolderDialog (folder picker +
+ * move call).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+const moveDocumentsToFolder = vi.fn();
+vi.mock("@/lib/api", () => ({
+  moveDocumentsToFolder: (...args: unknown[]) => moveDocumentsToFolder(...args),
+}));
+
+import { FolderTree } from "@/components/documents/FolderTree";
+import { MoveToFolderDialog } from "@/components/documents/MoveToFolderDialog";
+import type { Folder } from "@/lib/api";
+
+const folder = (id: number, name: string, parent: number | null = null): Folder => ({
+  id,
+  vault_id: 1,
+  parent_folder_id: parent,
+  name,
+  description: "",
+  created_at: "",
+  updated_at: "",
+  document_count: 0,
+});
+
+function renderTree(overrides: Partial<Parameters<typeof FolderTree>[0]> = {}) {
+  const props = {
+    folders: [folder(1, "Parent"), folder(2, "Child", 1), folder(3, "Sibling")],
+    selectedFolderId: null,
+    onSelect: vi.fn(),
+    canMutate: true,
+    onCreate: vi.fn().mockResolvedValue(undefined),
+    onRename: vi.fn().mockResolvedValue(undefined),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+  render(<FolderTree {...props} />);
+  return props;
+}
+
+describe("FolderTree", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders root folders and the All documents entry", () => {
+    renderTree();
+    expect(screen.getByText("All documents")).toBeInTheDocument();
+    expect(screen.getByText("Parent")).toBeInTheDocument();
+    expect(screen.getByText("Sibling")).toBeInTheDocument();
+    // Child is nested and collapsed by default.
+    expect(screen.queryByText("Child")).not.toBeInTheDocument();
+  });
+
+  it("selects a folder and the All documents entry", () => {
+    const { onSelect } = renderTree();
+    fireEvent.click(screen.getByText("Parent"));
+    expect(onSelect).toHaveBeenCalledWith(1);
+    fireEvent.click(screen.getByText("All documents"));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("expands a parent to reveal its child", () => {
+    renderTree();
+    fireEvent.click(screen.getByRole("button", { name: "Expand folder" }));
+    expect(screen.getByText("Child")).toBeInTheDocument();
+  });
+
+  it("creates a root folder via the inline input", async () => {
+    const { onCreate } = renderTree();
+    fireEvent.click(screen.getByRole("button", { name: "New folder" }));
+    const input = screen.getByLabelText("New folder name");
+    fireEvent.change(input, { target: { value: "Fresh" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(onCreate).toHaveBeenCalledWith("Fresh", null));
+  });
+
+  it("hides mutation controls when canMutate is false", () => {
+    renderTree({ canMutate: false });
+    expect(screen.queryByRole("button", { name: "New folder" })).not.toBeInTheDocument();
+  });
+});
+
+describe("MoveToFolderDialog", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const baseProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    vaultId: 1,
+    selectedFileIds: [10, 11],
+    folders: [folder(1, "Parent"), folder(2, "Child", 1)],
+    onMoved: vi.fn(),
+  };
+
+  it("moves documents into the selected folder", async () => {
+    moveDocumentsToFolder.mockResolvedValue({ moved: 2 });
+    const onMoved = vi.fn();
+    render(<MoveToFolderDialog {...baseProps} onMoved={onMoved} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Parent" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() =>
+      expect(moveDocumentsToFolder).toHaveBeenCalledWith(1, [10, 11], 1)
+    );
+    await waitFor(() => expect(onMoved).toHaveBeenCalled());
+  });
+
+  it("moves documents to root when 'No folder' is chosen", async () => {
+    moveDocumentsToFolder.mockResolvedValue({ moved: 2 });
+    render(<MoveToFolderDialog {...baseProps} />);
+
+    // Default selection is root (null); just click Move.
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() =>
+      expect(moveDocumentsToFolder).toHaveBeenCalledWith(1, [10, 11], null)
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 of the KMS/DMS feature track (issue #119). All four work items are fully implemented, tested, and wired end-to-end:

- **DD-C015 — Richer file type icons**: `fileIcon.tsx` now covers all 18 backend-allowed extensions with distinct colors/icons — pptx/ppt (Presentation, orange), json (FileJson, yellow), code files py/js/ts/html/css/xml/yaml/yml/sql (FileCode, purple), log (FileText neutral). Parameterized tests extended to match.

- **DD-C014 — Consolidate test fixtures**: Extracted a canonical `SimpleConnectionPool` into `backend/tests/_db_pool.py` (thread-safe, typed, early-exit release) and deduped 17 inline class definitions across 16 test files.

- **DD-C008 — KMS route coverage**: Added `test_kms_routes_crud.py` with 14 tests covering 401/403 auth, CRUD happy paths, search, async compile/recompile (202 status), jobs list/get, and 404 cases.

- **Folder hierarchy**: vault-scoped nested folder tree, one optional `folder_id` per document.

## Folder hierarchy detail

**Backend**
- `folder_store.py` — FolderStore: create/list/update/delete/move with BFS cycle detection, `_UNSET` sentinel distinguishing "omit reparent" from "set to root (null)", `IS NULL` uniqueness, cascade delete + SET NULL unfile, vault-scoped move guard
- `folders.py` — REST routes `GET /folders`, `POST /folders`, `PUT /folders/{id}`, `DELETE /folders/{id}`, `POST /folders/move`; CSRF on mutating endpoints; `model_fields_set` reparent detection
- `database.py` — `folders` table + indexes in SCHEMA; `folder_id` FK on `files` (`ON DELETE SET NULL`); `migrate_add_folders()` for safe legacy DB upgrade (ALTER TABLE + index via migration, not SCHEMA — avoids `no such column` on pre-existing DBs)
- `documents.py` — `folder_id` query filter, `folder_id` in all SELECT branches and `DocumentResponse`
- `main.py` — register folders router under `/api`

**Frontend**
- `FolderTree.tsx` — sidebar tree, `buildTree`, inline create/rename, expand/collapse, dropdown actions (rename/delete)
- `MoveToFolderDialog.tsx` — radio folder picker, "No folder (root)" default, calls `moveDocumentsToFolder`
- `DocumentsPage.tsx` — `fetchFolders`, `folderFilterId` state, "Move" bulk action wired to dialog, FolderTree sidebar in layout
- `api.ts` — `Folder` interface, full folder CRUD + move helpers, `folderId` filter on `listDocuments`
- `useDocumentPolling.ts` — passes `folderFilterId` through to `listDocuments`

**Tests**
- `test_folders_routes.py` — 17 backend route tests: CRUD, reparent, cycle rejection, cascade delete, document move + filter, vault isolation, 401/403 auth, CSRF
- `folders.test.tsx` — 7 frontend vitest tests for FolderTree (render, select, expand, inline create, canMutate=false) and MoveToFolderDialog (move to folder, move to root)

## Test plan

- [ ] Backend: `python -m pytest backend/tests/test_folders_routes.py backend/tests/test_kms_routes_crud.py -v`
- [ ] Frontend: `npm run test --prefix frontend` (1271 tests expected passing)
- [ ] Manual: create vault → create folders → upload docs → filter by folder → move docs between folders → delete parent folder (children cascade, files unfile)
- [ ] Legacy DB upgrade: start server against existing DB, verify `migrate_add_folders` runs cleanly (no `no such column` errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)