### PR TITLE
fix(subpath): resolve all 22 cross-review findings for subpath deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ PORT=9090
 # Root deployment:
 APP_ROOT_PATH=
 VITE_APP_BASENAME=/
-VITE_API_URL=/api
+VITE_API_URL=
+# When VITE_API_URL is empty it is derived from VITE_APP_BASENAME (e.g. /knowledgevault/api).
+# Set explicitly only for a custom API URL such as an external gateway.
 # Example for https://MEDXS.af.mil/knowledgevault/ with a prefix-stripping proxy:
 # APP_ROOT_PATH=/knowledgevault
 # VITE_APP_BASENAME=/knowledgevault

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
           VITE_APP_BASENAME: /knowledgevault
           VITE_API_URL: /knowledgevault/api
 
+      - name: Build subpath deployment (derived API URL)
+        run: npm run build
+        env:
+          VITE_APP_BASENAME: /meridian
+
   quality-contracts:
     name: Quality contracts
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ COPY frontend/package*.json ./
 RUN npm ci
 COPY frontend/ ./
 ARG VITE_APP_BASENAME=/
-ARG VITE_API_URL=/api
+ARG VITE_API_URL=
 ENV VITE_APP_BASENAME=${VITE_APP_BASENAME}
 ENV VITE_API_URL=${VITE_API_URL}
+COPY scripts/validate_vite_env.mjs /tmp/validate_vite_env.mjs
+RUN node /tmp/validate_vite_env.mjs
 RUN npm run build
 
 # Stage 2: Backend with Unstructured dependencies

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -383,7 +383,7 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_APP_BASENAME: ${VITE_APP_BASENAME:-/}
-        VITE_API_URL: ${VITE_API_URL:-/api}
+        VITE_API_URL: ${VITE_API_URL:-}
     ports:
       - "3000:3000"
     depends_on:
@@ -461,7 +461,7 @@ RUN npm ci
 COPY . .
 
 ARG VITE_APP_BASENAME=/
-ARG VITE_API_URL=/api
+ARG VITE_API_URL=
 ENV VITE_APP_BASENAME=${VITE_APP_BASENAME}
 ENV VITE_API_URL=${VITE_API_URL}
 
@@ -565,13 +565,14 @@ LOCKOUT_DURATION_MINUTES=15
 Create `frontend/.env`:
 
 ```bash
-# API URL
-VITE_API_URL=/api
+# Base path (VITE_API_URL is derived when empty — defaults to /api)
+VITE_API_URL=
 VITE_APP_BASENAME=/
 
 # For a subpath deployment behind a prefix-stripping proxy:
-# VITE_API_URL=/knowledgevault/api
 # VITE_APP_BASENAME=/knowledgevault
+# VITE_API_URL is derived from VITE_APP_BASENAME when empty (e.g. /knowledgevault/api).
+# Set VITE_API_URL explicitly only for custom API gateways.
 
 # Feature Flags
 VITE_USERS_ENABLED=true

--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -224,6 +224,7 @@ def stream_chat_response(
         return StreamingResponse(
             error_generator(),
             media_type="text/event-stream",
+            headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
         )
 
     async def event_generator():
@@ -340,6 +341,7 @@ def stream_chat_response(
     return StreamingResponse(
         event_generator(),
         media_type="text/event-stream",
+        headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,7 +45,7 @@ from app.lifespan import lifespan
 from app.limiter import limiter
 from app.middleware.logging import LoggingMiddleware
 from app.middleware.maintenance import MaintenanceMiddleware
-from app.utils.paths import normalize_root_path
+from app.utils.paths import is_unstripped_prefix, normalize_root_path
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,11 @@ app = FastAPI(
     description="Self-hosted RAG Knowledge Base API",
     root_path=normalize_root_path(settings.app_root_path),
     lifespan=lifespan,
+)
+logger.info(
+    "Subpath config: APP_ROOT_PATH=%r  root_path=%r",
+    settings.app_root_path,
+    app.root_path,
 )
 
 # Security check: warn if admin_secret_token is not set or using default value
@@ -155,11 +160,12 @@ if static_dir.exists():
         )
         logger.info(f"Static files mounted successfully from {static_dir}")
 
-        # Catch-all route for SPA client-side routing
-        # Serves index.html for any unmatched frontend routes (not API routes)
+        # ── SPA CATCH-ALL ──────────────────────────────────────
+        # Everything below this line is caught by the SPA fallback.
+        # All API routers MUST be registered ABOVE this point.
+        # ───────────────────────────────────────────────────────
         @app.get("/{full_path:path}")
         async def serve_spa(full_path: str):
-            # Return 404 for API and assets paths to avoid shadowing (case-insensitive)
             normalized_path = full_path.lower()
             if (
                 normalized_path == "api"
@@ -168,6 +174,15 @@ if static_dir.exists():
                 or normalized_path.startswith("assets/")
             ):
                 raise HTTPException(status_code=404, detail="Not found")
+            if is_unstripped_prefix(full_path, settings.app_root_path):
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        "Proxy misconfiguration: request path starts with "
+                        "APP_ROOT_PATH. Your reverse proxy must strip the "
+                        "prefix before forwarding. See deployment docs."
+                    ),
+                )
             return FileResponse(static_dir / "index.html")
 
     except Exception as e:

--- a/backend/app/utils/paths.py
+++ b/backend/app/utils/paths.py
@@ -50,3 +50,12 @@ def csrf_cookie_path(root_path: str | None = None) -> str:
 
         root_path = settings.app_root_path
     return normalize_root_path(root_path) or "/"
+
+
+def is_unstripped_prefix(full_path: str, root_path: str) -> bool:
+    """Detect if a request path still carries the external prefix (proxy misconfiguration)."""
+    prefix = normalize_root_path(root_path)
+    if not prefix:
+        return False
+    bare = prefix.lstrip("/")
+    return full_path == bare or full_path.startswith(bare + "/")

--- a/backend/tests/test_path_prefix.py
+++ b/backend/tests/test_path_prefix.py
@@ -11,6 +11,7 @@ from app.security import issue_csrf_token
 from app.utils.paths import (
     csrf_cookie_path,
     external_path,
+    is_unstripped_prefix,
     normalize_root_path,
     refresh_cookie_path,
 )
@@ -147,3 +148,92 @@ def test_backend_internal_routes_remain_unprefixed():
     assert 'app.mount(\n            "/assets"' in main_source
     assert "/knowledgevault/api" not in main_source
     assert "/knowledgevault/assets" not in main_source
+
+
+# ---------------------------------------------------------------------------
+# F-006: is_unstripped_prefix proxy guard unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsUnstrippedPrefix:
+    def test_detects_prefixed_api_path(self):
+        assert is_unstripped_prefix("meridian/api/health", "/meridian") is True
+
+    def test_detects_exact_prefix(self):
+        assert is_unstripped_prefix("meridian", "/meridian") is True
+
+    def test_ignores_api_path_without_prefix(self):
+        assert is_unstripped_prefix("api/health", "/meridian") is False
+
+    def test_ignores_frontend_route(self):
+        assert is_unstripped_prefix("chat", "/meridian") is False
+
+    def test_boundary_safe_no_partial_match(self):
+        assert is_unstripped_prefix("meridianx/foo", "/meridian") is False
+
+    def test_disabled_for_root_deploy(self):
+        assert is_unstripped_prefix("anything", "") is False
+
+    def test_multi_segment_prefix(self):
+        assert is_unstripped_prefix("apps/meridian/api", "/apps/meridian") is True
+
+    def test_multi_segment_no_match(self):
+        assert is_unstripped_prefix("apps/other/api", "/apps/meridian") is False
+
+
+# ---------------------------------------------------------------------------
+# F-005: delete_cookie must use refresh_cookie_path() helper
+# ---------------------------------------------------------------------------
+
+
+def test_delete_cookie_uses_refresh_cookie_path():
+    """delete_cookie must use the same path helper so the browser actually clears it."""
+    import re
+
+    auth_source = Path("app/api/routes/auth.py").read_text(encoding="utf-8")
+    # No hardcoded refresh cookie paths — all must use the helper
+    assert 'path="/api/auth/refresh"' not in auth_source
+    # Verify delete_cookie calls exist and use the helper
+    delete_calls = re.findall(r"delete_cookie\([^)]*\)", auth_source)
+    assert len(delete_calls) > 0, "Expected at least one delete_cookie call"
+    for call in delete_calls:
+        if "refresh" in call.lower() or "path=" in call:
+            assert "refresh_cookie_path()" in call, (
+                f"delete_cookie uses hardcoded path: {call}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# N-3: StreamingResponse must include X-Accel-Buffering for nginx proxies
+# ---------------------------------------------------------------------------
+
+
+def test_chat_streaming_responses_have_proxy_headers():
+    """All StreamingResponse in chat.py must include X-Accel-Buffering for nginx."""
+    import re
+
+    chat_source = Path("app/api/routes/chat.py").read_text(encoding="utf-8")
+    # Match StreamingResponse(...) including nested parens like error_generator()
+    streaming_blocks = re.findall(
+        r"StreamingResponse\((?:[^()]*\([^()]*\)[^()]*)*[^()]*\)",
+        chat_source,
+        re.DOTALL,
+    )
+    assert len(streaming_blocks) >= 2, (
+        f"Expected >=2 StreamingResponse calls, found {len(streaming_blocks)}"
+    )
+    for block in streaming_blocks:
+        assert "X-Accel-Buffering" in block, (
+            f"StreamingResponse missing X-Accel-Buffering header: {block[:80]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F-006: SPA catch-all must call the proxy guard
+# ---------------------------------------------------------------------------
+
+
+def test_spa_catchall_calls_proxy_guard():
+    """SPA catch-all must check for unstripped proxy prefix."""
+    main_source = Path("app/main.py").read_text(encoding="utf-8")
+    assert "is_unstripped_prefix" in main_source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_APP_BASENAME: ${VITE_APP_BASENAME:-/}
-        VITE_API_URL: ${VITE_API_URL:-/api}
+        VITE_API_URL: ${VITE_API_URL:-}
     container_name: knowledgevault
     restart: unless-stopped
     ports:

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -577,17 +577,60 @@ server {
 }
 ```
 
-For a subpath deployment such as `https://MEDXS.af.mil/knowledgevault/`, build and run with:
+#### Subpath Deployment
+
+For a subpath deployment such as `https://example.com/knowledgevault/`, configure these variables and rebuild the Docker image:
+
+| Variable | Type | Purpose |
+|----------|------|---------|
+| `APP_ROOT_PATH` | Runtime env | Cookie paths and OpenAPI docs (backend) |
+| `VITE_APP_BASENAME` | Build arg | Frontend base path and asset URLs |
+| `VITE_API_URL` | Build arg (optional) | API URL override. Derived from `VITE_APP_BASENAME` when empty |
+| `BACKEND_CORS_ORIGINS` | Runtime env | Allowed CORS origins for your domain |
+| `FORWARDED_ALLOW_IPS` | Runtime env | Trusted proxy IPs for forwarded headers |
+
+**Minimal configuration** (`.env` or environment):
 
 ```env
 APP_ROOT_PATH=/knowledgevault
 VITE_APP_BASENAME=/knowledgevault
-VITE_API_URL=/knowledgevault/api
-BACKEND_CORS_ORIGINS=https://MEDXS.af.mil
-FORWARDED_ALLOW_IPS=127.0.0.1
+BACKEND_CORS_ORIGINS=https://example.com
+FORWARDED_ALLOW_IPS=*
 ```
 
-Use a prefix-stripping proxy. The browser sees `/knowledgevault/...`; the container still receives unprefixed internal routes like `/api`, `/assets`, and `/health`.
+`VITE_API_URL` is automatically derived as `/knowledgevault/api` when left empty. To set it explicitly (e.g., for a custom API gateway), add it to your config:
+
+```env
+VITE_API_URL=/knowledgevault/api
+```
+
+**Rebuild and restart** after changing build args:
+
+```bash
+docker compose build --no-cache
+docker compose up -d
+```
+
+> **Important:** `VITE_APP_BASENAME` and `VITE_API_URL` are baked into the JavaScript bundle at Docker build time. Changing them at runtime has no effect — you must rebuild the image.
+
+##### Changing the Prefix
+
+To change from `/knowledgevault` to `/meridian` (or any path, including multi-segment like `/apps/meridian`):
+
+1. Update `.env`:
+   ```env
+   APP_ROOT_PATH=/meridian
+   VITE_APP_BASENAME=/meridian
+   ```
+2. Update your reverse proxy config to strip `/meridian` instead of `/knowledgevault`.
+3. Rebuild: `docker compose build --no-cache`
+4. Restart: `docker compose up -d`
+
+##### Reverse Proxy Configuration
+
+The reverse proxy **must strip the prefix** before forwarding to the container. The backend receives bare paths (`/api`, `/assets`, `/health`).
+
+**NGINX:**
 
 ```nginx
 location = /knowledgevault {
@@ -607,6 +650,40 @@ location /knowledgevault/ {
     proxy_read_timeout 3600;
 }
 ```
+
+**Caddy:**
+
+```caddyfile
+handle_path /knowledgevault/* {
+    reverse_proxy knowledgevault:9090
+}
+```
+
+> `handle_path` strips the prefix automatically. No additional rewrite configuration is needed.
+
+##### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Failed to load module script: MIME type "text/html"` | Docker image built without `VITE_APP_BASENAME` | Rebuild with `--build-arg VITE_APP_BASENAME=/yourprefix` |
+| 404 with "Proxy misconfiguration" message | Reverse proxy not stripping prefix | Add trailing `/` to `proxy_pass` (nginx) or use `handle_path` (Caddy) |
+| SSE/streaming appears in bursts | nginx buffering enabled | Add `proxy_buffering off;` to nginx location block |
+| Login/auth failures after prefix change | `APP_ROOT_PATH` doesn't match `VITE_APP_BASENAME` | Ensure both use the same prefix value |
+| Blank page, no console errors | `VITE_APP_BASENAME` set but image not rebuilt | Run `docker compose build --no-cache` |
+
+##### Deployment Compatibility Matrix
+
+| Frontend Build | Backend Config | Proxy | Result |
+|---------------|---------------|-------|--------|
+| Root (default) | Root | None | Works |
+| Prefixed | Prefixed (matching) | Stripping | Works |
+| Root | Prefixed | Stripping | Assets 404 — rebuild frontend |
+| Prefixed | Root | Stripping | Cookie/auth failures |
+| Prefixed | Prefixed | Non-stripping | MIME errors, 404 diagnostic |
+
+##### Multi-Instance Deployments
+
+Multiple KnowledgeVault instances can share a domain using distinct prefixes (e.g., `/team-a` and `/team-b`). Cookies are scoped to each prefix path, preventing unintentional cross-instance interference. However, path-scoped cookies are not a strong security boundary — for actual tenant isolation, use separate domains.
 
 **Option 3: VPN/Private Network**
 - Deploy behind corporate VPN

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -666,7 +666,7 @@ handle_path /knowledgevault/* {
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `Failed to load module script: MIME type "text/html"` | Docker image built without `VITE_APP_BASENAME` | Rebuild with `--build-arg VITE_APP_BASENAME=/yourprefix` |
-| 404 with "Proxy misconfiguration" message | Reverse proxy not stripping prefix | Add trailing `/` to `proxy_pass` (nginx) or use `handle_path` (Caddy) |
+| 404 with "Proxy misconfiguration" message | Reverse proxy not stripping prefix | Add trailing `/` to `proxy_pass` (nginx) or use `handle_path` (Caddy). Note: the detection is case-sensitive — `APP_ROOT_PATH` must exactly match the casing of the path forwarded by the proxy. |
 | SSE/streaming appears in bursts | nginx buffering enabled | Add `proxy_buffering off;` to nginx location block |
 | Login/auth failures after prefix change | `APP_ROOT_PATH` doesn't match `VITE_APP_BASENAME` | Ensure both use the same prefix value |
 | Blank page, no console errors | `VITE_APP_BASENAME` set but image not rebuilt | Run `docker compose build --no-cache` |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,26 @@
+# KnowledgeVault Frontend Build-Time Configuration
+# These values are baked into the JavaScript bundle at build time.
+# Changing them requires rebuilding the Docker image.
+
+# ---------- Root deployment (default) ----------
+# VITE_APP_BASENAME=/
+# VITE_API_URL=
+# (VITE_API_URL is derived from VITE_APP_BASENAME when empty — defaults to /api)
+
+# ---------- Subpath deployment ----------
+# To deploy at https://example.com/meridian/:
+# VITE_APP_BASENAME=/meridian
+# VITE_API_URL=
+# (automatically derives /meridian/api)
+
+# To explicitly set the API URL (e.g., external API gateway):
+# VITE_APP_BASENAME=/meridian
+# VITE_API_URL=https://api.example.com/v1
+
+# ---------- Changing prefix ----------
+# To change from /knowledgevault to /meridian:
+# 1. Set VITE_APP_BASENAME=/meridian (frontend build arg)
+# 2. Set APP_ROOT_PATH=/meridian (backend runtime env)
+# 3. Update reverse proxy to strip /meridian
+# 4. Rebuild Docker image: docker compose build --no-cache
+# 5. Restart: docker compose up -d

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,8 +20,13 @@ RUN node -e " \
   var v = process.env.VITE_APP_BASENAME || ''; \
   if (v && v !== '/') { \
     if (v !== v.trim()) throw new Error('VITE_APP_BASENAME: leading/trailing whitespace'); \
-    if (/^https?:\\/\\//i.test(v)) throw new Error('VITE_APP_BASENAME: must be path not URL'); \
+    if (/^https?:\\/\\//i.test(v) || (v.startsWith('//') && /[^\\/]/.test(v))) throw new Error('VITE_APP_BASENAME: must be a path not a URL'); \
     if (/[\\s;\\\\?#]/.test(v)) throw new Error('VITE_APP_BASENAME: unsafe characters'); \
+    var hasCtrl = Array.from(v).some(function(c) { var n = c.charCodeAt(0); return n < 32 || n === 127; }); \
+    if (hasCtrl) throw new Error('VITE_APP_BASENAME: contains control characters'); \
+    var inner = v.replace(/^\\/+|\\/+\$/g, ''); \
+    if (/\\/{2,}/.test(inner)) throw new Error('VITE_APP_BASENAME: duplicate slashes'); \
+    if (inner.split('/').some(function(p) { return p === '.' || p === '..'; })) throw new Error('VITE_APP_BASENAME: relative path segments not allowed'); \
   } \
   console.log('validate: VITE_APP_BASENAME=' + (v || '(root)') + ' OK'); \
   "

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,10 +12,19 @@ RUN npm ci
 COPY . .
 
 ARG VITE_APP_BASENAME=/
-ARG VITE_API_URL=/api
+ARG VITE_API_URL=
 ENV VITE_APP_BASENAME=${VITE_APP_BASENAME}
 ENV VITE_API_URL=${VITE_API_URL}
 
+RUN node -e " \
+  var v = process.env.VITE_APP_BASENAME || ''; \
+  if (v && v !== '/') { \
+    if (v !== v.trim()) throw new Error('VITE_APP_BASENAME: leading/trailing whitespace'); \
+    if (/^https?:\\/\\//i.test(v)) throw new Error('VITE_APP_BASENAME: must be path not URL'); \
+    if (/[\\s;\\\\?#]/.test(v)) throw new Error('VITE_APP_BASENAME: unsafe characters'); \
+  } \
+  console.log('validate: VITE_APP_BASENAME=' + (v || '(root)') + ' OK'); \
+  "
 RUN npm run build
 
 # Final stage

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,8 @@ import axios, { AxiosRequestHeaders } from "axios";
 import { setChatHistory as storageSetChatHistory, getChatHistory as storageGetChatHistory } from "./storage";
 import { appPath } from "./paths";
 
-export const API_BASE_URL = import.meta.env.VITE_API_URL || "/api";
+export const API_BASE_URL = import.meta.env.VITE_API_URL || appPath("/api");
+console.info("[KnowledgeVault] API_BASE_URL:", API_BASE_URL);
 
 // Module-level JWT token holder - persisted via useAuthStore persist middleware
 let _jwtAccessToken: string | null = null;

--- a/frontend/src/lib/normalize-base-path.ts
+++ b/frontend/src/lib/normalize-base-path.ts
@@ -1,0 +1,32 @@
+const UNSAFE_BASE_PATH_PATTERN = /[\s;\\?#]/;
+
+function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((char) => {
+    const code = char.charCodeAt(0);
+    return code < 32 || code === 127;
+  });
+}
+
+export function normalizeBasePath(value?: string | null): string {
+  const raw = value ?? "";
+  if (!raw) return "";
+  if (raw !== raw.trim()) {
+    throw new Error("Base path cannot contain leading or trailing whitespace");
+  }
+  if (/^https?:\/\//i.test(raw) || (raw.startsWith("//") && /[^/]/.test(raw))) {
+    throw new Error("Base path must be a path, not a URL");
+  }
+  if (UNSAFE_BASE_PATH_PATTERN.test(raw) || hasControlCharacter(raw)) {
+    throw new Error("Base path contains unsafe characters");
+  }
+  if (/\/{2,}/.test(raw.replace(/^\/+|\/+$/g, ""))) {
+    throw new Error("Base path cannot contain duplicate slashes");
+  }
+
+  const stripped = raw.replace(/^\/+|\/+$/g, "");
+  if (!stripped) return "";
+  if (stripped.split("/").some((part) => part === "." || part === "..")) {
+    throw new Error("Base path cannot contain relative path segments");
+  }
+  return `/${stripped}`;
+}

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -1,35 +1,6 @@
-const UNSAFE_BASE_PATH_PATTERN = /[\s;\\?#]/;
+import { normalizeBasePath } from "./normalize-base-path";
 
-function hasControlCharacter(value: string): boolean {
-  return Array.from(value).some((char) => {
-    const code = char.charCodeAt(0);
-    return code < 32 || code === 127;
-  });
-}
-
-export function normalizeBasePath(value?: string | null): string {
-  const raw = value ?? "";
-  if (!raw) return "";
-  if (raw !== raw.trim()) {
-    throw new Error("Base path cannot contain leading or trailing whitespace");
-  }
-  if (/^https?:\/\//i.test(raw) || (raw.startsWith("//") && /[^/]/.test(raw))) {
-    throw new Error("Base path must be a path, not a URL");
-  }
-  if (UNSAFE_BASE_PATH_PATTERN.test(raw) || hasControlCharacter(raw)) {
-    throw new Error("Base path contains unsafe characters");
-  }
-  if (/\/{2,}/.test(raw.replace(/^\/+|\/+$/g, ""))) {
-    throw new Error("Base path cannot contain duplicate slashes");
-  }
-
-  const stripped = raw.replace(/^\/+|\/+$/g, "");
-  if (!stripped) return "";
-  if (stripped.split("/").some((part) => part === "." || part === "..")) {
-    throw new Error("Base path cannot contain relative path segments");
-  }
-  return `/${stripped}`;
-}
+export { normalizeBasePath };
 
 export const APP_BASENAME = normalizeBasePath(
   import.meta.env.VITE_APP_BASENAME || import.meta.env.BASE_URL || "/"
@@ -41,4 +12,24 @@ export function appPath(path: string, basename = APP_BASENAME): string {
   if (!base) return suffix;
   if (suffix === "/") return `${base}/`;
   return `${base}${suffix}`;
+}
+
+export function logSubpathConfig(): void {
+  const viteAppBasename = import.meta.env.VITE_APP_BASENAME ?? "(not set)";
+  const viteApiUrl = import.meta.env.VITE_API_URL ?? "(not set)";
+  const baseUrl = import.meta.env.BASE_URL ?? "(not set)";
+
+  console.info(
+    "[KnowledgeVault] Subpath config:\n" +
+      `  VITE_APP_BASENAME = ${JSON.stringify(viteAppBasename)}\n` +
+      `  VITE_API_URL      = ${JSON.stringify(viteApiUrl)}${!import.meta.env.VITE_API_URL ? "  (derived)" : ""}\n` +
+      `  BASE_URL          = ${JSON.stringify(baseUrl)}\n` +
+      `  APP_BASENAME      = ${JSON.stringify(APP_BASENAME)}`
+  );
+
+  if (import.meta.env.VITE_APP_BASENAME && !import.meta.env.VITE_API_URL) {
+    console.info(
+      "[KnowledgeVault] VITE_API_URL not set — derived from VITE_APP_BASENAME"
+    );
+  }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,8 +6,11 @@ import App from './App.tsx'
 import './index.css'
 // Initialize theme from persisted preference before first paint
 import { useThemeStore } from '@/stores/useThemeStore'
+import { logSubpathConfig } from './lib/paths'
 
 const queryClient = new QueryClient()
+
+logSubpathConfig();
 
 // ThemedToaster keeps sonner's color scheme aligned with our user-overridable
 // theme toggle. We pass "system" through directly so OS-level preference

--- a/frontend/src/vite-config.test.ts
+++ b/frontend/src/vite-config.test.ts
@@ -26,8 +26,10 @@ describe("Vite subpath configuration helpers", () => {
     expect(createApiProxyPath("")).toBe("/api");
     expect(createApiProxyPath("/knowledgevault")).toBe("/knowledgevault/api");
     expect(Object.keys(createApiProxy(""))).toEqual(["/api"]);
+    // When a prefix is set, only the prefixed proxy is created (no bare /api).
+    // This enforces dev/prod parity: bare /api requests fail in dev the same
+    // way they fail in production behind the prefix-stripping proxy.
     expect(Object.keys(createApiProxy("/knowledgevault"))).toEqual([
-      "/api",
       "/knowledgevault/api",
     ]);
   });

--- a/frontend/vite.paths.ts
+++ b/frontend/vite.paths.ts
@@ -1,4 +1,6 @@
-const API_PROXY_TARGET = 'http://localhost:9090'
+// normalizeBasePath is duplicated here because vite.config.ts runs under
+// tsconfig.node.json which cannot import from src/ without composite conflicts.
+// Keep in sync with src/lib/normalize-base-path.ts.
 const UNSAFE_BASE_PATH_PATTERN = /[\s;\\?#]/
 
 function hasControlCharacter(value: string): boolean {
@@ -6,12 +8,6 @@ function hasControlCharacter(value: string): boolean {
     const code = char.charCodeAt(0)
     return code < 32 || code === 127
   })
-}
-
-export interface ApiProxyOptions {
-  target: string
-  changeOrigin: boolean
-  rewrite: (requestPath: string) => string
 }
 
 export function normalizeBasePath(value?: string | null): string {
@@ -36,6 +32,14 @@ export function normalizeBasePath(value?: string | null): string {
     throw new Error('Base path cannot contain relative path segments')
   }
   return `/${stripped}`
+}
+
+const API_PROXY_TARGET = 'http://localhost:9090'
+
+export interface ApiProxyOptions {
+  target: string
+  changeOrigin: boolean
+  rewrite: (requestPath: string) => string
 }
 
 export function normalizeViteBase(value?: string | null): string {
@@ -69,7 +73,6 @@ export function createApiProxy(basename: string): Record<string, ApiProxyOptions
   }
 
   return {
-    '/api': rootProxy,
     [createApiProxyPath(base)]: {
       target: API_PROXY_TARGET,
       changeOrigin: true,

--- a/scripts/check_config_contract.py
+++ b/scripts/check_config_contract.py
@@ -107,14 +107,14 @@ def main() -> int:
         failures.append(".env.example APP_ROOT_PATH should default to empty root path")
     if env_value(env_text, "VITE_APP_BASENAME") != "/":
         failures.append(".env.example VITE_APP_BASENAME should default to /")
-    if env_value(env_text, "VITE_API_URL") != "/api":
-        failures.append(".env.example VITE_API_URL should default to /api")
+    if env_value(env_text, "VITE_API_URL") != "":
+        failures.append(".env.example VITE_API_URL should default to empty (derived from VITE_APP_BASENAME)")
     if compose_default(compose_text, "APP_ROOT_PATH") != "":
         failures.append("docker-compose.yml APP_ROOT_PATH should default to empty")
     if compose_default(compose_text, "VITE_APP_BASENAME") != "/":
         failures.append("docker-compose.yml VITE_APP_BASENAME should default to /")
-    if compose_default(compose_text, "VITE_API_URL") != "/api":
-        failures.append("docker-compose.yml VITE_API_URL should default to /api")
+    if compose_default(compose_text, "VITE_API_URL") != "":
+        failures.append("docker-compose.yml VITE_API_URL should default to empty (derived from VITE_APP_BASENAME)")
 
     prefix_example = [
         "APP_ROOT_PATH=/knowledgevault",
@@ -132,15 +132,15 @@ def main() -> int:
     ]:
         for token in [
             "ARG VITE_APP_BASENAME=/",
-            "ARG VITE_API_URL=/api",
+            "ARG VITE_API_URL=",
             "ENV VITE_APP_BASENAME=${VITE_APP_BASENAME}",
             "ENV VITE_API_URL=${VITE_API_URL}",
         ]:
             if token not in dockerfile_text:
                 failures.append(f"{dockerfile_name} is missing {token}")
 
-    if 'import.meta.env.VITE_API_URL || "/api"' not in frontend_api:
-        failures.append("frontend API default no longer matches VITE_API_URL=/api")
+    if 'import.meta.env.VITE_API_URL || appPath("/api")' not in frontend_api:
+        failures.append("frontend API default no longer derives from appPath when VITE_API_URL is empty")
     if "VITE_APP_BASENAME" not in frontend_paths or "BASE_URL" not in frontend_paths:
         failures.append("frontend path helper no longer reads VITE_APP_BASENAME/BASE_URL")
     if "normalizeViteBase(appBasename)" not in vite_config:

--- a/scripts/validate_vite_env.mjs
+++ b/scripts/validate_vite_env.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Validate VITE_APP_BASENAME before the Vite build.
+ * Mirrors the rules in frontend/src/lib/normalize-base-path.ts.
+ * Exits 0 if valid or empty, exits 1 with a clear error if invalid.
+ */
+
+const value = process.env.VITE_APP_BASENAME ?? '';
+
+function validate(raw) {
+  if (!raw || raw === '/') return;
+  if (raw !== raw.trim()) {
+    throw new Error('VITE_APP_BASENAME cannot contain leading or trailing whitespace');
+  }
+  if (/^https?:\/\//i.test(raw) || (raw.startsWith('//') && /[^/]/.test(raw))) {
+    throw new Error('VITE_APP_BASENAME must be a path, not a URL');
+  }
+  if (/[\s;\\?#]/.test(raw) || hasControlCharacter(raw)) {
+    throw new Error('VITE_APP_BASENAME contains unsafe characters');
+  }
+  const inner = raw.replace(/^\/+|\/+$/g, '');
+  if (/\/{2,}/.test(inner)) {
+    throw new Error('VITE_APP_BASENAME cannot contain duplicate slashes');
+  }
+  if (inner && inner.split('/').some(p => p === '.' || p === '..')) {
+    throw new Error('VITE_APP_BASENAME cannot contain relative path segments');
+  }
+}
+
+function hasControlCharacter(s) {
+  for (const ch of s) {
+    const code = ch.charCodeAt(0);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+try {
+  validate(value);
+  const display = value || '(empty — root deployment)';
+  console.log(`validate_vite_env: VITE_APP_BASENAME=${display} OK`);
+} catch (err) {
+  console.error(`validate_vite_env: FATAL: ${err.message}`);
+  console.error('Fix VITE_APP_BASENAME and rebuild.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Resolves every finding from issue #133 — the comprehensive cross-review tracker for subpath/reverse-proxy deployment support (22 findings from 8 independent reviewers + GPT 5.5 analysis).

### Core Fixes
- **F-002**: `VITE_API_URL` now derived from `VITE_APP_BASENAME` when empty — operators only need to set `VITE_APP_BASENAME` and `APP_ROOT_PATH`. Docker/Compose defaults changed from `/api` to empty so the derivation actually fires in production.
- **F-001**: SPA catch-all detects non-stripping proxy misconfiguration and returns a 404 with actionable diagnostic message instead of silently serving `index.html` (which causes the MIME type errors seen in production).
- **N-3**: `X-Accel-Buffering: no` headers added to chat streaming responses for nginx proxy compatibility.
- **F-009**: `normalizeBasePath` extracted to shared module to reduce duplication risk.
- **N-6**: Dev proxy removes bare `/api` entry when prefix is set, enforcing dev/prod parity.

### New Files
- `frontend/.env.example` — Documents build-time env vars with root/subpath examples
- `frontend/src/lib/normalize-base-path.ts` — Shared path normalization module
- `scripts/validate_vite_env.mjs` — Build-time `VITE_APP_BASENAME` validation (fails fast on invalid values)

### Tests & CI
- 11 new backend tests covering proxy guard, cookie paths, streaming headers
- CI: new "derived API URL" build step testing `VITE_APP_BASENAME` without `VITE_API_URL`
- Contract script updated atomically with code changes

### Documentation
- Comprehensive subpath guide: variable reference table, prefix-change walkthrough, Caddy example, troubleshooting table, deployment compatibility matrix
- Frontend/backend diagnostic logging for production debugging

### Findings Confirmed Already Correct
- N-1 (CSRF cookie path scoping) — already returns prefix for prefixed deploys
- N-2 (startup validator parity) — already delegates to `normalize_root_path()`
- `proxy_buffering off` docs — already present in admin-guide.md

Closes #133

## Test plan
- [x] Config contract script passes
- [x] Backend ruff lint passes
- [x] Backend tests: 66 passed (test_path_prefix.py, test_auth_routes.py, test_main_catchall.py)
- [x] Frontend typecheck passes
- [x] Frontend lint passes (0 warnings)
- [x] Frontend CI smoke tests: 52 passed
- [x] Frontend build succeeds
- [x] Independent reviewer APPROVED (VERDICT: APPROVED, RISK: LOW)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)