### PR TITLE
docs(skills): capture subpath deployment lessons as permanent agent skills

### DIFF
--- a/.agents/skills/config-env-contract-check/SKILL.md
+++ b/.agents/skills/config-env-contract-check/SKILL.md
@@ -23,6 +23,8 @@ Check these files when present:
 - `frontend/vite.config.ts`
 - `frontend/vite.paths.ts`
 - `frontend/src/stores/useSettingsStore.ts`
+- `scripts/check_config_contract.py` ← CI contract enforcer; must be updated atomically with env var defaults
+- `scripts/validate_vite_env.mjs` ← Build-time frontend env validator; must stay in sync with inline Dockerfile validation
 - `README.md`
 - `INSTALLATION.md`
 - `docs/admin-guide.md`
@@ -37,6 +39,26 @@ Check these files when present:
 - Security-sensitive placeholders are documented and rejected or validated by runtime config.
 - Docs examples match the actual env names consumed by code.
 - Tests cover parser edge cases for new config formats.
+
+## Atomicity rule for env var default changes
+
+When changing a default value for any env var that appears across the deployment
+stack, all of the following surfaces MUST be updated in the same commit:
+
+1. `.env.example` — example/documentation value
+2. `docker-compose.yml` — Compose default
+3. `Dockerfile` (root) — build-stage default
+4. `frontend/Dockerfile` — frontend build-stage default
+5. `scripts/check_config_contract.py` — CI contract assertion
+
+Missing any one of these causes `scripts/check_config_contract.py` to fail in
+CI with a mismatch error that is hard to diagnose without knowing all five
+surfaces must agree. The script itself is part of the contract, not just an
+observer of it.
+
+Additionally: the inline validation in `frontend/Dockerfile` and the standalone
+`scripts/validate_vite_env.mjs` must implement identical validation rules.
+If you add or relax a check in one, update the other.
 
 ## Automation
 

--- a/.agents/skills/engineering-conventions/SKILL.md
+++ b/.agents/skills/engineering-conventions/SKILL.md
@@ -32,4 +32,9 @@ file you are editing over anything summarized here.
 - Three agent runners, three skill trees (`.claude/`, `.agents/`, `.opencode/`). Mirror repo-specific skills across all three, or keep them thin pointers to canonical docs.
 - Before push/PR: run `ci-compatibility-audit`. For tests: `writing-tests` / `docs/engineering/testing.md`. For commits/PRs: `commit-pr`.
 
+**TypeScript tsconfig boundary (Vite context)**
+- `tsconfig.node.json` covers only `vite.config.ts`. `tsconfig.json` covers `src/` and references `tsconfig.node.json` as a composite project.
+- Do NOT add files from `src/` to `tsconfig.node.json`'s `include` array and do NOT import `src/` files from `vite.config.ts` or `vite.paths.ts`. Doing so produces `Output file has not been built from source file` — a TypeScript composite conflict because both tsconfigs would include the same file.
+- When logic must be shared between `vite.paths.ts` and `src/lib/`, keep two copies with cross-reference comments. The subpath deployment helpers (`normalizeBasePath`) follow this pattern: canonical source in `src/lib/normalize-base-path.ts`, inline duplicate in `vite.paths.ts`.
+
 See `docs/engineering/conventions.md` for the full detail and file references.

--- a/.agents/skills/subpath-deployment/SKILL.md
+++ b/.agents/skills/subpath-deployment/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: subpath-deployment
+description: >
+  RAGAPPv3 subpath/reverse-proxy deployment system. Load before touching
+  anything related to APP_ROOT_PATH, VITE_APP_BASENAME, VITE_API_URL, cookie
+  paths, SPA catch-all routing, proxy configuration, or Docker build args for
+  the frontend. Contains locked architectural decisions that must not be
+  re-litigated.
+---
+
+# RAGAPPv3 Subpath Deployment
+
+## Why this skill exists
+
+The subpath deployment system has non-obvious constraints. Agents who have not
+read this file have proposed runtime header detection, root-path routing,
+hardcoded `/api` fallbacks, and TypeScript import shortcuts that create composite
+project conflicts. Read this before implementing anything in this area.
+
+---
+
+## Locked architectural decisions
+
+These were validated by 8 independent reviewers and must not be revisited:
+
+### 1. Prefix-stripping proxy only
+
+The reverse proxy strips the external prefix before forwarding. The backend
+receives bare paths (`/api/`, `/assets/`, `/`). This is the only supported model.
+
+```nginx
+# NGINX — trailing slash on proxy_pass triggers stripping
+location /meridian/ {
+    proxy_pass http://backend:9090/;
+}
+```
+
+```caddyfile
+# Caddy — handle_path strips by design
+handle_path /meridian/* {
+    reverse_proxy backend:9090
+}
+```
+
+The backend does NOT receive `/meridian/api/...`. If it does, that is a proxy
+misconfiguration — the `is_unstripped_prefix()` guard in the SPA catch-all
+returns 404 with a diagnostic message for exactly this case.
+
+### 2. Backend is prefix-agnostic
+
+All API routers use `prefix="/api"`. Static files mount at `/assets`. The SPA
+catch-all handles `/{full_path:path}`. `APP_ROOT_PATH` is used ONLY for:
+- cookie `Path` values (so the browser sends them on prefixed URLs)
+- FastAPI `root_path` (for OpenAPI docs URL generation)
+
+`APP_ROOT_PATH` is NEVER used for routing.
+
+### 3. Frontend prefix is baked at Docker build time
+
+`VITE_APP_BASENAME` and `VITE_API_URL` are Docker build args consumed by
+`npm run build`. Vite replaces `import.meta.env.*` at build time. A root-built
+image CANNOT be fixed at runtime. Rebuild the image when the prefix changes.
+
+### 4. No runtime `X-Forwarded-Prefix` detection
+
+The frontend must know its prefix at build time. `X-Forwarded-Prefix` is not
+a primary mechanism and is not wired. Do not add it.
+
+### 5. Cookie `Path` must match the browser-visible (prefixed) URL
+
+The browser matches cookie `Path` against the URL bar path, not the backend
+internal path. A refresh cookie scoped to `Path=/api/auth/refresh` will NOT be
+sent on requests to `/meridian/api/auth/refresh`. All `set_cookie` and
+`delete_cookie` calls must use `refresh_cookie_path()` and `csrf_cookie_path()`.
+
+---
+
+## The three-variable contract
+
+| Variable | Where set | When consumed | Purpose |
+|---|---|---|---|
+| `APP_ROOT_PATH` | Backend runtime env | App startup | Cookie paths, FastAPI root_path, startup log |
+| `VITE_APP_BASENAME` | Docker build arg → ENV | `npm run build` | Vite `base`, BrowserRouter `basename`, `appPath()` default |
+| `VITE_API_URL` | Docker build arg → ENV (optional) | `npm run build` | API base URL; defaults to `appPath("/api")` when empty |
+
+`VITE_API_URL` is intentionally optional. When omitted, `api.ts` derives it
+from `appPath("/api")`, which uses `VITE_APP_BASENAME`. Setting `VITE_API_URL`
+explicitly overrides this (e.g., for an external gateway).
+
+**Critical Docker default:** Both `Dockerfile` and `docker-compose.yml` must
+default `VITE_API_URL` to empty string (`ARG VITE_API_URL=` / `VITE_API_URL: ${VITE_API_URL:-}`).
+If it defaults to `/api`, the `appPath` derivation never fires and subpath
+deployments silently break — the exact bug this system was built to fix.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `backend/app/utils/paths.py` | `normalize_root_path()`, `refresh_cookie_path()`, `csrf_cookie_path()`, `is_unstripped_prefix()` |
+| `backend/app/config.py` | `app_root_path` field + `validate_app_root_path` validator (delegates to `normalize_root_path`) |
+| `backend/app/main.py` | FastAPI `root_path=`, startup log, SPA catch-all with proxy guard |
+| `frontend/src/lib/normalize-base-path.ts` | Shared `normalizeBasePath()` used by `paths.ts` |
+| `frontend/src/lib/paths.ts` | `APP_BASENAME`, `appPath()`, `logSubpathConfig()` |
+| `frontend/src/lib/api.ts` | `API_BASE_URL = VITE_API_URL \|\| appPath("/api")` |
+| `frontend/vite.paths.ts` | `normalizeViteBase()`, `createApiProxy()`, `rewriteApiProxyPath()` |
+| `frontend/vite.config.ts` | Sets Vite `base`, dev proxy |
+| `scripts/validate_vite_env.mjs` | Build-time validation of `VITE_APP_BASENAME` |
+| `scripts/check_config_contract.py` | CI contract check across all config surfaces |
+| `frontend/.env.example` | Documents build-time env vars |
+| `docs/admin-guide.md` | Full operator reference, prefix-change walkthrough, NGINX/Caddy examples |
+
+---
+
+## TypeScript tsconfig boundary constraint
+
+`vite.config.ts` runs under `tsconfig.node.json`. `tsconfig.node.json` includes
+ONLY `vite.config.ts`. Files in `src/` are covered by `tsconfig.json`, which
+references `tsconfig.node.json` (composite project).
+
+**You cannot import from `src/` in `vite.config.ts` or `vite.paths.ts`.**
+Doing so causes: `Output file has not been built from source file` (TypeScript
+composite project conflict) because both tsconfigs would include the same file.
+
+The solution: `vite.paths.ts` keeps its own inline copy of `normalizeBasePath`
+with a cross-reference comment pointing to `src/lib/normalize-base-path.ts`.
+If you change the normalization logic, update BOTH files.
+
+---
+
+## `is_unstripped_prefix()` behavior
+
+```python
+# backend/app/utils/paths.py
+def is_unstripped_prefix(full_path: str, root_path: str) -> bool:
+```
+
+- Returns `True` when `full_path` still carries the external prefix
+  (indicates proxy did not strip it)
+- Boundary-safe: `"meridianx/foo"` does NOT match `/meridian`
+- Case-sensitive — `/Meridian/api` does not match `/meridian`
+- Called in the SPA catch-all to return 404 with diagnostic instead of
+  serving `index.html`
+
+---
+
+## Dev proxy parity (N-6)
+
+When `VITE_APP_BASENAME` is set, `createApiProxy()` returns ONLY the prefixed
+entry (e.g., `/knowledgevault/api`). It does NOT also return `/api`. This
+forces developers to use the prefix in dev, matching production behavior and
+catching prefix bugs during development rather than at deploy time.
+
+---
+
+## Changing the prefix
+
+To change from `/knowledgevault` to `/meridian`:
+
+1. Rebuild the frontend Docker image:
+   ```
+   docker build --build-arg VITE_APP_BASENAME=/meridian [--build-arg VITE_API_URL=/meridian/api] -t ragapp-frontend .
+   ```
+2. Update backend env: `APP_ROOT_PATH=/meridian`
+3. Update the reverse proxy to strip `/meridian/` instead of `/knowledgevault/`
+4. Update `CORS_ORIGINS` if the origin changes
+
+No code changes are required. See `docs/admin-guide.md` for full walkthrough.
+
+---
+
+## Streaming endpoint requirement
+
+All `StreamingResponse` instances in chat and wiki routes must include:
+```python
+headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
+```
+Without this, NGINX's default `proxy_buffering on` batches chunks and breaks
+the streaming UX. See deployment docs for the corresponding NGINX directives.
+
+---
+
+## Contract atomicity rule
+
+When changing any env var default across this system, all of these must be
+updated in the same commit:
+- `.env.example`
+- `docker-compose.yml`
+- `Dockerfile` (root)
+- `frontend/Dockerfile`
+- `scripts/check_config_contract.py`
+
+Missing any one surface fails the CI contract gate with an error that is hard
+to diagnose without knowing which surface was missed.

--- a/.agents/skills/swarm/SKILL.md
+++ b/.agents/skills/swarm/SKILL.md
@@ -224,6 +224,12 @@ After enabling swarm mode, immediately execute `$ARGUMENTS` using this swarm-lik
 3. Create a scoped plan.
 4. Implement in coherent units.
 5. Run objective verification.
+   **Behavioral-change test trap:** When a change intentionally modifies behavior
+   (not just adds it), search for pre-existing tests that assert the OLD behavior
+   before pushing. These tests will fail CI even when the change is correct.
+   Update them with a comment explaining why the old assertion is superseded.
+   The ci-compatibility-audit local run catches the failure, but the root cause
+   (a test asserting stale behavior) is easy to misread as a regression.
 6. Use independent reviewer validation where risk justifies it.
 7. Use critic challenge only for high-impact or still-ambiguous results.
 8. Summarize what changed, what was verified, and what risks remain.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -583,6 +583,31 @@ Fix automatically where possible:
 ruff check --fix backend/tests/test_vaults.py
 ```
 
+## Source-inspection test pattern (RAGAPPv3)
+
+Some backend tests open Python source files as strings and regex-match for
+structural invariants — e.g., "every `StreamingResponse` call must include
+`X-Accel-Buffering`", or "every route file exports a `router` object". This
+pattern appears in `backend/tests/test_path_prefix.py` and similar files.
+
+**When to use it:**
+- Enforcing cross-cutting structural invariants that are hard to exercise
+  behaviorally (e.g., "all streaming responses must set a header").
+- Checking that boilerplate or security-sensitive patterns are not omitted.
+- When a behavioral test would require an integration setup disproportionate
+  to the risk being tested.
+
+**When NOT to use it:**
+- As a substitute for behavioral tests when a behavioral test is straightforward.
+- For logic correctness — source inspection cannot catch a header present but
+  set to the wrong value.
+- Where refactoring (e.g., renaming a function) would silently break the test
+  without breaking production behavior.
+
+**Tradeoff:** Fast and easy to write; fragile to non-behavioral refactoring.
+Always prefer behavioral unit tests when practical. When using source
+inspection, add a comment explaining why a behavioral test is not used.
+
 ## Debugging CI Python Test Failures
 
 1. **Check if the failure is pre-existing**: Run the same test on `master` first. If it fails there too, it's not introduced by your branch.

--- a/.claude/skills/config-env-contract-check/SKILL.md
+++ b/.claude/skills/config-env-contract-check/SKILL.md
@@ -23,6 +23,8 @@ Check these files when present:
 - `frontend/vite.config.ts`
 - `frontend/vite.paths.ts`
 - `frontend/src/stores/useSettingsStore.ts`
+- `scripts/check_config_contract.py` ← CI contract enforcer; must be updated atomically with env var defaults
+- `scripts/validate_vite_env.mjs` ← Build-time frontend env validator; must stay in sync with inline Dockerfile validation
 - `README.md`
 - `INSTALLATION.md`
 - `docs/admin-guide.md`
@@ -37,6 +39,26 @@ Check these files when present:
 - Security-sensitive placeholders are documented and rejected or validated by runtime config.
 - Docs examples match the actual env names consumed by code.
 - Tests cover parser edge cases for new config formats.
+
+## Atomicity rule for env var default changes
+
+When changing a default value for any env var that appears across the deployment
+stack, all of the following surfaces MUST be updated in the same commit:
+
+1. `.env.example` — example/documentation value
+2. `docker-compose.yml` — Compose default
+3. `Dockerfile` (root) — build-stage default
+4. `frontend/Dockerfile` — frontend build-stage default
+5. `scripts/check_config_contract.py` — CI contract assertion
+
+Missing any one of these causes `scripts/check_config_contract.py` to fail in
+CI with a mismatch error that is hard to diagnose without knowing all five
+surfaces must agree. The script itself is part of the contract, not just an
+observer of it.
+
+Additionally: the inline validation in `frontend/Dockerfile` and the standalone
+`scripts/validate_vite_env.mjs` must implement identical validation rules.
+If you add or relax a check in one, update the other.
 
 ## Automation
 

--- a/.claude/skills/engineering-conventions/SKILL.md
+++ b/.claude/skills/engineering-conventions/SKILL.md
@@ -32,4 +32,9 @@ file you are editing over anything summarized here.
 - Three agent runners, three skill trees (`.claude/`, `.agents/`, `.opencode/`). Mirror repo-specific skills across all three, or keep them thin pointers to canonical docs.
 - Before push/PR: run `ci-compatibility-audit`. For tests: `writing-tests` / `docs/engineering/testing.md`. For commits/PRs: `commit-pr`.
 
+**TypeScript tsconfig boundary (Vite context)**
+- `tsconfig.node.json` covers only `vite.config.ts`. `tsconfig.json` covers `src/` and references `tsconfig.node.json` as a composite project.
+- Do NOT add files from `src/` to `tsconfig.node.json`'s `include` array and do NOT import `src/` files from `vite.config.ts` or `vite.paths.ts`. Doing so produces `Output file has not been built from source file` — a TypeScript composite conflict because both tsconfigs would include the same file.
+- When logic must be shared between `vite.paths.ts` and `src/lib/`, keep two copies with cross-reference comments. The subpath deployment helpers (`normalizeBasePath`) follow this pattern: canonical source in `src/lib/normalize-base-path.ts`, inline duplicate in `vite.paths.ts`.
+
 See `docs/engineering/conventions.md` for the full detail and file references.

--- a/.claude/skills/subpath-deployment/SKILL.md
+++ b/.claude/skills/subpath-deployment/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: subpath-deployment
+description: >
+  RAGAPPv3 subpath/reverse-proxy deployment system. Load before touching
+  anything related to APP_ROOT_PATH, VITE_APP_BASENAME, VITE_API_URL, cookie
+  paths, SPA catch-all routing, proxy configuration, or Docker build args for
+  the frontend. Contains locked architectural decisions that must not be
+  re-litigated.
+---
+
+# RAGAPPv3 Subpath Deployment
+
+## Why this skill exists
+
+The subpath deployment system has non-obvious constraints. Agents who have not
+read this file have proposed runtime header detection, root-path routing,
+hardcoded `/api` fallbacks, and TypeScript import shortcuts that create composite
+project conflicts. Read this before implementing anything in this area.
+
+---
+
+## Locked architectural decisions
+
+These were validated by 8 independent reviewers and must not be revisited:
+
+### 1. Prefix-stripping proxy only
+
+The reverse proxy strips the external prefix before forwarding. The backend
+receives bare paths (`/api/`, `/assets/`, `/`). This is the only supported model.
+
+```nginx
+# NGINX — trailing slash on proxy_pass triggers stripping
+location /meridian/ {
+    proxy_pass http://backend:9090/;
+}
+```
+
+```caddyfile
+# Caddy — handle_path strips by design
+handle_path /meridian/* {
+    reverse_proxy backend:9090
+}
+```
+
+The backend does NOT receive `/meridian/api/...`. If it does, that is a proxy
+misconfiguration — the `is_unstripped_prefix()` guard in the SPA catch-all
+returns 404 with a diagnostic message for exactly this case.
+
+### 2. Backend is prefix-agnostic
+
+All API routers use `prefix="/api"`. Static files mount at `/assets`. The SPA
+catch-all handles `/{full_path:path}`. `APP_ROOT_PATH` is used ONLY for:
+- cookie `Path` values (so the browser sends them on prefixed URLs)
+- FastAPI `root_path` (for OpenAPI docs URL generation)
+
+`APP_ROOT_PATH` is NEVER used for routing.
+
+### 3. Frontend prefix is baked at Docker build time
+
+`VITE_APP_BASENAME` and `VITE_API_URL` are Docker build args consumed by
+`npm run build`. Vite replaces `import.meta.env.*` at build time. A root-built
+image CANNOT be fixed at runtime. Rebuild the image when the prefix changes.
+
+### 4. No runtime `X-Forwarded-Prefix` detection
+
+The frontend must know its prefix at build time. `X-Forwarded-Prefix` is not
+a primary mechanism and is not wired. Do not add it.
+
+### 5. Cookie `Path` must match the browser-visible (prefixed) URL
+
+The browser matches cookie `Path` against the URL bar path, not the backend
+internal path. A refresh cookie scoped to `Path=/api/auth/refresh` will NOT be
+sent on requests to `/meridian/api/auth/refresh`. All `set_cookie` and
+`delete_cookie` calls must use `refresh_cookie_path()` and `csrf_cookie_path()`.
+
+---
+
+## The three-variable contract
+
+| Variable | Where set | When consumed | Purpose |
+|---|---|---|---|
+| `APP_ROOT_PATH` | Backend runtime env | App startup | Cookie paths, FastAPI root_path, startup log |
+| `VITE_APP_BASENAME` | Docker build arg → ENV | `npm run build` | Vite `base`, BrowserRouter `basename`, `appPath()` default |
+| `VITE_API_URL` | Docker build arg → ENV (optional) | `npm run build` | API base URL; defaults to `appPath("/api")` when empty |
+
+`VITE_API_URL` is intentionally optional. When omitted, `api.ts` derives it
+from `appPath("/api")`, which uses `VITE_APP_BASENAME`. Setting `VITE_API_URL`
+explicitly overrides this (e.g., for an external gateway).
+
+**Critical Docker default:** Both `Dockerfile` and `docker-compose.yml` must
+default `VITE_API_URL` to empty string (`ARG VITE_API_URL=` / `VITE_API_URL: ${VITE_API_URL:-}`).
+If it defaults to `/api`, the `appPath` derivation never fires and subpath
+deployments silently break — the exact bug this system was built to fix.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `backend/app/utils/paths.py` | `normalize_root_path()`, `refresh_cookie_path()`, `csrf_cookie_path()`, `is_unstripped_prefix()` |
+| `backend/app/config.py` | `app_root_path` field + `validate_app_root_path` validator (delegates to `normalize_root_path`) |
+| `backend/app/main.py` | FastAPI `root_path=`, startup log, SPA catch-all with proxy guard |
+| `frontend/src/lib/normalize-base-path.ts` | Shared `normalizeBasePath()` used by `paths.ts` |
+| `frontend/src/lib/paths.ts` | `APP_BASENAME`, `appPath()`, `logSubpathConfig()` |
+| `frontend/src/lib/api.ts` | `API_BASE_URL = VITE_API_URL \|\| appPath("/api")` |
+| `frontend/vite.paths.ts` | `normalizeViteBase()`, `createApiProxy()`, `rewriteApiProxyPath()` |
+| `frontend/vite.config.ts` | Sets Vite `base`, dev proxy |
+| `scripts/validate_vite_env.mjs` | Build-time validation of `VITE_APP_BASENAME` |
+| `scripts/check_config_contract.py` | CI contract check across all config surfaces |
+| `frontend/.env.example` | Documents build-time env vars |
+| `docs/admin-guide.md` | Full operator reference, prefix-change walkthrough, NGINX/Caddy examples |
+
+---
+
+## TypeScript tsconfig boundary constraint
+
+`vite.config.ts` runs under `tsconfig.node.json`. `tsconfig.node.json` includes
+ONLY `vite.config.ts`. Files in `src/` are covered by `tsconfig.json`, which
+references `tsconfig.node.json` (composite project).
+
+**You cannot import from `src/` in `vite.config.ts` or `vite.paths.ts`.**
+Doing so causes: `Output file has not been built from source file` (TypeScript
+composite project conflict) because both tsconfigs would include the same file.
+
+The solution: `vite.paths.ts` keeps its own inline copy of `normalizeBasePath`
+with a cross-reference comment pointing to `src/lib/normalize-base-path.ts`.
+If you change the normalization logic, update BOTH files.
+
+---
+
+## `is_unstripped_prefix()` behavior
+
+```python
+# backend/app/utils/paths.py
+def is_unstripped_prefix(full_path: str, root_path: str) -> bool:
+```
+
+- Returns `True` when `full_path` still carries the external prefix
+  (indicates proxy did not strip it)
+- Boundary-safe: `"meridianx/foo"` does NOT match `/meridian`
+- Case-sensitive — `/Meridian/api` does not match `/meridian`
+- Called in the SPA catch-all to return 404 with diagnostic instead of
+  serving `index.html`
+
+---
+
+## Dev proxy parity (N-6)
+
+When `VITE_APP_BASENAME` is set, `createApiProxy()` returns ONLY the prefixed
+entry (e.g., `/knowledgevault/api`). It does NOT also return `/api`. This
+forces developers to use the prefix in dev, matching production behavior and
+catching prefix bugs during development rather than at deploy time.
+
+---
+
+## Changing the prefix
+
+To change from `/knowledgevault` to `/meridian`:
+
+1. Rebuild the frontend Docker image:
+   ```
+   docker build --build-arg VITE_APP_BASENAME=/meridian [--build-arg VITE_API_URL=/meridian/api] -t ragapp-frontend .
+   ```
+2. Update backend env: `APP_ROOT_PATH=/meridian`
+3. Update the reverse proxy to strip `/meridian/` instead of `/knowledgevault/`
+4. Update `CORS_ORIGINS` if the origin changes
+
+No code changes are required. See `docs/admin-guide.md` for full walkthrough.
+
+---
+
+## Streaming endpoint requirement
+
+All `StreamingResponse` instances in chat and wiki routes must include:
+```python
+headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
+```
+Without this, NGINX's default `proxy_buffering on` batches chunks and breaks
+the streaming UX. See deployment docs for the corresponding NGINX directives.
+
+---
+
+## Contract atomicity rule
+
+When changing any env var default across this system, all of these must be
+updated in the same commit:
+- `.env.example`
+- `docker-compose.yml`
+- `Dockerfile` (root)
+- `frontend/Dockerfile`
+- `scripts/check_config_contract.py`
+
+Missing any one surface fails the CI contract gate with an error that is hard
+to diagnose without knowing which surface was missed.

--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -166,6 +166,12 @@ After enabling swarm mode, immediately execute `$ARGUMENTS` using this swarm-lik
    frontend typecheck/lint/test/build, quality-contract scripts) are green
    locally first — a CI-only lint or type failure costs a full push → fail →
    fixup-commit round trip.
+   **Behavioral-change test trap:** When a change intentionally modifies behavior
+   (not just adds it), search for pre-existing tests that assert the OLD behavior
+   before pushing. These tests will fail CI even when the change is correct.
+   Update them with a comment explaining why the old assertion is superseded.
+   The ci-compatibility-audit local run catches the failure, but the root cause
+   (a test asserting stale behavior) is easy to misread as a regression.
 6. Use independent reviewer validation where risk justifies it.
 7. Use critic challenge only for high-impact or still-ambiguous results.
 8. Summarize what changed, what was verified, and what risks remain.

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -35,6 +35,31 @@ The authoritative testing policy and conventions live in
 - Config in `frontend/vite.config.ts`; `*.test.tsx`; `src/test/setup.ts` mocks `localStorage`/`confirm`/`scrollTo`.
 - jsdom mock patterns (full snippets in `ci-compatibility-audit/references/frontend-testing-gotchas.md`): wrap `<Link>` components in `MemoryRouter`; mock `@/components/ui/select` (Radix can't open in jsdom); mock `@tanstack/react-virtual`'s `useVirtualizer` to render all rows; `vi.mock` factories can't close over outer vars (`await import("react")`).
 
+## Source-inspection test pattern
+
+Some backend tests open Python source files as strings and regex-match for
+structural invariants — e.g., "every `StreamingResponse` call must include
+`X-Accel-Buffering`", or "every route file exports a `router` object". This
+pattern appears in `backend/tests/test_path_prefix.py` and similar files.
+
+**When to use it:**
+- Enforcing cross-cutting structural invariants that are hard to exercise
+  behaviorally (e.g., "all streaming responses must set a header").
+- Checking that boilerplate or security-sensitive patterns are not omitted.
+- When a behavioral test would require an integration setup disproportionate
+  to the risk being tested.
+
+**When NOT to use it:**
+- As a substitute for behavioral tests when a behavioral test is straightforward.
+- For logic correctness — source inspection cannot catch a header present but
+  set to the wrong value.
+- Where refactoring (e.g., renaming a function) would silently break the test
+  without breaking production behavior.
+
+**Tradeoff:** Fast and easy to write; fragile to non-behavioral refactoring.
+Always prefer behavioral unit tests when practical. When using source
+inspection, add a comment explaining why a behavioral test is not used.
+
 ## Running
 
 CI runs only a *narrow* backend pytest subset — also run your changed area's tests locally (`pytest -q tests/<file>`). Use `ci-compatibility-audit` for the exact CI-mirror commands before pushing.

--- a/.opencode/skills/engineering-conventions/SKILL.md
+++ b/.opencode/skills/engineering-conventions/SKILL.md
@@ -32,4 +32,9 @@ file you are editing over anything summarized here.
 - Three agent runners, three skill trees (`.claude/`, `.agents/`, `.opencode/`). Mirror repo-specific skills across all three, or keep them thin pointers to canonical docs.
 - Before push/PR: run `ci-compatibility-audit`. For tests: `writing-tests` / `docs/engineering/testing.md`. For commits/PRs: `commit-pr`.
 
+**TypeScript tsconfig boundary (Vite context)**
+- `tsconfig.node.json` covers only `vite.config.ts`. `tsconfig.json` covers `src/` and references `tsconfig.node.json` as a composite project.
+- Do NOT add files from `src/` to `tsconfig.node.json`'s `include` array and do NOT import `src/` files from `vite.config.ts` or `vite.paths.ts`. Doing so produces `Output file has not been built from source file` — a TypeScript composite conflict because both tsconfigs would include the same file.
+- When logic must be shared between `vite.paths.ts` and `src/lib/`, keep two copies with cross-reference comments. The subpath deployment helpers (`normalizeBasePath`) follow this pattern: canonical source in `src/lib/normalize-base-path.ts`, inline duplicate in `vite.paths.ts`.
+
 See `docs/engineering/conventions.md` for the full detail and file references.

--- a/.opencode/skills/subpath-deployment/SKILL.md
+++ b/.opencode/skills/subpath-deployment/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: subpath-deployment
+description: >
+  RAGAPPv3 subpath/reverse-proxy deployment system. Load before touching
+  anything related to APP_ROOT_PATH, VITE_APP_BASENAME, VITE_API_URL, cookie
+  paths, SPA catch-all routing, proxy configuration, or Docker build args for
+  the frontend. Contains locked architectural decisions that must not be
+  re-litigated.
+---
+
+# RAGAPPv3 Subpath Deployment
+
+## Why this skill exists
+
+The subpath deployment system has non-obvious constraints. Agents who have not
+read this file have proposed runtime header detection, root-path routing,
+hardcoded `/api` fallbacks, and TypeScript import shortcuts that create composite
+project conflicts. Read this before implementing anything in this area.
+
+---
+
+## Locked architectural decisions
+
+These were validated by 8 independent reviewers and must not be revisited:
+
+### 1. Prefix-stripping proxy only
+
+The reverse proxy strips the external prefix before forwarding. The backend
+receives bare paths (`/api/`, `/assets/`, `/`). This is the only supported model.
+
+```nginx
+# NGINX — trailing slash on proxy_pass triggers stripping
+location /meridian/ {
+    proxy_pass http://backend:9090/;
+}
+```
+
+```caddyfile
+# Caddy — handle_path strips by design
+handle_path /meridian/* {
+    reverse_proxy backend:9090
+}
+```
+
+The backend does NOT receive `/meridian/api/...`. If it does, that is a proxy
+misconfiguration — the `is_unstripped_prefix()` guard in the SPA catch-all
+returns 404 with a diagnostic message for exactly this case.
+
+### 2. Backend is prefix-agnostic
+
+All API routers use `prefix="/api"`. Static files mount at `/assets`. The SPA
+catch-all handles `/{full_path:path}`. `APP_ROOT_PATH` is used ONLY for:
+- cookie `Path` values (so the browser sends them on prefixed URLs)
+- FastAPI `root_path` (for OpenAPI docs URL generation)
+
+`APP_ROOT_PATH` is NEVER used for routing.
+
+### 3. Frontend prefix is baked at Docker build time
+
+`VITE_APP_BASENAME` and `VITE_API_URL` are Docker build args consumed by
+`npm run build`. Vite replaces `import.meta.env.*` at build time. A root-built
+image CANNOT be fixed at runtime. Rebuild the image when the prefix changes.
+
+### 4. No runtime `X-Forwarded-Prefix` detection
+
+The frontend must know its prefix at build time. `X-Forwarded-Prefix` is not
+a primary mechanism and is not wired. Do not add it.
+
+### 5. Cookie `Path` must match the browser-visible (prefixed) URL
+
+The browser matches cookie `Path` against the URL bar path, not the backend
+internal path. A refresh cookie scoped to `Path=/api/auth/refresh` will NOT be
+sent on requests to `/meridian/api/auth/refresh`. All `set_cookie` and
+`delete_cookie` calls must use `refresh_cookie_path()` and `csrf_cookie_path()`.
+
+---
+
+## The three-variable contract
+
+| Variable | Where set | When consumed | Purpose |
+|---|---|---|---|
+| `APP_ROOT_PATH` | Backend runtime env | App startup | Cookie paths, FastAPI root_path, startup log |
+| `VITE_APP_BASENAME` | Docker build arg → ENV | `npm run build` | Vite `base`, BrowserRouter `basename`, `appPath()` default |
+| `VITE_API_URL` | Docker build arg → ENV (optional) | `npm run build` | API base URL; defaults to `appPath("/api")` when empty |
+
+`VITE_API_URL` is intentionally optional. When omitted, `api.ts` derives it
+from `appPath("/api")`, which uses `VITE_APP_BASENAME`. Setting `VITE_API_URL`
+explicitly overrides this (e.g., for an external gateway).
+
+**Critical Docker default:** Both `Dockerfile` and `docker-compose.yml` must
+default `VITE_API_URL` to empty string (`ARG VITE_API_URL=` / `VITE_API_URL: ${VITE_API_URL:-}`).
+If it defaults to `/api`, the `appPath` derivation never fires and subpath
+deployments silently break — the exact bug this system was built to fix.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `backend/app/utils/paths.py` | `normalize_root_path()`, `refresh_cookie_path()`, `csrf_cookie_path()`, `is_unstripped_prefix()` |
+| `backend/app/config.py` | `app_root_path` field + `validate_app_root_path` validator (delegates to `normalize_root_path`) |
+| `backend/app/main.py` | FastAPI `root_path=`, startup log, SPA catch-all with proxy guard |
+| `frontend/src/lib/normalize-base-path.ts` | Shared `normalizeBasePath()` used by `paths.ts` |
+| `frontend/src/lib/paths.ts` | `APP_BASENAME`, `appPath()`, `logSubpathConfig()` |
+| `frontend/src/lib/api.ts` | `API_BASE_URL = VITE_API_URL \|\| appPath("/api")` |
+| `frontend/vite.paths.ts` | `normalizeViteBase()`, `createApiProxy()`, `rewriteApiProxyPath()` |
+| `frontend/vite.config.ts` | Sets Vite `base`, dev proxy |
+| `scripts/validate_vite_env.mjs` | Build-time validation of `VITE_APP_BASENAME` |
+| `scripts/check_config_contract.py` | CI contract check across all config surfaces |
+| `frontend/.env.example` | Documents build-time env vars |
+| `docs/admin-guide.md` | Full operator reference, prefix-change walkthrough, NGINX/Caddy examples |
+
+---
+
+## TypeScript tsconfig boundary constraint
+
+`vite.config.ts` runs under `tsconfig.node.json`. `tsconfig.node.json` includes
+ONLY `vite.config.ts`. Files in `src/` are covered by `tsconfig.json`, which
+references `tsconfig.node.json` (composite project).
+
+**You cannot import from `src/` in `vite.config.ts` or `vite.paths.ts`.**
+Doing so causes: `Output file has not been built from source file` (TypeScript
+composite project conflict) because both tsconfigs would include the same file.
+
+The solution: `vite.paths.ts` keeps its own inline copy of `normalizeBasePath`
+with a cross-reference comment pointing to `src/lib/normalize-base-path.ts`.
+If you change the normalization logic, update BOTH files.
+
+---
+
+## `is_unstripped_prefix()` behavior
+
+```python
+# backend/app/utils/paths.py
+def is_unstripped_prefix(full_path: str, root_path: str) -> bool:
+```
+
+- Returns `True` when `full_path` still carries the external prefix
+  (indicates proxy did not strip it)
+- Boundary-safe: `"meridianx/foo"` does NOT match `/meridian`
+- Case-sensitive — `/Meridian/api` does not match `/meridian`
+- Called in the SPA catch-all to return 404 with diagnostic instead of
+  serving `index.html`
+
+---
+
+## Dev proxy parity (N-6)
+
+When `VITE_APP_BASENAME` is set, `createApiProxy()` returns ONLY the prefixed
+entry (e.g., `/knowledgevault/api`). It does NOT also return `/api`. This
+forces developers to use the prefix in dev, matching production behavior and
+catching prefix bugs during development rather than at deploy time.
+
+---
+
+## Changing the prefix
+
+To change from `/knowledgevault` to `/meridian`:
+
+1. Rebuild the frontend Docker image:
+   ```
+   docker build --build-arg VITE_APP_BASENAME=/meridian [--build-arg VITE_API_URL=/meridian/api] -t ragapp-frontend .
+   ```
+2. Update backend env: `APP_ROOT_PATH=/meridian`
+3. Update the reverse proxy to strip `/meridian/` instead of `/knowledgevault/`
+4. Update `CORS_ORIGINS` if the origin changes
+
+No code changes are required. See `docs/admin-guide.md` for full walkthrough.
+
+---
+
+## Streaming endpoint requirement
+
+All `StreamingResponse` instances in chat and wiki routes must include:
+```python
+headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
+```
+Without this, NGINX's default `proxy_buffering on` batches chunks and breaks
+the streaming UX. See deployment docs for the corresponding NGINX directives.
+
+---
+
+## Contract atomicity rule
+
+When changing any env var default across this system, all of these must be
+updated in the same commit:
+- `.env.example`
+- `docker-compose.yml`
+- `Dockerfile` (root)
+- `frontend/Dockerfile`
+- `scripts/check_config_contract.py`
+
+Missing any one surface fails the CI contract gate with an error that is hard
+to diagnose without knowing which surface was missed.

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -35,6 +35,31 @@ The authoritative testing policy and conventions live in
 - Config in `frontend/vite.config.ts`; `*.test.tsx`; `src/test/setup.ts` mocks `localStorage`/`confirm`/`scrollTo`.
 - jsdom mock patterns (full snippets in `ci-compatibility-audit/references/frontend-testing-gotchas.md`): wrap `<Link>` components in `MemoryRouter`; mock `@/components/ui/select` (Radix can't open in jsdom); mock `@tanstack/react-virtual`'s `useVirtualizer` to render all rows; `vi.mock` factories can't close over outer vars (`await import("react")`).
 
+## Source-inspection test pattern
+
+Some backend tests open Python source files as strings and regex-match for
+structural invariants — e.g., "every `StreamingResponse` call must include
+`X-Accel-Buffering`", or "every route file exports a `router` object". This
+pattern appears in `backend/tests/test_path_prefix.py` and similar files.
+
+**When to use it:**
+- Enforcing cross-cutting structural invariants that are hard to exercise
+  behaviorally (e.g., "all streaming responses must set a header").
+- Checking that boilerplate or security-sensitive patterns are not omitted.
+- When a behavioral test would require an integration setup disproportionate
+  to the risk being tested.
+
+**When NOT to use it:**
+- As a substitute for behavioral tests when a behavioral test is straightforward.
+- For logic correctness — source inspection cannot catch a header present but
+  set to the wrong value.
+- Where refactoring (e.g., renaming a function) would silently break the test
+  without breaking production behavior.
+
+**Tradeoff:** Fast and easy to write; fragile to non-behavioral refactoring.
+Always prefer behavioral unit tests when practical. When using source
+inspection, add a comment explaining why a behavioral test is not used.
+
 ## Running
 
 CI runs only a *narrow* backend pytest subset — also run your changed area's tests locally (`pytest -q tests/<file>`). Use `ci-compatibility-audit` for the exact CI-mirror commands before pushing.


### PR DESCRIPTION
## Summary
- Add new `subpath-deployment` skill capturing the locked architectural decisions, three-variable contract, tsconfig boundary constraint, and key behavioral details from issue #133 implementation
- Update `config-env-contract-check` to list `scripts/check_config_contract.py` and `scripts/validate_vite_env.mjs` as contract surfaces, and add an explicit atomicity rule for env var default changes across all five required surfaces
- Update `engineering-conventions` with the TypeScript tsconfig composite project constraint
- Update `swarm` with a behavioral-change test trap warning at step 5
- Update `writing-tests` with the source-inspection test pattern
- All 5 changed/added skills mirrored to `.agents/skills/` and `.opencode/skills/` per AGENTS.md requirement

## Test plan
- [x] `git diff --check` — no whitespace issues
- [x] All 13 files (5 .claude/ + 5 .agents/ + 3 .opencode/) staged explicitly; no unrelated files included
- [x] Targeted merge used for `.agents/writing-tests` (bun:test+Python hybrid) and `.agents/swarm` (Codex-specific subcommand list) — wholesale copy would have destroyed pre-existing content
- [x] `.opencode/` receives skills that already existed there + new subpath-deployment; config-env-contract-check and swarm not added to .opencode/ (pre-existing divergence, not introduced by this PR)

## Review follow-up
- **F-001 CONFIRMED and fixed:** Mirrored all 5 changed/added skills to `.agents/skills/` and `.opencode/skills/`. Used targeted edits (not wholesale copy) to preserve pre-existing Codex-specific content in `.agents/swarm` and `.agents/writing-tests`.