### PR TITLE
feat(wiki): implement 25 confirmed findings from issue #120 deep-dive analysis

### DIFF
--- a/backend/app/api/routes/wiki.py
+++ b/backend/app/api/routes/wiki.py
@@ -191,9 +191,9 @@ async def create_wiki_page(
             created_by=user.get("id"),
             parent_id=request.parent_id,
         )
-    except Exception as e:
+    except Exception:
         logger.exception("Error creating wiki page")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Failed to create wiki page")
     return _page_dict(page)
 
 
@@ -207,7 +207,14 @@ async def get_wiki_page(
     page = store.get_page(page_id)
     if not page:
         raise HTTPException(status_code=404, detail="Wiki page not found")
-    await _require_vault_read(user, page.vault_id)
+    # F-003: collapse a vault-access denial to 404 so an unauthorized caller cannot
+    # distinguish "exists in another vault" (403) from "does not exist" (404).
+    try:
+        await _require_vault_read(user, page.vault_id)
+    except HTTPException as exc:
+        if exc.status_code == 403:
+            raise HTTPException(status_code=404, detail="Wiki page not found")
+        raise
     return _page_dict(page)
 
 
@@ -223,7 +230,13 @@ async def update_wiki_page(
     page = store.get_page(page_id, load_relations=False)
     if not page:
         raise HTTPException(status_code=404, detail="Wiki page not found")
-    await _require_vault_write(user, page.vault_id)
+    # F-003: collapse a vault-access denial to 404 (existence non-distinguishable).
+    try:
+        await _require_vault_write(user, page.vault_id)
+    except HTTPException as exc:
+        if exc.status_code == 403:
+            raise HTTPException(status_code=404, detail="Wiki page not found")
+        raise
     updates = request.model_dump(exclude_none=True)
     expected_version = updates.pop("expected_version", None)
     try:
@@ -254,7 +267,13 @@ async def delete_wiki_page(
     page = store.get_page(page_id, load_relations=False)
     if not page:
         raise HTTPException(status_code=404, detail="Wiki page not found")
-    await _require_vault_write(user, page.vault_id)
+    # F-003: collapse a vault-access denial to 404 (existence non-distinguishable).
+    try:
+        await _require_vault_write(user, page.vault_id)
+    except HTTPException as exc:
+        if exc.status_code == 403:
+            raise HTTPException(status_code=404, detail="Wiki page not found")
+        raise
     store.delete_page(page_id, page.vault_id)
 
 
@@ -303,8 +322,9 @@ async def attach_file_to_page(
         pf = store.attach_file(page_id, request.file_id, request.vault_id)
     except sqlite3.IntegrityError:
         raise HTTPException(status_code=409, detail="File already attached to this page")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        logger.exception("Error attaching file to wiki page")
+        raise HTTPException(status_code=400, detail="Failed to attach file to page")
     return _as_dict(pf)
 
 
@@ -360,7 +380,7 @@ async def list_page_backlinks(
         raise HTTPException(status_code=404, detail="Wiki page not found")
     if page.vault_id != vault_id:
         raise HTTPException(status_code=404, detail="Wiki page not found")
-    backlinks = store.list_backlinks(page_id)
+    backlinks = store.list_backlinks(page_id, vault_id)
     return {"backlinks": [_as_dict(bl) for bl in backlinks]}
 
 
@@ -414,12 +434,14 @@ async def bulk_wiki_pages(
 async def list_wiki_entities(
     vault_id: int = Query(...),
     search: Optional[str] = Query(None),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
 ):
     await _require_vault_read(user, vault_id)
     store = WikiStore(db)
-    entities = store.list_entities(vault_id, search=search)
+    entities = store.list_entities(vault_id, search=search, limit=limit, offset=offset)
     return {"entities": [_as_dict(e) for e in entities]}
 
 
@@ -434,12 +456,17 @@ async def list_wiki_claims(
     entity: Optional[str] = Query(None),
     search: Optional[str] = Query(None),
     status: Optional[str] = Query(None),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
 ):
     await _require_vault_read(user, vault_id)
     store = WikiStore(db)
-    claims = store.list_claims(vault_id, page_id=page_id, entity=entity, search=search, status=status)
+    claims = store.list_claims(
+        vault_id, page_id=page_id, entity=entity, search=search, status=status,
+        limit=limit, offset=offset,
+    )
     return {"claims": [_as_dict(c) for c in claims]}
 
 
@@ -643,9 +670,9 @@ async def promote_memory_to_wiki(
         raise HTTPException(status_code=404, detail=str(e))
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
-    except Exception as e:
+    except Exception:
         logger.exception("Error promoting memory to wiki")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Failed to promote memory to wiki")
 
     return {
         "page": _page_dict(result["page"]),
@@ -837,12 +864,12 @@ async def get_document_wiki_status(
     db.row_factory = sqlite3.Row
     store = WikiStore(db)
 
-    # Collect ingest jobs for this file
-    jobs = store.list_jobs(vault_id)
-    file_jobs = sorted(
-        [j for j in jobs if j.trigger_type == "ingest" and j.trigger_id == f"file:{file_id}"],
-        key=lambda j: j.created_at,
-        reverse=True,
+    # Collect ingest jobs for this file (filtered + bounded in SQL — F-012)
+    file_jobs = store.list_jobs(
+        vault_id,
+        trigger_type="ingest",
+        trigger_id=f"file:{file_id}",
+        limit=50,
     )
     latest_job = file_jobs[0] if file_jobs else None
 
@@ -937,15 +964,11 @@ async def get_memory_wiki_status(
     db.row_factory = sqlite3.Row
     store = WikiStore(db)
 
-    # Collect memory jobs
-    jobs = store.list_jobs(vault_id)
-    mem_jobs = sorted(
-        [j for j in jobs
-         if j.trigger_type in ("memory", "manual")
-         and j.trigger_id == f"memory:{memory_id}"],
-        key=lambda j: j.created_at,
-        reverse=True,
-    )
+    # Collect memory jobs (trigger_id filtered + bounded in SQL — F-012).
+    # trigger_type can be either "memory" or "manual", so keep that check in Python
+    # over the already-bounded result set.
+    jobs = store.list_jobs(vault_id, trigger_id=f"memory:{memory_id}", limit=50)
+    mem_jobs = [j for j in jobs if j.trigger_type in ("memory", "manual")]
     latest_job = mem_jobs[0] if mem_jobs else None
 
     # Claims sourced from this memory

--- a/backend/app/api/routes/wiki.py
+++ b/backend/app/api/routes/wiki.py
@@ -84,6 +84,7 @@ class WikiPageCreateRequest(BaseModel):
     summary: str = ""
     status: str = "draft"
     confidence: float = 0.0
+    parent_id: Optional[int] = None
 
 
 class WikiPageUpdateRequest(BaseModel):
@@ -94,6 +95,8 @@ class WikiPageUpdateRequest(BaseModel):
     summary: Optional[str] = None
     status: Optional[str] = None
     confidence: Optional[float] = None
+    parent_id: Optional[int] = None
+    expected_version: Optional[int] = None
 
 
 class WikiClaimCreateRequest(BaseModel):
@@ -131,6 +134,18 @@ class PromoteMemoryRequest(BaseModel):
 
 class LintRunRequest(BaseModel):
     vault_id: int
+
+
+class WikiFileAttachRequest(BaseModel):
+    vault_id: int
+    file_id: int
+
+
+class WikiBulkRequest(BaseModel):
+    vault_id: int
+    page_ids: list[int] = Field(..., min_length=1)
+    action: str = Field(..., description="Action: delete or update")
+    updates: Optional[dict] = None
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +189,7 @@ async def create_wiki_page(
             status=request.status,
             confidence=request.confidence,
             created_by=user.get("id"),
+            parent_id=request.parent_id,
         )
     except Exception as e:
         logger.exception("Error creating wiki page")
@@ -209,8 +225,22 @@ async def update_wiki_page(
         raise HTTPException(status_code=404, detail="Wiki page not found")
     await _require_vault_write(user, page.vault_id)
     updates = request.model_dump(exclude_none=True)
-    updated = store.update_page(page_id, page.vault_id, **updates)
-    return _page_dict(updated)
+    expected_version = updates.pop("expected_version", None)
+    try:
+        updated = store.update_page(
+            page_id,
+            page.vault_id,
+            expected_version=expected_version,
+            edited_by=user.get("id"),
+            **updates,
+        )
+    except ValueError as e:
+        if "Version conflict" in str(e):
+            raise HTTPException(status_code=409, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e))
+    result = _page_dict(updated)
+    result["version"] = updated.version if updated else None
+    return result
 
 
 @router.delete("/wiki/pages/{page_id}", status_code=204)
@@ -226,6 +256,154 @@ async def delete_wiki_page(
         raise HTTPException(status_code=404, detail="Wiki page not found")
     await _require_vault_write(user, page.vault_id)
     store.delete_page(page_id, page.vault_id)
+
+
+# ---------------------------------------------------------------------------
+# Page version history (DD-C003)
+# ---------------------------------------------------------------------------
+
+@router.get("/wiki/pages/{page_id}/versions")
+async def list_page_versions(
+    page_id: int,
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = WikiStore(db)
+    page = store.get_page(page_id, load_relations=False)
+    if not page:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    if page.vault_id != vault_id:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    versions = store.list_versions(page_id)
+    return {"versions": [_as_dict(v) for v in versions]}
+
+
+# ---------------------------------------------------------------------------
+# Page file attachments (DD-C019)
+# ---------------------------------------------------------------------------
+
+@router.post("/wiki/pages/{page_id}/files", status_code=201)
+async def attach_file_to_page(
+    page_id: int,
+    request: WikiFileAttachRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    await _require_vault_write(user, request.vault_id)
+    store = WikiStore(db)
+    page = store.get_page(page_id, load_relations=False)
+    if not page:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    if page.vault_id != request.vault_id:
+        raise HTTPException(status_code=403, detail="Page does not belong to this vault")
+    try:
+        pf = store.attach_file(page_id, request.file_id, request.vault_id)
+    except sqlite3.IntegrityError:
+        raise HTTPException(status_code=409, detail="File already attached to this page")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return _as_dict(pf)
+
+
+@router.delete("/wiki/pages/{page_id}/files/{file_id}", status_code=204)
+async def detach_file_from_page(
+    page_id: int,
+    file_id: int,
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    await _require_vault_write(user, vault_id)
+    store = WikiStore(db)
+    removed = store.detach_file(page_id, file_id, vault_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="File attachment not found")
+
+
+@router.get("/wiki/pages/{page_id}/files")
+async def list_page_files(
+    page_id: int,
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = WikiStore(db)
+    page = store.get_page(page_id, load_relations=False)
+    if not page:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    if page.vault_id != vault_id:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    files = store.list_page_files(page_id)
+    return {"files": [_as_dict(f) for f in files]}
+
+
+# ---------------------------------------------------------------------------
+# Backlinks (DD-C030)
+# ---------------------------------------------------------------------------
+
+@router.get("/wiki/pages/{page_id}/backlinks")
+async def list_page_backlinks(
+    page_id: int,
+    vault_id: int = Query(...),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = WikiStore(db)
+    page = store.get_page(page_id, load_relations=False)
+    if not page:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    if page.vault_id != vault_id:
+        raise HTTPException(status_code=404, detail="Wiki page not found")
+    backlinks = store.list_backlinks(page_id)
+    return {"backlinks": [_as_dict(bl) for bl in backlinks]}
+
+
+# ---------------------------------------------------------------------------
+# Activity feed (DD-C026)
+# ---------------------------------------------------------------------------
+
+@router.get("/wiki/activity")
+async def list_wiki_activity(
+    vault_id: int = Query(...),
+    limit: int = Query(50, ge=1, le=200),
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+):
+    await _require_vault_read(user, vault_id)
+    store = WikiStore(db)
+    entries = store.list_activity(vault_id, limit=limit)
+    return {"activity": [_as_dict(e) for e in entries]}
+
+
+# ---------------------------------------------------------------------------
+# Bulk operations (DD-C025)
+# ---------------------------------------------------------------------------
+
+@router.post("/wiki/pages/bulk")
+async def bulk_wiki_pages(
+    request: WikiBulkRequest,
+    db: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_active_user),
+    _csrf_token: str = Depends(csrf_protect),
+):
+    await _require_vault_write(user, request.vault_id)
+    store = WikiStore(db)
+    if request.action == "delete":
+        count = store.bulk_delete_pages(request.page_ids, request.vault_id)
+        return {"action": "delete", "deleted": count}
+    elif request.action == "update":
+        if not request.updates:
+            raise HTTPException(status_code=400, detail="updates field required for update action")
+        pages = store.bulk_update_pages(request.page_ids, request.vault_id, **request.updates)
+        return {"action": "update", "updated": len(pages), "pages": [_as_dict(p) for p in pages]}
+    else:
+        raise HTTPException(status_code=400, detail=f"Unknown bulk action: {request.action}")
 
 
 # ---------------------------------------------------------------------------
@@ -542,12 +720,15 @@ async def wiki_events_stream(
 async def search_wiki(
     vault_id: int = Query(...),
     q: str = Query(..., min_length=1),
+    page_type: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    sort_by: Optional[str] = Query(None, description="Sort pages by: title, updated_at, confidence"),
     db: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(get_current_active_user),
 ):
     await _require_vault_read(user, vault_id)
     store = WikiStore(db)
-    results = store.search(vault_id, q)
+    results = store.search(vault_id, q, page_type=page_type, status=status, sort_by=sort_by)
     return {
         "query": q,
         "pages": [_as_dict(p) for p in results["pages"]],

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -350,6 +350,7 @@ CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
 CREATE TABLE IF NOT EXISTS wiki_pages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     vault_id INTEGER NOT NULL,
+    parent_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
     slug TEXT NOT NULL,
     title TEXT NOT NULL,
     page_type TEXT NOT NULL CHECK (page_type IN (
@@ -360,6 +361,7 @@ CREATE TABLE IF NOT EXISTS wiki_pages (
     status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN (
         'draft','verified','stale','needs_review','archived')),
     confidence REAL DEFAULT 0.0,
+    version INTEGER NOT NULL DEFAULT 1,
     created_by INTEGER,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -407,7 +409,7 @@ CREATE TABLE IF NOT EXISTS wiki_claim_sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     claim_id INTEGER NOT NULL REFERENCES wiki_claims(id) ON DELETE CASCADE,
     source_kind TEXT NOT NULL CHECK (source_kind IN (
-        'document','memory','chat_message','manual')),
+        'document','memory','chat_message','manual','wiki')),
     file_id INTEGER,
     chunk_id TEXT,
     memory_id INTEGER,
@@ -430,7 +432,8 @@ CREATE TABLE IF NOT EXISTS wiki_relations (
     object_text TEXT,
     claim_id INTEGER REFERENCES wiki_claims(id) ON DELETE CASCADE,
     confidence REAL DEFAULT 0.0,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(subject_entity_id, predicate, object_entity_id)
 );
 
 CREATE TABLE IF NOT EXISTS wiki_compile_jobs (
@@ -526,6 +529,65 @@ CREATE INDEX IF NOT EXISTS idx_wiki_claims_vault_page_status ON wiki_claims(vaul
 CREATE INDEX IF NOT EXISTS idx_wiki_claim_sources_claim_id ON wiki_claim_sources(claim_id);
 CREATE INDEX IF NOT EXISTS idx_wiki_compile_jobs_vault_status ON wiki_compile_jobs(vault_id, status);
 CREATE INDEX IF NOT EXISTS idx_wiki_lint_findings_vault_status_severity ON wiki_lint_findings(vault_id, status, severity);
+
+-- Wiki page version history (DD-C003)
+CREATE TABLE IF NOT EXISTS wiki_page_versions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+    vault_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    markdown TEXT NOT NULL DEFAULT '',
+    summary TEXT DEFAULT '',
+    status TEXT NOT NULL,
+    confidence REAL DEFAULT 0.0,
+    edited_by INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_wiki_page_versions_page ON wiki_page_versions(page_id);
+
+-- Wiki page file attachments (DD-C019)
+CREATE TABLE IF NOT EXISTS wiki_page_files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    vault_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(page_id, file_id)
+);
+CREATE INDEX IF NOT EXISTS idx_wiki_page_files_page ON wiki_page_files(page_id);
+CREATE INDEX IF NOT EXISTS idx_wiki_page_files_file ON wiki_page_files(file_id);
+
+-- Wiki inter-page links and backlinks (DD-C030)
+CREATE TABLE IF NOT EXISTS wiki_page_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+    target_page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+    vault_id INTEGER NOT NULL,
+    link_text TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source_page_id, target_page_id)
+);
+CREATE INDEX IF NOT EXISTS idx_wiki_page_links_source ON wiki_page_links(source_page_id);
+CREATE INDEX IF NOT EXISTS idx_wiki_page_links_target ON wiki_page_links(target_page_id);
+
+-- Wiki activity log (DD-C026)
+CREATE TABLE IF NOT EXISTS wiki_activity_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    vault_id INTEGER NOT NULL,
+    action TEXT NOT NULL CHECK (action IN (
+        'page_created','page_updated','page_deleted',
+        'claim_created','claim_updated','claim_deleted',
+        'entity_created','entity_updated',
+        'job_completed','job_failed',
+        'lint_resolved','lint_dismissed')),
+    target_type TEXT NOT NULL CHECK (target_type IN (
+        'page','claim','entity','job','lint_finding')),
+    target_id INTEGER NOT NULL,
+    user_id INTEGER,
+    details_json TEXT DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_wiki_activity_log_vault ON wiki_activity_log(vault_id, created_at DESC);
 
 -- ============================================================
 -- KMS / Knowledge Management tables (user-curated documentation)
@@ -781,6 +843,10 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_files_search_fts(sqlite_path)
     migrate_add_files_content_fts(sqlite_path)
     migrate_add_curator_claim_support(sqlite_path)
+    migrate_widen_wiki_claim_sources_source_kind(sqlite_path)
+    migrate_add_wiki_relations_unique(sqlite_path)
+    migrate_add_wiki_page_hierarchy_and_versioning(sqlite_path)
+    migrate_add_wiki_supporting_tables(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
     # Wrapped in IntegrityError handler: existing databases may have duplicate
@@ -2136,6 +2202,230 @@ migrate_add_files_content_fts('/path/to/app.db')"
     except Exception:
         conn.rollback()
         raise
+    finally:
+        conn.close()
+
+
+def migrate_widen_wiki_claim_sources_source_kind(sqlite_path: str) -> None:
+    """Migration: add 'wiki' to the wiki_claim_sources.source_kind CHECK constraint.
+
+    SQLite cannot ALTER a CHECK constraint, so we use the rename-recreate-copy
+    pattern. wiki_claim_sources has NO child tables referencing it, NO FTS
+    virtual table, and NO triggers — simpler than the wiki_claims rebuild.
+
+    We still set ``legacy_alter_table=ON`` and ``foreign_keys=OFF`` during the
+    swap for safety, and validate FK integrity afterwards.
+
+    Idempotent — safe to run multiple times.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    conn.isolation_level = None
+    try:
+        tbl = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='wiki_claim_sources'"
+        ).fetchone()
+        if not tbl:
+            return
+
+        old_present = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='wiki_claim_sources_old'"
+        ).fetchone()
+        if old_present and not tbl:
+            conn.execute("PRAGMA legacy_alter_table = ON")
+            conn.execute("ALTER TABLE wiki_claim_sources_old RENAME TO wiki_claim_sources")
+            conn.execute("PRAGMA legacy_alter_table = OFF")
+        elif old_present:
+            conn.execute("DROP TABLE IF EXISTS wiki_claim_sources_old")
+
+        create_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='wiki_claim_sources'"
+        ).fetchone()
+        if create_sql and "'wiki'" in create_sql[0]:
+            return
+
+        before_count = conn.execute("SELECT COUNT(*) FROM wiki_claim_sources").fetchone()[0]
+
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute("PRAGMA legacy_alter_table = ON")
+        try:
+            conn.execute("ALTER TABLE wiki_claim_sources RENAME TO wiki_claim_sources_old")
+
+            conn.execute(
+                """
+                CREATE TABLE wiki_claim_sources (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    claim_id INTEGER NOT NULL REFERENCES wiki_claims(id) ON DELETE CASCADE,
+                    source_kind TEXT NOT NULL CHECK (source_kind IN (
+                        'document','memory','chat_message','manual','wiki')),
+                    file_id INTEGER,
+                    chunk_id TEXT,
+                    memory_id INTEGER,
+                    chat_message_id INTEGER,
+                    source_label TEXT,
+                    quote TEXT,
+                    char_start INTEGER,
+                    char_end INTEGER,
+                    page_number INTEGER,
+                    confidence REAL DEFAULT 0.0,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+            conn.execute(
+                """
+                INSERT INTO wiki_claim_sources (
+                    id, claim_id, source_kind, file_id, chunk_id, memory_id,
+                    chat_message_id, source_label, quote, char_start, char_end,
+                    page_number, confidence, created_at
+                )
+                SELECT id, claim_id, source_kind, file_id, chunk_id, memory_id,
+                       chat_message_id, source_label, quote, char_start, char_end,
+                       page_number, confidence, created_at
+                FROM wiki_claim_sources_old
+                """
+            )
+
+            after_count = conn.execute("SELECT COUNT(*) FROM wiki_claim_sources").fetchone()[0]
+            if after_count != before_count:
+                raise RuntimeError(
+                    f"migrate_widen_wiki_claim_sources_source_kind: row-count "
+                    f"parity failed ({before_count} -> {after_count}). "
+                    f"wiki_claim_sources_old has been preserved."
+                )
+
+            conn.execute("DROP TABLE wiki_claim_sources_old")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_wiki_claim_sources_claim_id "
+                "ON wiki_claim_sources(claim_id)"
+            )
+        finally:
+            conn.execute("PRAGMA legacy_alter_table = OFF")
+            conn.execute("PRAGMA foreign_keys = ON")
+
+        violations = conn.execute("PRAGMA foreign_key_check(wiki_claim_sources)").fetchall()
+        if violations:
+            raise RuntimeError(
+                f"migrate_widen_wiki_claim_sources_source_kind: "
+                f"foreign_key_check reported {len(violations)} violation(s): "
+                f"{violations[:5]}"
+            )
+    finally:
+        conn.close()
+
+
+def migrate_add_wiki_relations_unique(sqlite_path: str) -> None:
+    """Migration: add UNIQUE constraint on wiki_relations(subject_entity_id, predicate, object_entity_id).
+
+    Deduplicates existing rows first (keeps highest id per triple), then
+    creates a unique index. Idempotent.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        tbl = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='wiki_relations'"
+        ).fetchone()
+        if not tbl:
+            return
+
+        idx = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_wiki_relations_unique_triple'"
+        ).fetchone()
+        if idx:
+            return
+
+        conn.execute(
+            """DELETE FROM wiki_relations WHERE id NOT IN (
+                SELECT MAX(id) FROM wiki_relations
+                GROUP BY subject_entity_id, predicate, object_entity_id
+            )"""
+        )
+        conn.execute(
+            "CREATE UNIQUE INDEX idx_wiki_relations_unique_triple "
+            "ON wiki_relations(subject_entity_id, predicate, object_entity_id)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_wiki_page_hierarchy_and_versioning(sqlite_path: str) -> None:
+    """Migration: add parent_id and version columns to wiki_pages. Idempotent."""
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(wiki_pages)").fetchall()]
+        if "parent_id" not in cols:
+            conn.execute("ALTER TABLE wiki_pages ADD COLUMN parent_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_wiki_pages_parent ON wiki_pages(parent_id)")
+        if "version" not in cols:
+            conn.execute("ALTER TABLE wiki_pages ADD COLUMN version INTEGER NOT NULL DEFAULT 1")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_wiki_supporting_tables(sqlite_path: str) -> None:
+    """Migration: add wiki_page_versions, wiki_page_files, wiki_page_links,
+    wiki_activity_log tables. Idempotent via IF NOT EXISTS."""
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS wiki_page_versions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+                vault_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                markdown TEXT NOT NULL DEFAULT '',
+                summary TEXT DEFAULT '',
+                status TEXT NOT NULL,
+                confidence REAL DEFAULT 0.0,
+                edited_by INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_wiki_page_versions_page ON wiki_page_versions(page_id);
+
+            CREATE TABLE IF NOT EXISTS wiki_page_files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+                file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                vault_id INTEGER NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(page_id, file_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_wiki_page_files_page ON wiki_page_files(page_id);
+            CREATE INDEX IF NOT EXISTS idx_wiki_page_files_file ON wiki_page_files(file_id);
+
+            CREATE TABLE IF NOT EXISTS wiki_page_links (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+                target_page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+                vault_id INTEGER NOT NULL,
+                link_text TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(source_page_id, target_page_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_wiki_page_links_source ON wiki_page_links(source_page_id);
+            CREATE INDEX IF NOT EXISTS idx_wiki_page_links_target ON wiki_page_links(target_page_id);
+
+            CREATE TABLE IF NOT EXISTS wiki_activity_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL,
+                action TEXT NOT NULL CHECK (action IN (
+                    'page_created','page_updated','page_deleted',
+                    'claim_created','claim_updated','claim_deleted',
+                    'entity_created','entity_updated',
+                    'job_completed','job_failed',
+                    'lint_resolved','lint_dismissed')),
+                target_type TEXT NOT NULL CHECK (target_type IN (
+                    'page','claim','entity','job','lint_finding')),
+                target_id INTEGER NOT NULL,
+                user_id INTEGER,
+                details_json TEXT DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_wiki_activity_log_vault ON wiki_activity_log(vault_id, created_at DESC);
+        """)
+        conn.commit()
     finally:
         conn.close()
 

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -387,6 +387,7 @@ CREATE TABLE IF NOT EXISTS wiki_claims (
     vault_id INTEGER NOT NULL,
     page_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
     claim_text TEXT NOT NULL,
+    normalized_text TEXT,
     claim_type TEXT NOT NULL DEFAULT 'fact',
     subject TEXT,
     predicate TEXT,
@@ -526,6 +527,7 @@ CREATE INDEX IF NOT EXISTS idx_wiki_pages_vault_type_status ON wiki_pages(vault_
 CREATE INDEX IF NOT EXISTS idx_wiki_pages_vault_slug ON wiki_pages(vault_id, slug);
 CREATE INDEX IF NOT EXISTS idx_wiki_entities_vault_name ON wiki_entities(vault_id, canonical_name);
 CREATE INDEX IF NOT EXISTS idx_wiki_claims_vault_page_status ON wiki_claims(vault_id, page_id, status);
+CREATE INDEX IF NOT EXISTS idx_wiki_claims_vault_normalized ON wiki_claims(vault_id, normalized_text);
 CREATE INDEX IF NOT EXISTS idx_wiki_claim_sources_claim_id ON wiki_claim_sources(claim_id);
 CREATE INDEX IF NOT EXISTS idx_wiki_compile_jobs_vault_status ON wiki_compile_jobs(vault_id, status);
 CREATE INDEX IF NOT EXISTS idx_wiki_lint_findings_vault_status_severity ON wiki_lint_findings(vault_id, status, severity);
@@ -847,6 +849,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_relations_unique(sqlite_path)
     migrate_add_wiki_page_hierarchy_and_versioning(sqlite_path)
     migrate_add_wiki_supporting_tables(sqlite_path)
+    migrate_add_wiki_claims_normalized_text(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
     # Wrapped in IntegrityError handler: existing databases may have duplicate
@@ -2425,6 +2428,36 @@ def migrate_add_wiki_supporting_tables(sqlite_path: str) -> None:
             );
             CREATE INDEX IF NOT EXISTS idx_wiki_activity_log_vault ON wiki_activity_log(vault_id, created_at DESC);
         """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_wiki_claims_normalized_text(sqlite_path: str) -> None:
+    """Migration: add normalized_text column + index to wiki_claims and backfill
+    existing rows. Idempotent. Mirrors normalize_claim_text in wiki_store."""
+    import re
+
+    def _normalize(text: str) -> str:
+        normalized = re.sub(r"[^\w\s]", "", (text or "").lower().strip())
+        return re.sub(r"\s+", " ", normalized).strip()
+
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(wiki_claims)").fetchall()]
+        if "normalized_text" not in cols:
+            conn.execute("ALTER TABLE wiki_claims ADD COLUMN normalized_text TEXT")
+            # Backfill existing rows (SQLite has no regex, so normalize in Python).
+            rows = conn.execute("SELECT id, claim_text FROM wiki_claims").fetchall()
+            for claim_id, claim_text in rows:
+                conn.execute(
+                    "UPDATE wiki_claims SET normalized_text = ? WHERE id = ?",
+                    (_normalize(claim_text), claim_id),
+                )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wiki_claims_vault_normalized "
+            "ON wiki_claims(vault_id, normalized_text)"
+        )
         conn.commit()
     finally:
         conn.close()

--- a/backend/app/services/prompt_builder.py
+++ b/backend/app/services/prompt_builder.py
@@ -221,6 +221,19 @@ class PromptBuilderService:
                 + "\n\n".join(kms_sections)
             )
 
+        # Dedup: skip document chunks whose text substantially overlaps wiki claims
+        if wiki_evidence:
+            wiki_texts = {
+                (ev.claim_text or "").lower().strip()
+                for ev in wiki_evidence
+                if ev.claim_text
+            }
+            def _covered_by_wiki(section_text: str) -> bool:
+                lower = section_text.lower()
+                return any(wt in lower for wt in wiki_texts if len(wt) > 40)
+            primary_sections = [s for s in primary_sections if not _covered_by_wiki(s)]
+            supporting_sections = [s for s in supporting_sections if not _covered_by_wiki(s)]
+
         if primary_sections:
             primary_text = "\n\n".join(primary_sections)
             user_content_parts.append(f"Primary Evidence:\n{primary_text}")

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -85,6 +85,20 @@ def _classify_query(query: str) -> str:
     return "general"
 
 
+_WIKI_FRESHNESS_MAX_AGE_DAYS = 7
+
+
+def _is_fresh(freshness_str: Optional[str], max_age_days: int = _WIKI_FRESHNESS_MAX_AGE_DAYS) -> bool:
+    """Return True if the freshness timestamp is within max_age_days of now."""
+    if not freshness_str:
+        return False
+    try:
+        compiled_at = datetime.fromisoformat(freshness_str)
+        return (datetime.utcnow() - compiled_at).days <= max_age_days
+    except (ValueError, TypeError):
+        return False
+
+
 def _raw_rag_required(query_type: str, wiki_evidence: List[Any]) -> bool:
     """Return True if raw document RAG is needed given query type and wiki results."""
     if not wiki_evidence:
@@ -92,13 +106,14 @@ def _raw_rag_required(query_type: str, wiki_evidence: List[Any]) -> bool:
     if query_type == "document_specific":
         return True
     if query_type == "entity_lookup":
-        # Skip raw RAG only when a high-confidence, non-stale claim directly answers
+        # Skip raw RAG only when a high-confidence, non-stale, fresh claim directly answers
         high_conf = [
             ev for ev in wiki_evidence
             if ev.claim_id is not None
             and (ev.claim_status or "") in ("active", "verified")
             and (ev.page_status or "") not in ("stale", "archived", "draft")
             and ev.confidence >= 0.75
+            and _is_fresh(ev.freshness)
         ]
         return len(high_conf) == 0
     # For all other query types, keep raw RAG as supplement
@@ -528,34 +543,40 @@ class RAGEngine:
 
         effective_alpha = self.hybrid_alpha
 
-        # Wiki retrieval: query the Knowledge Compiler before raw document RAG.
-        wiki_evidence: List[Any] = []
-        if self._wiki_retrieval is not None and vault_id is not None:
+        # Wiki + KMS retrieval: run in parallel when both are enabled.
+        async def _wiki_retrieve() -> List[Any]:
+            if self._wiki_retrieval is None or vault_id is None:
+                return []
             try:
-                wiki_evidence = await asyncio.to_thread(
+                result = await asyncio.to_thread(
                     self._wiki_retrieval.retrieve, retrieval_query, vault_id
                 )
-                logger.info("[query] Wiki retrieval: %d candidates", len(wiki_evidence))
+                logger.info("[query] Wiki retrieval: %d candidates", len(result))
+                return result
             except Exception as exc:
                 logger.warning("Wiki retrieval failed: %s", exc)
-                wiki_evidence = []
+                return []
 
-        # KMS retrieval: query user-curated knowledge entries. Gated by the
-        # kms_enabled master switch (also re-checked inside the service).
-        kms_evidence: List[Any] = []
-        if (
-            self._kms_retrieval is not None
-            and vault_id is not None
-            and settings.kms_enabled
-        ):
+        async def _kms_retrieve() -> List[Any]:
+            if (
+                self._kms_retrieval is None
+                or vault_id is None
+                or not settings.kms_enabled
+            ):
+                return []
             try:
-                kms_evidence = await asyncio.to_thread(
+                result = await asyncio.to_thread(
                     self._kms_retrieval.retrieve, retrieval_query, vault_id
                 )
-                logger.info("[query] KMS retrieval: %d candidates", len(kms_evidence))
+                logger.info("[query] KMS retrieval: %d candidates", len(result))
+                return result
             except Exception as exc:
                 logger.warning("KMS retrieval failed: %s", exc)
-                kms_evidence = []
+                return []
+
+        wiki_evidence, kms_evidence = await asyncio.gather(
+            _wiki_retrieve(), _kms_retrieve()
+        )
 
         # Update trace with wiki results
         query_type = _classify_query(retrieval_query)

--- a/backend/app/services/wiki_citation_helpers.py
+++ b/backend/app/services/wiki_citation_helpers.py
@@ -102,7 +102,7 @@ def build_per_claim_sources(
             return mem
         if prefix == "W" and num_str in wiki_by_num:
             ref = dict(wiki_by_num[num_str])
-            ref["source_kind"] = "manual"
+            ref["source_kind"] = "wiki"
             return ref
         return None
 

--- a/backend/app/services/wiki_compiler.py
+++ b/backend/app/services/wiki_compiler.py
@@ -217,7 +217,10 @@ class WikiCompiler:
           memory   → memory_id (int)
           manual   → source_label (str)
         """
-        existing = self._store.find_claim_by_text(vault_id, claim_text)
+        # Exact match first; fall back to normalized (fuzzy) match so claims that
+        # differ only in punctuation/whitespace/case are deduped (DD-C011).
+        existing = self._store.find_claim_by_text(vault_id, claim_text) or \
+            self._store.find_claim_by_normalized_text(vault_id, claim_text)
         if existing:
             # Promote unverified → active when the caller has explicit per-claim citations.
             new_status = create_kwargs.get("status")

--- a/backend/app/services/wiki_curator.py
+++ b/backend/app/services/wiki_curator.py
@@ -88,7 +88,7 @@ class CuratorResult:
     input_chars: int = 0
 
     def to_summary(self) -> dict[str, Any]:
-        return {
+        summary: dict[str, Any] = {
             "accepted": len(self.accepted),
             "rejected": len(self.rejected),
             "lint": len(self.lint_findings),
@@ -96,6 +96,12 @@ class CuratorResult:
             "calls": self.calls,
             "input_chars": self.input_chars,
         }
+        if self.rejected:
+            summary["rejections"] = [
+                {"claim_text": r.claim_text, "reason": r.reason}
+                for r in self.rejected
+            ]
+        return summary
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +347,11 @@ class WikiCurator:
                 merged_contradictions.extend(
                     c for c in raw_contradictions if isinstance(c, dict)
                 )
+
+        # Sort merged claims deterministically so that when concurrency > 1
+        # and two chunks propose the same claim, the dedup winner is always
+        # the same regardless of parallel execution order.
+        merged_claims.sort(key=lambda c: (str(c.get("claim_text") or ""), str(c.get("chunk_id") or "")))
 
         for raw in merged_claims:
             try:

--- a/backend/app/services/wiki_events.py
+++ b/backend/app/services/wiki_events.py
@@ -56,6 +56,40 @@ class WikiEventBus:
                 except Exception:
                     logger.debug("wiki event bus: dropped event for vault %d", vault_id)
 
+    def publish_page_change(
+        self,
+        vault_id: int,
+        page_id: int,
+        action: str,
+        user_id: Optional[int] = None,
+    ) -> None:
+        """Publish a wiki page change event (created/updated/deleted)."""
+        event: dict = {
+            "type": "page_change",
+            "page_id": page_id,
+            "action": action,
+        }
+        if user_id is not None:
+            event["user_id"] = user_id
+        self.publish(vault_id, event)
+
+    def publish_claim_change(
+        self,
+        vault_id: int,
+        claim_id: int,
+        action: str,
+        user_id: Optional[int] = None,
+    ) -> None:
+        """Publish a wiki claim change event (created/updated/deleted)."""
+        event: dict = {
+            "type": "claim_change",
+            "claim_id": claim_id,
+            "action": action,
+        }
+        if user_id is not None:
+            event["user_id"] = user_id
+        self.publish(vault_id, event)
+
 
 _bus: Optional[WikiEventBus] = None
 

--- a/backend/app/services/wiki_retrieval.py
+++ b/backend/app/services/wiki_retrieval.py
@@ -264,7 +264,7 @@ class WikiRetrievalService:
                     candidates[key] = ev
 
         # 4. FTS page search (fallback, lower score)
-        if normalized_query and len(candidates) < 3:
+        if normalized_query and len(candidates) < 5:
             fts_page_results = self._fts_page_search(conn, normalized_query, vault_id)
             for ev in fts_page_results:
                 if entity_candidates:

--- a/backend/app/services/wiki_store.py
+++ b/backend/app/services/wiki_store.py
@@ -440,6 +440,10 @@ class WikiStore:
         page = self.get_page(cur.lastrowid)  # type: ignore[arg-type]
         if page:
             self.log_activity(vault_id, "page_created", "page", page.id, user_id=created_by)
+            # DD-C030: resolve [[slug]] wiki-links in the new page's body so
+            # backlinks exist as soon as the page is created.
+            if markdown:
+                self.sync_page_links(page.id, vault_id, markdown)
         return page  # type: ignore[return-value]
 
     def get_page(self, page_id: int, load_relations: bool = True) -> Optional[WikiPage]:
@@ -547,6 +551,10 @@ class WikiStore:
                 f"Version conflict: page {page_id} was modified concurrently"
             )
         self.log_activity(vault_id, "page_updated", "page", page_id, user_id=edited_by, commit=False)
+        # DD-C030: if the body changed, re-resolve [[slug]] wiki-links inside this
+        # same transaction so the save stays atomic.
+        if "markdown" in updates:
+            self.sync_page_links(page_id, vault_id, updates["markdown"], commit=False)
         if commit:
             self._db.commit()
         return self.get_page(page_id)
@@ -1401,13 +1409,23 @@ class WikiStore:
     # -----------------------------------------------------------------------
 
     def attach_file(self, page_id: int, file_id: int, vault_id: int) -> Optional[WikiPageFile]:
-        """Attach a file to a wiki page. INSERT OR IGNORE for idempotency."""
+        """Attach a file to a wiki page.
+
+        Uses a plain INSERT so a duplicate (page_id, file_id) raises
+        ``sqlite3.IntegrityError`` against the UNIQUE constraint. The route layer
+        translates that into a 409 — using ``INSERT OR IGNORE`` here would
+        silently swallow the conflict and make that 409 handler dead code.
+        """
         now = datetime.utcnow().isoformat()
-        self._db.execute(
-            """INSERT OR IGNORE INTO wiki_page_files (page_id, file_id, vault_id, created_at)
-               VALUES (?, ?, ?, ?)""",
-            (page_id, file_id, vault_id, now),
-        )
+        try:
+            self._db.execute(
+                """INSERT INTO wiki_page_files (page_id, file_id, vault_id, created_at)
+                   VALUES (?, ?, ?, ?)""",
+                (page_id, file_id, vault_id, now),
+            )
+        except sqlite3.IntegrityError:
+            self._db.rollback()
+            raise
         self._db.commit()
         row = self._db.execute(
             "SELECT * FROM wiki_page_files WHERE page_id = ? AND file_id = ?",
@@ -1436,9 +1454,15 @@ class WikiStore:
     # Wiki Links (DD-C030)
     # -----------------------------------------------------------------------
 
-    def sync_page_links(self, page_id: int, vault_id: int, markdown: str) -> list[WikiPageLink]:
+    def sync_page_links(
+        self, page_id: int, vault_id: int, markdown: str, commit: bool = True
+    ) -> list[WikiPageLink]:
         """Parse [[slug]] and [[slug|display]] from markdown, resolve to page IDs,
-        replace old links."""
+        replace old links.
+
+        ``commit=False`` lets a caller (e.g. ``update_page``) fold the link sync
+        into its own transaction so the whole save is atomic.
+        """
         # Extract all [[...]] wiki-link targets. F-006: support the
         # ``[[slug|display text]]`` form — the part before the pipe is the link
         # target, the part after is the human-readable label.
@@ -1486,7 +1510,8 @@ class WikiStore:
                    VALUES (?, ?, ?, ?, ?)""",
                 (page_id, target_id, vault_id, link_text, now),
             )
-        self._db.commit()
+        if commit:
+            self._db.commit()
 
         rows = self._db.execute(
             "SELECT * FROM wiki_page_links WHERE source_page_id = ? AND vault_id = ?",

--- a/backend/app/services/wiki_store.py
+++ b/backend/app/services/wiki_store.py
@@ -201,6 +201,16 @@ def normalize_slug(text: str) -> str:
     return text
 
 
+def normalize_claim_text(text: str) -> str:
+    """Normalize claim text for fuzzy dedup: lowercase, strip punctuation,
+    collapse whitespace. Stored in the indexed ``wiki_claims.normalized_text``
+    column so near-duplicate claims can be found with a bounded indexed lookup
+    instead of a full-table scan (DD-C011)."""
+    normalized = re.sub(r"[^\w\s]", "", (text or "").lower().strip())
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
 def _row_to_dict(row: sqlite3.Row) -> dict:
     return dict(row)
 
@@ -491,6 +501,7 @@ class WikiStore:
         vault_id: int,
         expected_version: Optional[int] = None,
         edited_by: Optional[int] = None,
+        commit: bool = True,
         **kwargs: Any,
     ) -> Optional[WikiPage]:
         allowed = {"title", "page_type", "markdown", "summary", "status", "confidence", "slug", "last_compiled_at", "parent_id"}
@@ -498,49 +509,57 @@ class WikiStore:
         if not updates:
             return self.get_page(page_id)
 
-        # DD-C020: optimistic locking
-        if expected_version is not None:
-            row = self._db.execute(
-                "SELECT version FROM wiki_pages WHERE id = ? AND vault_id = ?",
-                (page_id, vault_id),
-            ).fetchone()
-            if not row:
-                return None
-            current_version = dict(row)["version"]
-            if current_version != expected_version:
-                raise ValueError(
-                    f"Version conflict: expected {expected_version}, got {current_version}"
-                )
+        # DD-C020: optimistic locking. Read current version once and reuse it for
+        # both the conflict check and the bump so there is a single read point.
+        row = self._db.execute(
+            "SELECT version FROM wiki_pages WHERE id = ? AND vault_id = ?",
+            (page_id, vault_id),
+        ).fetchone()
+        if not row:
+            return None
+        current_version = dict(row)["version"]
+        if expected_version is not None and current_version != expected_version:
+            raise ValueError(
+                f"Version conflict: expected {expected_version}, got {current_version}"
+            )
 
         # DD-C003: snapshot current state before updating
-        self.save_version(page_id, vault_id, edited_by=edited_by)
+        self.save_version(page_id, vault_id, edited_by=edited_by, commit=False)
 
         if "title" in updates and "slug" not in updates:
             updates["slug"] = normalize_slug(updates["title"])
         if "slug" in updates:
             updates["slug"] = normalize_slug(updates["slug"])
         updates["updated_at"] = datetime.utcnow().isoformat()
-        updates["version"] = self._db.execute(
-            "SELECT version FROM wiki_pages WHERE id = ? AND vault_id = ?",
-            (page_id, vault_id),
-        ).fetchone()[0] + 1
+        updates["version"] = current_version + 1
         set_clause = ", ".join(f"{k} = ?" for k in updates)
-        values = list(updates.values()) + [page_id, vault_id]
-        self._db.execute(
-            f"UPDATE wiki_pages SET {set_clause} WHERE id = ? AND vault_id = ?", values
+        # F-005: pin the UPDATE to the version we read so a concurrent writer that
+        # already bumped the row cannot be silently clobbered (TOCTOU). The
+        # rowcount check turns a lost update into an explicit conflict.
+        values = list(updates.values()) + [page_id, vault_id, current_version]
+        cur = self._db.execute(
+            f"UPDATE wiki_pages SET {set_clause} WHERE id = ? AND vault_id = ? AND version = ?",
+            values,
         )
-        self._db.commit()
-        self.log_activity(vault_id, "page_updated", "page", page_id, user_id=edited_by)
+        if cur.rowcount == 0:
+            self._db.rollback()
+            raise ValueError(
+                f"Version conflict: page {page_id} was modified concurrently"
+            )
+        self.log_activity(vault_id, "page_updated", "page", page_id, user_id=edited_by, commit=False)
+        if commit:
+            self._db.commit()
         return self.get_page(page_id)
 
-    def delete_page(self, page_id: int, vault_id: int) -> bool:
+    def delete_page(self, page_id: int, vault_id: int, commit: bool = True) -> bool:
         cur = self._db.execute(
             "DELETE FROM wiki_pages WHERE id = ? AND vault_id = ?", (page_id, vault_id)
         )
-        self._db.commit()
         deleted = cur.rowcount > 0
         if deleted:
-            self.log_activity(vault_id, "page_deleted", "page", page_id)
+            self.log_activity(vault_id, "page_deleted", "page", page_id, commit=False)
+        if commit:
+            self._db.commit()
         return deleted
 
     def _fts_page_ids(self, vault_id: int, query: str) -> list[int]:
@@ -611,25 +630,36 @@ class WikiStore:
         vault_id: int,
         search: Optional[str] = None,
         page_id: Optional[int] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
     ) -> list[WikiEntity]:
+        # F-012: bound result sets so a large vault cannot return an unbounded list.
+        page_clause = ""
+        page_params: list[Any] = []
+        if limit is not None:
+            page_clause = " LIMIT ? OFFSET ?"
+            page_params = [limit, offset]
         if search:
             ids = self._fts_entity_ids(vault_id, search)
             if not ids:
                 return []
             placeholders = ",".join("?" * len(ids))
             rows = self._db.execute(
-                f"SELECT * FROM wiki_entities WHERE id IN ({placeholders}) AND vault_id = ?",
-                [*ids, vault_id],
+                f"SELECT * FROM wiki_entities WHERE id IN ({placeholders}) AND vault_id = ?"
+                f" ORDER BY canonical_name{page_clause}",
+                [*ids, vault_id, *page_params],
             ).fetchall()
         elif page_id is not None:
             rows = self._db.execute(
-                "SELECT * FROM wiki_entities WHERE vault_id = ? AND page_id = ? ORDER BY canonical_name",
-                (vault_id, page_id),
+                f"SELECT * FROM wiki_entities WHERE vault_id = ? AND page_id = ?"
+                f" ORDER BY canonical_name{page_clause}",
+                [vault_id, page_id, *page_params],
             ).fetchall()
         else:
             rows = self._db.execute(
-                "SELECT * FROM wiki_entities WHERE vault_id = ? ORDER BY canonical_name",
-                (vault_id,),
+                f"SELECT * FROM wiki_entities WHERE vault_id = ?"
+                f" ORDER BY canonical_name{page_clause}",
+                [vault_id, *page_params],
             ).fetchall()
         return [_to_wiki_entity(r) for r in rows]
 
@@ -662,11 +692,12 @@ class WikiStore:
         now = datetime.utcnow().isoformat()
         cur = self._db.execute(
             """INSERT INTO wiki_claims
-               (vault_id, page_id, claim_text, claim_type, subject, predicate, object,
+               (vault_id, page_id, claim_text, normalized_text, claim_type, subject, predicate, object,
                 source_type, status, confidence, created_by, created_by_kind,
                 created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (vault_id, page_id, claim_text, claim_type, subject, predicate, object,
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (vault_id, page_id, claim_text, normalize_claim_text(claim_text), claim_type,
+             subject, predicate, object,
              source_type, status, confidence, created_by, created_by_kind, now, now),
         )
         claim_id = cur.lastrowid
@@ -691,6 +722,8 @@ class WikiStore:
         entity: Optional[str] = None,
         search: Optional[str] = None,
         status: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
     ) -> list[WikiClaim]:
         if search:
             ids = self._fts_claim_ids(vault_id, search)
@@ -712,10 +745,17 @@ class WikiStore:
             sql += " AND status = ?"
             params.append(status)
         sql += " ORDER BY created_at DESC"
+        # F-012: bound result sets so a large vault cannot return an unbounded list.
+        if limit is not None:
+            sql += " LIMIT ? OFFSET ?"
+            params += [limit, offset]
         rows = self._db.execute(sql, params).fetchall()
         claims = [_to_wiki_claim(r) for r in rows]
+        # F-008: batch-load every claim's sources in a single query instead of
+        # firing one SELECT per claim (N+1).
+        sources_by_claim = self._load_sources_for([c.id for c in claims])
         for claim in claims:
-            claim.sources = self._load_sources(claim.id)
+            claim.sources = sources_by_claim.get(claim.id, [])
         return claims
 
     def find_claim_by_text(self, vault_id: int, claim_text: str) -> Optional[WikiClaim]:
@@ -735,6 +775,8 @@ class WikiStore:
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:
             return self.get_claim(claim_id)
+        if "claim_text" in updates:
+            updates["normalized_text"] = normalize_claim_text(updates["claim_text"])
         updates["updated_at"] = datetime.utcnow().isoformat()
         set_clause = ", ".join(f"{k} = ?" for k in updates)
         values = list(updates.values()) + [claim_id, vault_id]
@@ -802,6 +844,21 @@ class WikiStore:
             "SELECT * FROM wiki_claim_sources WHERE claim_id = ? ORDER BY id", (claim_id,)
         ).fetchall()
         return [_to_claim_source(r) for r in rows]
+
+    def _load_sources_for(self, claim_ids: list[int]) -> dict[int, list[WikiClaimSource]]:
+        """Batch-load sources for many claims in one query (avoids N+1)."""
+        if not claim_ids:
+            return {}
+        placeholders = ",".join("?" * len(claim_ids))
+        rows = self._db.execute(
+            f"SELECT * FROM wiki_claim_sources WHERE claim_id IN ({placeholders}) ORDER BY claim_id, id",
+            claim_ids,
+        ).fetchall()
+        grouped: dict[int, list[WikiClaimSource]] = {}
+        for r in rows:
+            src = _to_claim_source(r)
+            grouped.setdefault(src.claim_id, []).append(src)
+        return grouped
 
     def _fts_claim_ids(self, vault_id: int, query: str) -> list[int]:
         rows = self._db.execute(
@@ -886,17 +943,33 @@ class WikiStore:
         row = self._db.execute("SELECT * FROM wiki_compile_jobs WHERE id = ?", (cur.lastrowid,)).fetchone()
         return _to_compile_job(row)
 
-    def list_jobs(self, vault_id: int, status: Optional[str] = None) -> list[WikiCompileJob]:
+    def list_jobs(
+        self,
+        vault_id: int,
+        status: Optional[str] = None,
+        limit: Optional[int] = None,
+        trigger_type: Optional[str] = None,
+        trigger_id: Optional[str] = None,
+    ) -> list[WikiCompileJob]:
+        # F-012: optional bound so callers that only need recent jobs don't pull
+        # the vault's entire job history. trigger_type/trigger_id let status
+        # endpoints filter in SQL instead of pulling and filtering in Python.
+        sql = "SELECT * FROM wiki_compile_jobs WHERE vault_id = ?"
+        params: list[Any] = [vault_id]
         if status:
-            rows = self._db.execute(
-                "SELECT * FROM wiki_compile_jobs WHERE vault_id = ? AND status = ? ORDER BY created_at DESC",
-                (vault_id, status),
-            ).fetchall()
-        else:
-            rows = self._db.execute(
-                "SELECT * FROM wiki_compile_jobs WHERE vault_id = ? ORDER BY created_at DESC",
-                (vault_id,),
-            ).fetchall()
+            sql += " AND status = ?"
+            params.append(status)
+        if trigger_type is not None:
+            sql += " AND trigger_type = ?"
+            params.append(trigger_type)
+        if trigger_id is not None:
+            sql += " AND trigger_id = ?"
+            params.append(trigger_id)
+        sql += " ORDER BY created_at DESC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = self._db.execute(sql, params).fetchall()
         return [_to_compile_job(r) for r in rows]
 
     def get_job(self, job_id: int, vault_id: int) -> Optional[WikiCompileJob]:
@@ -1290,6 +1363,7 @@ class WikiStore:
         page_id: int,
         vault_id: int,
         edited_by: Optional[int] = None,
+        commit: bool = True,
     ) -> Optional[WikiPageVersion]:
         """Snapshot current page state into wiki_page_versions before an update."""
         row = self._db.execute(
@@ -1307,7 +1381,8 @@ class WikiStore:
             (page_id, vault_id, d["title"], d["markdown"], d.get("summary") or "",
              d["status"], d.get("confidence") or 0.0, edited_by, now),
         )
-        self._db.commit()
+        if commit:
+            self._db.commit()
         vrow = self._db.execute(
             "SELECT * FROM wiki_page_versions WHERE id = ?", (cur.lastrowid,)
         ).fetchone()
@@ -1362,18 +1437,39 @@ class WikiStore:
     # -----------------------------------------------------------------------
 
     def sync_page_links(self, page_id: int, vault_id: int, markdown: str) -> list[WikiPageLink]:
-        """Parse [[slug]] from markdown, resolve to page IDs, replace old links."""
-        # Extract all [[...]] wiki-link targets
-        slugs = re.findall(r"\[\[([^\]]+)\]\]", markdown)
+        """Parse [[slug]] and [[slug|display]] from markdown, resolve to page IDs,
+        replace old links."""
+        # Extract all [[...]] wiki-link targets. F-006: support the
+        # ``[[slug|display text]]`` form — the part before the pipe is the link
+        # target, the part after is the human-readable label.
+        raw_targets = re.findall(r"\[\[([^\]]+)\]\]", markdown)
+        # (normalized_slug, link_text) pairs in document order.
+        parsed: list[tuple[str, str]] = []
+        for raw in raw_targets:
+            target_part, _, display_part = raw.partition("|")
+            slug = normalize_slug(target_part.strip())
+            if not slug:
+                continue
+            link_text = (display_part.strip() or target_part.strip())
+            parsed.append((slug, link_text))
+
+        # F-009: resolve every distinct slug in a single query instead of one
+        # SELECT per link.
         resolved: list[tuple[int, str]] = []
-        for raw in slugs:
-            slug = normalize_slug(raw.strip())
-            target = self._db.execute(
-                "SELECT id FROM wiki_pages WHERE vault_id = ? AND slug = ?",
-                (vault_id, slug),
-            ).fetchone()
-            if target:
-                resolved.append((target[0], raw.strip()))
+        unique_slugs = list({slug for slug, _ in parsed})
+        if unique_slugs:
+            placeholders = ",".join("?" * len(unique_slugs))
+            rows_by_slug = {
+                r["slug"]: r["id"]
+                for r in self._db.execute(
+                    f"SELECT id, slug FROM wiki_pages WHERE vault_id = ? AND slug IN ({placeholders})",
+                    [vault_id, *unique_slugs],
+                ).fetchall()
+            }
+            for slug, link_text in parsed:
+                target_id = rows_by_slug.get(slug)
+                if target_id is not None:
+                    resolved.append((target_id, link_text))
 
         # Replace old links for this source page
         self._db.execute(
@@ -1398,11 +1494,12 @@ class WikiStore:
         ).fetchall()
         return [_to_page_link(r) for r in rows]
 
-    def list_backlinks(self, page_id: int) -> list[WikiPageLink]:
-        """List pages that link TO this page."""
+    def list_backlinks(self, page_id: int, vault_id: int) -> list[WikiPageLink]:
+        """List pages that link TO this page (scoped to the page's vault)."""
         rows = self._db.execute(
-            "SELECT * FROM wiki_page_links WHERE target_page_id = ? ORDER BY created_at DESC",
-            (page_id,),
+            "SELECT * FROM wiki_page_links WHERE target_page_id = ? AND vault_id = ? "
+            "ORDER BY created_at DESC",
+            (page_id, vault_id),
         ).fetchall()
         return [_to_page_link(r) for r in rows]
 
@@ -1418,6 +1515,7 @@ class WikiStore:
         target_id: int,
         user_id: Optional[int] = None,
         details: Optional[dict] = None,
+        commit: bool = True,
     ) -> WikiActivityEntry:
         """Insert an entry into the wiki activity log."""
         now = datetime.utcnow().isoformat()
@@ -1428,7 +1526,8 @@ class WikiStore:
                VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (vault_id, action, target_type, target_id, user_id, details_json, now),
         )
-        self._db.commit()
+        if commit:
+            self._db.commit()
         row = self._db.execute(
             "SELECT * FROM wiki_activity_log WHERE id = ?", (cur.lastrowid,)
         ).fetchone()
@@ -1447,39 +1546,47 @@ class WikiStore:
     # -----------------------------------------------------------------------
 
     def find_claim_by_normalized_text(self, vault_id: int, claim_text: str) -> Optional[WikiClaim]:
-        """Normalize text (lowercase, strip punctuation, collapse spaces) and compare."""
-        normalized = re.sub(r"[^\w\s]", "", claim_text.lower().strip())
-        normalized = re.sub(r"\s+", " ", normalized).strip()
-        rows = self._db.execute(
-            "SELECT * FROM wiki_claims WHERE vault_id = ?", (vault_id,)
-        ).fetchall()
-        for row in rows:
-            existing_text = dict(row).get("claim_text") or ""
-            existing_norm = re.sub(r"[^\w\s]", "", existing_text.lower().strip())
-            existing_norm = re.sub(r"\s+", " ", existing_norm).strip()
-            if existing_norm == normalized:
-                claim = _to_wiki_claim(row)
-                claim.sources = self._load_sources(claim.id)
-                return claim
-        return None
+        """Find a claim by normalized text using the indexed normalized_text column."""
+        normalized = normalize_claim_text(claim_text)
+        if not normalized:
+            return None
+        row = self._db.execute(
+            "SELECT * FROM wiki_claims WHERE vault_id = ? AND normalized_text = ? LIMIT 1",
+            (vault_id, normalized),
+        ).fetchone()
+        if row is None:
+            return None
+        claim = _to_wiki_claim(row)
+        claim.sources = self._load_sources(claim.id)
+        return claim
 
     # -----------------------------------------------------------------------
     # Bulk Operations (DD-C025)
     # -----------------------------------------------------------------------
 
     def bulk_update_pages(self, page_ids: list[int], vault_id: int, **kwargs: Any) -> list[WikiPage]:
-        """Update multiple pages at once. Returns list of updated pages."""
-        results = []
-        for pid in page_ids:
-            page = self.update_page(pid, vault_id, **kwargs)
-            if page:
-                results.append(page)
+        """Update multiple pages atomically. Either all succeed or none are committed."""
+        results: list[WikiPage] = []
+        try:
+            for pid in page_ids:
+                page = self.update_page(pid, vault_id, commit=False, **kwargs)
+                if page:
+                    results.append(page)
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
         return results
 
     def bulk_delete_pages(self, page_ids: list[int], vault_id: int) -> int:
-        """Delete multiple pages at once. Returns number of pages deleted."""
+        """Delete multiple pages atomically. Either all succeed or none are committed."""
         count = 0
-        for pid in page_ids:
-            if self.delete_page(pid, vault_id):
-                count += 1
+        try:
+            for pid in page_ids:
+                if self.delete_page(pid, vault_id, commit=False):
+                    count += 1
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
         return count

--- a/backend/app/services/wiki_store.py
+++ b/backend/app/services/wiki_store.py
@@ -31,6 +31,8 @@ class WikiPage:
     created_at: str
     updated_at: str
     last_compiled_at: Optional[str]
+    parent_id: Optional[int] = None
+    version: int = 1
     claims: list = field(default_factory=list)
     entities: list = field(default_factory=list)
     lint_findings: list = field(default_factory=list)
@@ -141,6 +143,51 @@ class WikiLintFinding:
     updated_at: str
 
 
+@dataclass
+class WikiPageVersion:
+    id: int
+    page_id: int
+    vault_id: int
+    title: str
+    markdown: str
+    summary: str
+    status: str
+    confidence: float
+    edited_by: Optional[int]
+    created_at: str
+
+
+@dataclass
+class WikiPageFile:
+    id: int
+    page_id: int
+    file_id: int
+    vault_id: int
+    created_at: str
+
+
+@dataclass
+class WikiPageLink:
+    id: int
+    source_page_id: int
+    target_page_id: int
+    vault_id: int
+    link_text: Optional[str]
+    created_at: str
+
+
+@dataclass
+class WikiActivityEntry:
+    id: int
+    vault_id: int
+    action: str
+    target_type: str
+    target_id: int
+    user_id: Optional[int]
+    details_json: str
+    created_at: str
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -174,6 +221,8 @@ def _to_wiki_page(row: sqlite3.Row) -> WikiPage:
         created_at=d["created_at"],
         updated_at=d["updated_at"],
         last_compiled_at=d.get("last_compiled_at"),
+        parent_id=d.get("parent_id"),
+        version=d.get("version") or 1,
     )
 
 
@@ -283,6 +332,59 @@ def _to_lint_finding(row: sqlite3.Row) -> WikiLintFinding:
     )
 
 
+def _to_page_version(row: sqlite3.Row) -> WikiPageVersion:
+    d = _row_to_dict(row)
+    return WikiPageVersion(
+        id=d["id"],
+        page_id=d["page_id"],
+        vault_id=d["vault_id"],
+        title=d["title"],
+        markdown=d["markdown"],
+        summary=d.get("summary") or "",
+        status=d["status"],
+        confidence=d.get("confidence") or 0.0,
+        edited_by=d.get("edited_by"),
+        created_at=d["created_at"],
+    )
+
+
+def _to_page_file(row: sqlite3.Row) -> WikiPageFile:
+    d = _row_to_dict(row)
+    return WikiPageFile(
+        id=d["id"],
+        page_id=d["page_id"],
+        file_id=d["file_id"],
+        vault_id=d["vault_id"],
+        created_at=d["created_at"],
+    )
+
+
+def _to_page_link(row: sqlite3.Row) -> WikiPageLink:
+    d = _row_to_dict(row)
+    return WikiPageLink(
+        id=d["id"],
+        source_page_id=d["source_page_id"],
+        target_page_id=d["target_page_id"],
+        vault_id=d["vault_id"],
+        link_text=d.get("link_text"),
+        created_at=d["created_at"],
+    )
+
+
+def _to_activity_entry(row: sqlite3.Row) -> WikiActivityEntry:
+    d = _row_to_dict(row)
+    return WikiActivityEntry(
+        id=d["id"],
+        vault_id=d["vault_id"],
+        action=d["action"],
+        target_type=d["target_type"],
+        target_id=d["target_id"],
+        user_id=d.get("user_id"),
+        details_json=d.get("details_json") or "{}",
+        created_at=d["created_at"],
+    )
+
+
 # ---------------------------------------------------------------------------
 # WikiStore
 # ---------------------------------------------------------------------------
@@ -309,6 +411,7 @@ class WikiStore:
         status: str = "draft",
         confidence: float = 0.0,
         created_by: Optional[int] = None,
+        parent_id: Optional[int] = None,
     ) -> WikiPage:
         if not slug:
             slug = normalize_slug(title)
@@ -318,13 +421,16 @@ class WikiStore:
         cur = self._db.execute(
             """
             INSERT INTO wiki_pages
-                (vault_id, slug, title, page_type, markdown, summary, status, confidence, created_by, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (vault_id, slug, title, page_type, markdown, summary, status, confidence, created_by, parent_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (vault_id, slug, title, page_type, markdown, summary, status, confidence, created_by, now, now),
+            (vault_id, slug, title, page_type, markdown, summary, status, confidence, created_by, parent_id, now, now),
         )
         self._db.commit()
-        return self.get_page(cur.lastrowid)  # type: ignore[arg-type]
+        page = self.get_page(cur.lastrowid)  # type: ignore[arg-type]
+        if page:
+            self.log_activity(vault_id, "page_created", "page", page.id, user_id=created_by)
+        return page  # type: ignore[return-value]
 
     def get_page(self, page_id: int, load_relations: bool = True) -> Optional[WikiPage]:
         row = self._db.execute(
@@ -379,22 +485,52 @@ class WikiStore:
             rows = self._db.execute(sql, params).fetchall()
         return [_to_wiki_page(r) for r in rows]
 
-    def update_page(self, page_id: int, vault_id: int, **kwargs: Any) -> Optional[WikiPage]:
-        allowed = {"title", "page_type", "markdown", "summary", "status", "confidence", "slug", "last_compiled_at"}
+    def update_page(
+        self,
+        page_id: int,
+        vault_id: int,
+        expected_version: Optional[int] = None,
+        edited_by: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Optional[WikiPage]:
+        allowed = {"title", "page_type", "markdown", "summary", "status", "confidence", "slug", "last_compiled_at", "parent_id"}
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:
             return self.get_page(page_id)
+
+        # DD-C020: optimistic locking
+        if expected_version is not None:
+            row = self._db.execute(
+                "SELECT version FROM wiki_pages WHERE id = ? AND vault_id = ?",
+                (page_id, vault_id),
+            ).fetchone()
+            if not row:
+                return None
+            current_version = dict(row)["version"]
+            if current_version != expected_version:
+                raise ValueError(
+                    f"Version conflict: expected {expected_version}, got {current_version}"
+                )
+
+        # DD-C003: snapshot current state before updating
+        self.save_version(page_id, vault_id, edited_by=edited_by)
+
         if "title" in updates and "slug" not in updates:
             updates["slug"] = normalize_slug(updates["title"])
         if "slug" in updates:
             updates["slug"] = normalize_slug(updates["slug"])
         updates["updated_at"] = datetime.utcnow().isoformat()
+        updates["version"] = self._db.execute(
+            "SELECT version FROM wiki_pages WHERE id = ? AND vault_id = ?",
+            (page_id, vault_id),
+        ).fetchone()[0] + 1
         set_clause = ", ".join(f"{k} = ?" for k in updates)
         values = list(updates.values()) + [page_id, vault_id]
         self._db.execute(
             f"UPDATE wiki_pages SET {set_clause} WHERE id = ? AND vault_id = ?", values
         )
         self._db.commit()
+        self.log_activity(vault_id, "page_updated", "page", page_id, user_id=edited_by)
         return self.get_page(page_id)
 
     def delete_page(self, page_id: int, vault_id: int) -> bool:
@@ -402,7 +538,10 @@ class WikiStore:
             "DELETE FROM wiki_pages WHERE id = ? AND vault_id = ?", (page_id, vault_id)
         )
         self._db.commit()
-        return cur.rowcount > 0
+        deleted = cur.rowcount > 0
+        if deleted:
+            self.log_activity(vault_id, "page_deleted", "page", page_id)
+        return deleted
 
     def _fts_page_ids(self, vault_id: int, query: str) -> list[int]:
         rows = self._db.execute(
@@ -432,6 +571,16 @@ class WikiStore:
         if existing:
             existing_entity = _to_wiki_entity(existing)
             merged_aliases = list(set(existing_entity.aliases + (aliases or [])))
+            # Guard: skip aliases that collide with another entity's canonical_name
+            if merged_aliases:
+                placeholders = ",".join("?" for _ in merged_aliases)
+                conflicts = self._db.execute(
+                    f"SELECT canonical_name FROM wiki_entities WHERE vault_id = ? AND id != ? AND lower(canonical_name) IN ({placeholders})",
+                    [vault_id, existing_entity.id] + [a.lower() for a in merged_aliases],
+                ).fetchall()
+                if conflicts:
+                    conflict_names = {r[0].lower() for r in conflicts}
+                    merged_aliases = [a for a in merged_aliases if a.lower() not in conflict_names]
             merged_json = json.dumps(merged_aliases)
             new_page_id = page_id if page_id is not None else existing_entity.page_id
             new_desc = description or existing_entity.description
@@ -811,7 +960,7 @@ class WikiStore:
             """UPDATE wiki_compile_jobs
                SET status = 'failed', completed_at = ?, error = ?, retry_count = retry_count + 1
                WHERE id = ? AND status != 'cancelled'""",
-            (now, error[:2000], job_id),
+            (now, error[:8000], job_id),
         )
         self._db.commit()
         row = self._db.execute(
@@ -1085,6 +1234,9 @@ class WikiStore:
         vault_id: int,
         query: str,
         limit: int = 20,
+        page_type: Optional[str] = None,
+        status: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> dict:
         page_ids = self._fts_page_ids(vault_id, query)
         claim_ids = self._fts_claim_ids(vault_id, query)
@@ -1093,10 +1245,20 @@ class WikiStore:
         pages = []
         if page_ids:
             ph = ",".join("?" * min(len(page_ids), limit))
-            rows = self._db.execute(
-                f"SELECT * FROM wiki_pages WHERE id IN ({ph}) AND vault_id = ? LIMIT ?",
-                [*page_ids[:limit], vault_id, limit],
-            ).fetchall()
+            sql = f"SELECT * FROM wiki_pages WHERE id IN ({ph}) AND vault_id = ?"
+            params: list[Any] = [*page_ids[:limit], vault_id]
+            if page_type:
+                sql += " AND page_type = ?"
+                params.append(page_type)
+            if status:
+                sql += " AND status = ?"
+                params.append(status)
+            allowed_sorts = {"updated_at", "created_at", "title", "confidence"}
+            order_col = sort_by if sort_by in allowed_sorts else "updated_at"
+            order_dir = "ASC" if order_col == "title" else "DESC"
+            sql += f" ORDER BY {order_col} {order_dir} LIMIT ?"
+            params.append(limit)
+            rows = self._db.execute(sql, params).fetchall()
             pages = [_to_wiki_page(r) for r in rows]
 
         claims = []
@@ -1118,3 +1280,206 @@ class WikiStore:
             entities = [_to_wiki_entity(r) for r in rows]
 
         return {"pages": pages, "claims": claims, "entities": entities, "query": query}
+
+    # -----------------------------------------------------------------------
+    # Version History (DD-C003)
+    # -----------------------------------------------------------------------
+
+    def save_version(
+        self,
+        page_id: int,
+        vault_id: int,
+        edited_by: Optional[int] = None,
+    ) -> Optional[WikiPageVersion]:
+        """Snapshot current page state into wiki_page_versions before an update."""
+        row = self._db.execute(
+            "SELECT * FROM wiki_pages WHERE id = ? AND vault_id = ?",
+            (page_id, vault_id),
+        ).fetchone()
+        if not row:
+            return None
+        d = _row_to_dict(row)
+        now = datetime.utcnow().isoformat()
+        cur = self._db.execute(
+            """INSERT INTO wiki_page_versions
+               (page_id, vault_id, title, markdown, summary, status, confidence, edited_by, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (page_id, vault_id, d["title"], d["markdown"], d.get("summary") or "",
+             d["status"], d.get("confidence") or 0.0, edited_by, now),
+        )
+        self._db.commit()
+        vrow = self._db.execute(
+            "SELECT * FROM wiki_page_versions WHERE id = ?", (cur.lastrowid,)
+        ).fetchone()
+        return _to_page_version(vrow)
+
+    def list_versions(self, page_id: int, limit: int = 20) -> list[WikiPageVersion]:
+        """List version history for a page, most recent first."""
+        rows = self._db.execute(
+            "SELECT * FROM wiki_page_versions WHERE page_id = ? ORDER BY created_at DESC LIMIT ?",
+            (page_id, limit),
+        ).fetchall()
+        return [_to_page_version(r) for r in rows]
+
+    # -----------------------------------------------------------------------
+    # File Attachments (DD-C019)
+    # -----------------------------------------------------------------------
+
+    def attach_file(self, page_id: int, file_id: int, vault_id: int) -> Optional[WikiPageFile]:
+        """Attach a file to a wiki page. INSERT OR IGNORE for idempotency."""
+        now = datetime.utcnow().isoformat()
+        self._db.execute(
+            """INSERT OR IGNORE INTO wiki_page_files (page_id, file_id, vault_id, created_at)
+               VALUES (?, ?, ?, ?)""",
+            (page_id, file_id, vault_id, now),
+        )
+        self._db.commit()
+        row = self._db.execute(
+            "SELECT * FROM wiki_page_files WHERE page_id = ? AND file_id = ?",
+            (page_id, file_id),
+        ).fetchone()
+        return _to_page_file(row) if row else None
+
+    def detach_file(self, page_id: int, file_id: int, vault_id: int) -> bool:
+        """Remove a file attachment from a wiki page."""
+        cur = self._db.execute(
+            "DELETE FROM wiki_page_files WHERE page_id = ? AND file_id = ? AND vault_id = ?",
+            (page_id, file_id, vault_id),
+        )
+        self._db.commit()
+        return cur.rowcount > 0
+
+    def list_page_files(self, page_id: int) -> list[WikiPageFile]:
+        """List files attached to a wiki page."""
+        rows = self._db.execute(
+            "SELECT * FROM wiki_page_files WHERE page_id = ? ORDER BY created_at",
+            (page_id,),
+        ).fetchall()
+        return [_to_page_file(r) for r in rows]
+
+    # -----------------------------------------------------------------------
+    # Wiki Links (DD-C030)
+    # -----------------------------------------------------------------------
+
+    def sync_page_links(self, page_id: int, vault_id: int, markdown: str) -> list[WikiPageLink]:
+        """Parse [[slug]] from markdown, resolve to page IDs, replace old links."""
+        # Extract all [[...]] wiki-link targets
+        slugs = re.findall(r"\[\[([^\]]+)\]\]", markdown)
+        resolved: list[tuple[int, str]] = []
+        for raw in slugs:
+            slug = normalize_slug(raw.strip())
+            target = self._db.execute(
+                "SELECT id FROM wiki_pages WHERE vault_id = ? AND slug = ?",
+                (vault_id, slug),
+            ).fetchone()
+            if target:
+                resolved.append((target[0], raw.strip()))
+
+        # Replace old links for this source page
+        self._db.execute(
+            "DELETE FROM wiki_page_links WHERE source_page_id = ? AND vault_id = ?",
+            (page_id, vault_id),
+        )
+        now = datetime.utcnow().isoformat()
+        for target_id, link_text in resolved:
+            if target_id == page_id:
+                continue  # skip self-links
+            self._db.execute(
+                """INSERT OR IGNORE INTO wiki_page_links
+                   (source_page_id, target_page_id, vault_id, link_text, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (page_id, target_id, vault_id, link_text, now),
+            )
+        self._db.commit()
+
+        rows = self._db.execute(
+            "SELECT * FROM wiki_page_links WHERE source_page_id = ? AND vault_id = ?",
+            (page_id, vault_id),
+        ).fetchall()
+        return [_to_page_link(r) for r in rows]
+
+    def list_backlinks(self, page_id: int) -> list[WikiPageLink]:
+        """List pages that link TO this page."""
+        rows = self._db.execute(
+            "SELECT * FROM wiki_page_links WHERE target_page_id = ? ORDER BY created_at DESC",
+            (page_id,),
+        ).fetchall()
+        return [_to_page_link(r) for r in rows]
+
+    # -----------------------------------------------------------------------
+    # Activity Log (DD-C026)
+    # -----------------------------------------------------------------------
+
+    def log_activity(
+        self,
+        vault_id: int,
+        action: str,
+        target_type: str,
+        target_id: int,
+        user_id: Optional[int] = None,
+        details: Optional[dict] = None,
+    ) -> WikiActivityEntry:
+        """Insert an entry into the wiki activity log."""
+        now = datetime.utcnow().isoformat()
+        details_json = json.dumps(details) if details else "{}"
+        cur = self._db.execute(
+            """INSERT INTO wiki_activity_log
+               (vault_id, action, target_type, target_id, user_id, details_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (vault_id, action, target_type, target_id, user_id, details_json, now),
+        )
+        self._db.commit()
+        row = self._db.execute(
+            "SELECT * FROM wiki_activity_log WHERE id = ?", (cur.lastrowid,)
+        ).fetchone()
+        return _to_activity_entry(row)
+
+    def list_activity(self, vault_id: int, limit: int = 50) -> list[WikiActivityEntry]:
+        """List recent activity for a vault."""
+        rows = self._db.execute(
+            "SELECT * FROM wiki_activity_log WHERE vault_id = ? ORDER BY created_at DESC LIMIT ?",
+            (vault_id, limit),
+        ).fetchall()
+        return [_to_activity_entry(r) for r in rows]
+
+    # -----------------------------------------------------------------------
+    # Improved Claim Dedup (DD-C011)
+    # -----------------------------------------------------------------------
+
+    def find_claim_by_normalized_text(self, vault_id: int, claim_text: str) -> Optional[WikiClaim]:
+        """Normalize text (lowercase, strip punctuation, collapse spaces) and compare."""
+        normalized = re.sub(r"[^\w\s]", "", claim_text.lower().strip())
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        rows = self._db.execute(
+            "SELECT * FROM wiki_claims WHERE vault_id = ?", (vault_id,)
+        ).fetchall()
+        for row in rows:
+            existing_text = dict(row).get("claim_text") or ""
+            existing_norm = re.sub(r"[^\w\s]", "", existing_text.lower().strip())
+            existing_norm = re.sub(r"\s+", " ", existing_norm).strip()
+            if existing_norm == normalized:
+                claim = _to_wiki_claim(row)
+                claim.sources = self._load_sources(claim.id)
+                return claim
+        return None
+
+    # -----------------------------------------------------------------------
+    # Bulk Operations (DD-C025)
+    # -----------------------------------------------------------------------
+
+    def bulk_update_pages(self, page_ids: list[int], vault_id: int, **kwargs: Any) -> list[WikiPage]:
+        """Update multiple pages at once. Returns list of updated pages."""
+        results = []
+        for pid in page_ids:
+            page = self.update_page(pid, vault_id, **kwargs)
+            if page:
+                results.append(page)
+        return results
+
+    def bulk_delete_pages(self, page_ids: list[int], vault_id: int) -> int:
+        """Delete multiple pages at once. Returns number of pages deleted."""
+        count = 0
+        for pid in page_ids:
+            if self.delete_page(pid, vault_id):
+                count += 1
+        return count

--- a/backend/tests/test_wiki_compile_processor.py
+++ b/backend/tests/test_wiki_compile_processor.py
@@ -1193,8 +1193,12 @@ class TestWikiFirstRetrievalGate(unittest.TestCase):
     def tearDown(self):
         self.conn.close()
 
-    def _make_wiki_evidence(self, claim_status, confidence, page_status="needs_review"):
+    def _make_wiki_evidence(self, claim_status, confidence, page_status="needs_review", freshness=None):
+        from datetime import datetime as _dt
+
         from app.services.wiki_retrieval import WikiEvidence
+        if freshness is None:
+            freshness = _dt.utcnow().isoformat()
         return WikiEvidence(
             label_placeholder="W1",
             page_id=1,
@@ -1209,7 +1213,7 @@ class TestWikiFirstRetrievalGate(unittest.TestCase):
             claim_status=claim_status,
             score=confidence,
             score_type="relation",
-            freshness=None,
+            freshness=freshness,
             source_count=1,
             provenance_summary="1 doc",
         )
@@ -1280,3 +1284,12 @@ class TestWikiFirstRetrievalGate(unittest.TestCase):
         )
         result = _raw_rag_required("entity_lookup", [evidence])
         self.assertTrue(result, "Stale page must require raw RAG regardless of claim status")
+
+    def test_stale_freshness_requires_raw_rag(self):
+        """Old freshness timestamp must not suppress raw RAG even with active high-confidence claim."""
+        from app.services.rag_engine import _raw_rag_required
+        evidence = self._make_wiki_evidence(
+            claim_status="active", confidence=0.9, freshness="2020-01-01T00:00:00"
+        )
+        result = _raw_rag_required("entity_lookup", [evidence])
+        self.assertTrue(result, "Stale freshness must require raw RAG")

--- a/backend/tests/test_wiki_routes.py
+++ b/backend/tests/test_wiki_routes.py
@@ -899,3 +899,578 @@ class TestWikiCSRFProtection(WikiRouteTestBase):
 
     # ---- Lint finding resolve route with CSRF ----
     # Skipping as it requires lint_finding seeding with proper schema
+
+
+# ===========================================================================
+# New endpoint coverage (versions, files, backlinks, activity, bulk,
+# entities/claims paging, document/memory status, optimistic lock, F-003,
+# F-010). All subclass WikiRouteTestBase and mirror its harness exactly.
+# ===========================================================================
+
+
+class WikiNewRouteTestBase(WikiRouteTestBase):
+    """Extends the base harness with a file-insert helper and vault-2 helper.
+
+    The base ``init_db`` applies SCHEMA only; it does NOT run the production
+    migrations that add ``wiki_compile_jobs.input_json`` /
+    ``wiki_compile_jobs.retry_count`` (those live in ``run_migrations``). The
+    ``/compile``, ``/recompile``, and job-status routes call
+    ``store.create_job(..., input_json=...)``, so we patch those columns onto
+    the harness DB here (test-only fixture parity with production migrations).
+    This does NOT modify any source or the shared base class.
+    """
+
+    def setUp(self):
+        super().setUp()
+        conn = self._raw()
+        job_cols = {r[1] for r in conn.execute("PRAGMA table_info(wiki_compile_jobs)").fetchall()}
+        if "input_json" not in job_cols:
+            conn.execute("ALTER TABLE wiki_compile_jobs ADD COLUMN input_json TEXT DEFAULT '{}'")
+        if "retry_count" not in job_cols:
+            conn.execute("ALTER TABLE wiki_compile_jobs ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0")
+        conn.commit()
+        self._pool.release(conn)
+
+    def _insert_file(
+        self,
+        vault_id: int = 1,
+        file_name: str = "doc.pdf",
+        status: str = "indexed",
+    ) -> int:
+        conn = self._raw()
+        cur = conn.execute(
+            """INSERT INTO files (vault_id, file_path, file_name, file_size, status)
+               VALUES (?, ?, ?, ?, ?)""",
+            (vault_id, f"/tmp/{file_name}", file_name, 1234, status),
+        )
+        conn.commit()
+        file_id = cur.lastrowid
+        self._pool.release(conn)
+        return file_id
+
+    def _insert_vault2(self) -> None:
+        conn = self._raw()
+        conn.execute("INSERT OR IGNORE INTO vaults (id, name) VALUES (2, 'Other')")
+        conn.commit()
+        self._pool.release(conn)
+
+    def _create_page(self, vault_id: int = 1, title: str = "Page", page_type: str = "entity", markdown: str = "") -> dict:
+        resp = self.client.post(
+            "/api/wiki/pages",
+            json={"vault_id": vault_id, "title": title, "page_type": page_type, "markdown": markdown},
+        )
+        self.assertEqual(resp.status_code, 201, resp.text)
+        return resp.json()
+
+
+class TestWikiPageVersionsRoute(WikiNewRouteTestBase):
+
+    def test_versions_returns_history_after_update(self):
+        page = self._create_page(title="Versioned")
+        page_id = page["id"]
+        # An update snapshots the prior state into wiki_page_versions.
+        upd = self.client.put(
+            f"/api/wiki/pages/{page_id}",
+            json={"title": "Versioned v2", "status": "verified"},
+        )
+        self.assertEqual(upd.status_code, 200, upd.text)
+
+        resp = self.client.get(f"/api/wiki/pages/{page_id}/versions", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertIn("versions", data)
+        self.assertGreaterEqual(len(data["versions"]), 1)
+        v = data["versions"][0]
+        self.assertEqual(v["page_id"], page_id)
+        self.assertEqual(v["vault_id"], 1)
+        # The snapshot is the PRE-update title.
+        self.assertEqual(v["title"], "Versioned")
+
+    def test_versions_nonexistent_page_returns_404(self):
+        resp = self.client.get("/api/wiki/pages/99999/versions", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 404)
+
+    def test_versions_wrong_vault_returns_404(self):
+        self._insert_vault2()
+        page = self._create_page(vault_id=1, title="In Vault One")
+        page_id = page["id"]
+        # Page exists but is in vault 1; query as vault 2 -> 404 (scoping).
+        resp = self.client.get(f"/api/wiki/pages/{page_id}/versions", params={"vault_id": 2})
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestWikiPageFilesRoute(WikiNewRouteTestBase):
+
+    def test_attach_list_detach_file(self):
+        page = self._create_page(title="Has Files")
+        page_id = page["id"]
+        file_id = self._insert_file(vault_id=1, file_name="attach.pdf")
+
+        # Attach -> 201
+        attach = self.client.post(
+            f"/api/wiki/pages/{page_id}/files",
+            json={"vault_id": 1, "file_id": file_id},
+        )
+        self.assertEqual(attach.status_code, 201, attach.text)
+        pf = attach.json()
+        self.assertEqual(pf["page_id"], page_id)
+        self.assertEqual(pf["file_id"], file_id)
+        self.assertEqual(pf["vault_id"], 1)
+
+        # List -> 200 with the attachment
+        listing = self.client.get(f"/api/wiki/pages/{page_id}/files", params={"vault_id": 1})
+        self.assertEqual(listing.status_code, 200, listing.text)
+        files = listing.json()["files"]
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0]["file_id"], file_id)
+
+        # Detach -> 204
+        detach = self.client.delete(
+            f"/api/wiki/pages/{page_id}/files/{file_id}", params={"vault_id": 1}
+        )
+        self.assertEqual(detach.status_code, 204, detach.text)
+
+        # List again -> empty
+        listing2 = self.client.get(f"/api/wiki/pages/{page_id}/files", params={"vault_id": 1})
+        self.assertEqual(listing2.json()["files"], [])
+
+    def test_duplicate_attach_returns_409(self):
+        # A second attach of the same (page, file) pair must return 409.
+        # WikiStore.attach_file uses a plain INSERT, so the UNIQUE(page_id,
+        # file_id) constraint raises sqlite3.IntegrityError, which the route
+        # translates into 409. The first attach still leaves exactly one row.
+        page = self._create_page(title="Dup Files")
+        page_id = page["id"]
+        file_id = self._insert_file(vault_id=1)
+        first = self.client.post(
+            f"/api/wiki/pages/{page_id}/files",
+            json={"vault_id": 1, "file_id": file_id},
+        )
+        self.assertEqual(first.status_code, 201, first.text)
+        dup = self.client.post(
+            f"/api/wiki/pages/{page_id}/files",
+            json={"vault_id": 1, "file_id": file_id},
+        )
+        self.assertEqual(dup.status_code, 409, dup.text)
+        self.assertIn("already attached", dup.json()["detail"].lower())
+        # The conflict left the original single attachment intact.
+        listing = self.client.get(f"/api/wiki/pages/{page_id}/files", params={"vault_id": 1})
+        self.assertEqual(len(listing.json()["files"]), 1)
+
+    def test_attach_wrong_vault_page_returns_403(self):
+        # Page is in vault 1; request claims vault 2 -> handler returns 403.
+        self._insert_vault2()
+        page = self._create_page(vault_id=1, title="Vault1 Page")
+        page_id = page["id"]
+        file_id = self._insert_file(vault_id=2)
+        resp = self.client.post(
+            f"/api/wiki/pages/{page_id}/files",
+            json={"vault_id": 2, "file_id": file_id},
+        )
+        self.assertEqual(resp.status_code, 403, resp.text)
+        self.assertIn("vault", resp.json()["detail"].lower())
+
+    def test_detach_nonexistent_attachment_returns_404(self):
+        page = self._create_page(title="No Attach")
+        page_id = page["id"]
+        resp = self.client.delete(
+            f"/api/wiki/pages/{page_id}/files/99999", params={"vault_id": 1}
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_list_files_wrong_vault_returns_404(self):
+        self._insert_vault2()
+        page = self._create_page(vault_id=1, title="Vault1 Files")
+        page_id = page["id"]
+        resp = self.client.get(f"/api/wiki/pages/{page_id}/files", params={"vault_id": 2})
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestWikiBacklinksRoute(WikiNewRouteTestBase):
+
+    def test_backlinks_returns_linking_pages(self):
+        # DD-C030 end-to-end: creating a page whose body contains [[slug]] must
+        # auto-create the link (create_page wires sync_page_links), so the
+        # target's backlinks list it without any manual store call.
+        target = self._create_page(title="Target Page")
+        target_slug = target["slug"]
+        target_id = target["id"]
+        source = self._create_page(
+            title="Source Page",
+            markdown=f"See [[{target_slug}]] for details.",
+        )
+        source_id = source["id"]
+
+        resp = self.client.get(f"/api/wiki/pages/{target_id}/backlinks", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertIn("backlinks", data)
+        self.assertEqual(len(data["backlinks"]), 1)
+        bl = data["backlinks"][0]
+        self.assertEqual(bl["source_page_id"], source_id)
+        self.assertEqual(bl["target_page_id"], target_id)
+
+    def test_update_page_markdown_resyncs_backlinks(self):
+        # DD-C030 end-to-end: editing a page's body via PUT re-resolves its
+        # [[slug]] links (update_page wires sync_page_links). A link added on
+        # edit appears; one removed on a later edit disappears.
+        target = self._create_page(title="Edit Target")
+        target_slug = target["slug"]
+        target_id = target["id"]
+        source = self._create_page(title="Edit Source", markdown="no links yet")
+        source_id = source["id"]
+
+        # Initially no backlinks.
+        before = self.client.get(
+            f"/api/wiki/pages/{target_id}/backlinks", params={"vault_id": 1}
+        )
+        self.assertEqual(before.json()["backlinks"], [])
+
+        # Edit the source to reference the target.
+        put = self.client.put(
+            f"/api/wiki/pages/{source_id}",
+            json={"markdown": f"Now see [[{target_slug}]]."},
+        )
+        self.assertEqual(put.status_code, 200, put.text)
+        after = self.client.get(
+            f"/api/wiki/pages/{target_id}/backlinks", params={"vault_id": 1}
+        )
+        self.assertEqual(len(after.json()["backlinks"]), 1)
+        self.assertEqual(after.json()["backlinks"][0]["source_page_id"], source_id)
+
+        # Edit again to remove the link -> backlink is dropped.
+        put2 = self.client.put(
+            f"/api/wiki/pages/{source_id}",
+            json={"markdown": "link removed"},
+        )
+        self.assertEqual(put2.status_code, 200, put2.text)
+        final = self.client.get(
+            f"/api/wiki/pages/{target_id}/backlinks", params={"vault_id": 1}
+        )
+        self.assertEqual(final.json()["backlinks"], [])
+
+    def test_backlinks_wrong_vault_returns_404(self):
+        # F-002 vault scoping: a page in vault 1 is invisible when queried as vault 2.
+        self._insert_vault2()
+        page = self._create_page(vault_id=1, title="Scoped Page")
+        page_id = page["id"]
+        resp = self.client.get(f"/api/wiki/pages/{page_id}/backlinks", params={"vault_id": 2})
+        self.assertEqual(resp.status_code, 404)
+
+    def test_backlinks_nonexistent_page_returns_404(self):
+        resp = self.client.get("/api/wiki/pages/99999/backlinks", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestWikiActivityRoute(WikiNewRouteTestBase):
+
+    def test_activity_returns_entries_for_vault(self):
+        page = self._create_page(title="Activity Page")
+        page_id = page["id"]
+        # An update logs a page_updated activity entry.
+        self.client.put(f"/api/wiki/pages/{page_id}", json={"status": "verified"})
+
+        resp = self.client.get("/api/wiki/activity", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertIn("activity", data)
+        self.assertGreaterEqual(len(data["activity"]), 1)
+        actions = {e["action"] for e in data["activity"]}
+        self.assertIn("page_updated", actions)
+        for e in data["activity"]:
+            self.assertEqual(e["vault_id"], 1)
+
+    def test_activity_respects_limit(self):
+        # Generate several activity entries via repeated updates.
+        page = self._create_page(title="Limit Page")
+        page_id = page["id"]
+        for i in range(5):
+            self.client.put(f"/api/wiki/pages/{page_id}", json={"status": "verified", "summary": f"s{i}"})
+
+        resp = self.client.get("/api/wiki/activity", params={"vault_id": 1, "limit": 2})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertLessEqual(len(resp.json()["activity"]), 2)
+
+
+class TestWikiBulkRoute(WikiNewRouteTestBase):
+
+    def test_bulk_delete_removes_pages(self):
+        ids = [self._create_page(title=f"Bulk Del {i}")["id"] for i in range(3)]
+        resp = self.client.post(
+            "/api/wiki/pages/bulk",
+            json={"vault_id": 1, "page_ids": ids, "action": "delete"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["action"], "delete")
+        self.assertEqual(data["deleted"], 3)
+        for pid in ids:
+            self.assertEqual(self.client.get(f"/api/wiki/pages/{pid}").status_code, 404)
+
+    def test_bulk_update_sets_status_on_all(self):
+        ids = [self._create_page(title=f"Bulk Upd {i}")["id"] for i in range(3)]
+        resp = self.client.post(
+            "/api/wiki/pages/bulk",
+            json={
+                "vault_id": 1,
+                "page_ids": ids,
+                "action": "update",
+                "updates": {"status": "verified"},
+            },
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["action"], "update")
+        self.assertEqual(data["updated"], 3)
+        for pid in ids:
+            page = self.client.get(f"/api/wiki/pages/{pid}").json()
+            self.assertEqual(page["status"], "verified")
+
+    def test_bulk_update_without_updates_returns_400(self):
+        ids = [self._create_page(title="Bulk NoUpdates")["id"]]
+        resp = self.client.post(
+            "/api/wiki/pages/bulk",
+            json={"vault_id": 1, "page_ids": ids, "action": "update"},
+        )
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self.assertIn("updates", resp.json()["detail"].lower())
+
+    def test_bulk_unknown_action_returns_400(self):
+        ids = [self._create_page(title="Bulk Unknown")["id"]]
+        resp = self.client.post(
+            "/api/wiki/pages/bulk",
+            json={"vault_id": 1, "page_ids": ids, "action": "frobnicate"},
+        )
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self.assertIn("unknown bulk action", resp.json()["detail"].lower())
+
+
+class TestWikiEntitiesClaimsPaging(WikiNewRouteTestBase):
+
+    def _insert_entity(self, canonical_name: str, vault_id: int = 1) -> int:
+        conn = self._raw()
+        now = "2026-01-01T00:00:00"
+        cur = conn.execute(
+            """INSERT INTO wiki_entities
+               (vault_id, canonical_name, entity_type, aliases_json, description, created_at, updated_at)
+               VALUES (?, ?, 'unknown', '[]', '', ?, ?)""",
+            (vault_id, canonical_name, now, now),
+        )
+        conn.commit()
+        eid = cur.lastrowid
+        self._pool.release(conn)
+        return eid
+
+    def test_entities_limit_caps_results(self):
+        for i in range(5):
+            self._insert_entity(f"Entity{i:02d}")
+        resp = self.client.get(
+            "/api/wiki/entities", params={"vault_id": 1, "limit": 2, "offset": 0}
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(len(resp.json()["entities"]), 2)
+
+    def test_entities_offset_windows_results(self):
+        for i in range(5):
+            self._insert_entity(f"Ent{i:02d}")
+        full = self.client.get("/api/wiki/entities", params={"vault_id": 1, "limit": 1000}).json()["entities"]
+        self.assertEqual(len(full), 5)
+        windowed = self.client.get(
+            "/api/wiki/entities", params={"vault_id": 1, "limit": 2, "offset": 2}
+        ).json()["entities"]
+        self.assertEqual(len(windowed), 2)
+        # ordered by canonical_name, so offset window matches the full ordering
+        self.assertEqual(
+            [e["canonical_name"] for e in windowed],
+            [e["canonical_name"] for e in full[2:4]],
+        )
+
+    def test_claims_limit_caps_results(self):
+        for i in range(5):
+            self.client.post(
+                "/api/wiki/claims",
+                json={"vault_id": 1, "claim_text": f"Claim number {i}", "source_type": "manual"},
+            )
+        resp = self.client.get(
+            "/api/wiki/claims", params={"vault_id": 1, "limit": 3, "offset": 0}
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(len(resp.json()["claims"]), 3)
+
+    def test_claims_status_filter(self):
+        self.client.post(
+            "/api/wiki/claims",
+            json={"vault_id": 1, "claim_text": "Active claim", "source_type": "manual", "status": "active"},
+        )
+        self.client.post(
+            "/api/wiki/claims",
+            json={"vault_id": 1, "claim_text": "Superseded claim", "source_type": "manual", "status": "superseded"},
+        )
+        resp = self.client.get(
+            "/api/wiki/claims", params={"vault_id": 1, "status": "active"}
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        claims = resp.json()["claims"]
+        self.assertEqual(len(claims), 1)
+        self.assertEqual(claims[0]["status"], "active")
+
+
+class TestWikiDocumentStatusRoute(WikiNewRouteTestBase):
+
+    def test_document_status_no_jobs(self):
+        file_id = self._insert_file(vault_id=1)
+        resp = self.client.get(f"/api/wiki/documents/{file_id}/status", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["file_id"], file_id)
+        self.assertEqual(data["wiki_status"], "not_compiled")
+        self.assertEqual(data["claims_count"], 0)
+        self.assertIsNone(data["latest_job"])
+        self.assertEqual(data["job_count"], 0)
+
+    def test_document_status_selects_latest_job(self):
+        file_id = self._insert_file(vault_id=1)
+        # Enqueue a compile job (POST /compile creates a wiki ingest job).
+        compile_resp = self.client.post(
+            f"/api/wiki/documents/{file_id}/compile", params={"vault_id": 1}
+        )
+        self.assertEqual(compile_resp.status_code, 202, compile_resp.text)
+
+        resp = self.client.get(f"/api/wiki/documents/{file_id}/status", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["job_count"], 1)
+        self.assertIsNotNone(data["latest_job"])
+        self.assertEqual(data["latest_job"]["trigger_id"], f"file:{file_id}")
+        # A pending job is not yet compiled.
+        self.assertEqual(data["wiki_status"], "not_compiled")
+
+
+class TestWikiMemoryStatusRoute(WikiNewRouteTestBase):
+
+    def test_memory_status_not_promoted(self):
+        mem_id = self._insert_memory("Some memory content")
+        resp = self.client.get(f"/api/wiki/memories/{mem_id}/status", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["memory_id"], mem_id)
+        self.assertEqual(data["wiki_status"], "not_promoted")
+        self.assertEqual(data["claims_count"], 0)
+        self.assertEqual(data["job_count"], 0)
+        self.assertIsNone(data["latest_job"])
+
+    def test_memory_status_selects_memory_job(self):
+        mem_id = self._insert_memory("Memory with a job")
+        # Seed a memory-trigger job directly through the store.
+        conn = self._raw()
+        from app.services.wiki_store import WikiStore
+        store = WikiStore(conn)
+        job = store.create_job(
+            vault_id=1,
+            trigger_type="memory",
+            trigger_id=f"memory:{mem_id}",
+            input_json={"memory_id": mem_id},
+        )
+        self._pool.release(conn)
+
+        resp = self.client.get(f"/api/wiki/memories/{mem_id}/status", params={"vault_id": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["job_count"], 1)
+        self.assertIsNotNone(data["latest_job"])
+        self.assertEqual(data["latest_job"]["id"], job.id)
+        self.assertEqual(data["latest_job"]["trigger_id"], f"memory:{mem_id}")
+
+
+class TestWikiOptimisticLock(WikiNewRouteTestBase):
+
+    def test_stale_expected_version_returns_409(self):
+        page = self._create_page(title="Lock Me")
+        page_id = page["id"]
+        # A freshly-created page starts at version 1. First update (no expected
+        # version) bumps it to 2.
+        first = self.client.put(
+            f"/api/wiki/pages/{page_id}",
+            json={"title": "Lock Me v1"},
+        )
+        self.assertEqual(first.status_code, 200, first.text)
+        current_version = first.json()["version"]
+        self.assertEqual(current_version, 2)
+
+        # Second update with a now-stale expected_version (1) -> 409 conflict.
+        stale = self.client.put(
+            f"/api/wiki/pages/{page_id}",
+            json={"title": "Lock Me stale", "expected_version": 1},
+        )
+        self.assertEqual(stale.status_code, 409, stale.text)
+        self.assertIn("version conflict", stale.json()["detail"].lower())
+
+        # A matching expected_version still succeeds.
+        ok = self.client.put(
+            f"/api/wiki/pages/{page_id}",
+            json={"title": "Lock Me ok", "expected_version": current_version},
+        )
+        self.assertEqual(ok.status_code, 200, ok.text)
+
+
+class TestWikiF003ExistenceOracle(WikiNewRouteTestBase):
+    """F-003: a vault the caller cannot read must return 404, not 403, so an
+    unauthorized caller cannot distinguish 'exists elsewhere' from 'absent'."""
+
+    def setUp(self):
+        super().setUp()
+        # Seed vault 2 (private by default) and a page inside it.
+        self._insert_vault2()
+        page = self._create_page(vault_id=2, title="Secret Vault2 Page")
+        self._secret_page_id = page["id"]
+
+    def _use_viewer(self):
+        viewer = {
+            "id": 4242,
+            "username": "viewer",
+            "full_name": "Viewer",
+            "role": "viewer",
+            "is_active": True,
+            "must_change_password": False,
+        }
+        app.dependency_overrides[get_current_active_user] = lambda: viewer
+
+    def test_unreadable_vault_page_returns_404_not_403(self):
+        # A viewer with no membership has no read access to private vault 2;
+        # the route collapses the 403 to 404 (F-003).
+        self._use_viewer()
+        resp = self.client.get(f"/api/wiki/pages/{self._secret_page_id}")
+        self.assertEqual(resp.status_code, 404, resp.text)
+        self.assertEqual(resp.json()["detail"], "Wiki page not found")
+        # Restore superadmin override so tearDown's pop is consistent.
+        app.dependency_overrides[get_current_active_user] = lambda: _MOCK_SUPERADMIN
+
+    def test_nonexistent_page_also_returns_404(self):
+        # The negative existence path returns the same status/detail, so the
+        # two cases are indistinguishable to the caller.
+        self._use_viewer()
+        resp = self.client.get("/api/wiki/pages/99999")
+        self.assertEqual(resp.status_code, 404, resp.text)
+        self.assertEqual(resp.json()["detail"], "Wiki page not found")
+        app.dependency_overrides[get_current_active_user] = lambda: _MOCK_SUPERADMIN
+
+
+class TestWikiF010GenericError(WikiNewRouteTestBase):
+    """F-010: internal create_page failures surface a generic message, never a
+    raw exception string."""
+
+    def test_create_page_internal_error_is_generic(self):
+        # Force store.create_page to raise. The handler logs the exception and
+        # returns a 400 with a fixed, non-leaking detail.
+        from unittest.mock import patch
+        with patch(
+            "app.api.routes.wiki.WikiStore.create_page",
+            side_effect=RuntimeError("super-secret internal stack detail"),
+        ):
+            resp = self.client.post(
+                "/api/wiki/pages",
+                json={"vault_id": 1, "title": "Boom", "page_type": "entity"},
+            )
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self.assertEqual(resp.json()["detail"], "Failed to create wiki page")
+        self.assertNotIn("super-secret", resp.json()["detail"])

--- a/backend/tests/test_wiki_store.py
+++ b/backend/tests/test_wiki_store.py
@@ -292,3 +292,577 @@ class TestWikiStoreFTSSearch(unittest.TestCase):
         self.assertEqual(result["pages"], [])
         self.assertEqual(result["claims"], [])
         self.assertEqual(result["entities"], [])
+
+
+def _seed_file(conn, vault_id=1, file_name="doc.pdf"):
+    """Insert a minimal files row for the given vault; return its id."""
+    cur = conn.execute(
+        "INSERT INTO files (vault_id, file_path, file_name, file_size) VALUES (?, ?, ?, ?)",
+        (vault_id, f"/tmp/{file_name}", file_name, 1024),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+class TestWikiStoreVersionHistory(unittest.TestCase):
+    """save_version + list_versions (DD-C003)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_update_page_snapshots_pre_update_state(self):
+        page = self.store.create_page(
+            vault_id=1, title="V1 Title", page_type="entity",
+            markdown="body one", summary="sum one", status="draft",
+        )
+        self.assertEqual(self.store.list_versions(page.id), [])
+
+        self.store.update_page(page.id, vault_id=1, title="V2 Title", markdown="body two")
+
+        versions = self.store.list_versions(page.id)
+        self.assertEqual(len(versions), 1)
+        snap = versions[0]
+        # Snapshot must capture the PRE-update state, not the new values.
+        self.assertEqual(snap.title, "V1 Title")
+        self.assertEqual(snap.markdown, "body one")
+        self.assertEqual(snap.summary, "sum one")
+        self.assertEqual(snap.status, "draft")
+        self.assertEqual(snap.page_id, page.id)
+        self.assertEqual(snap.vault_id, 1)
+
+    def test_list_versions_newest_first(self):
+        page = self.store.create_page(
+            vault_id=1, title="Title A", page_type="entity", markdown="m-a"
+        )
+        # Each update snapshots the state just before that update.
+        self.store.update_page(page.id, vault_id=1, title="Title B", markdown="m-b")
+        self.store.update_page(page.id, vault_id=1, title="Title C", markdown="m-c")
+        self.store.update_page(page.id, vault_id=1, title="Title D", markdown="m-d")
+
+        versions = self.store.list_versions(page.id)
+        self.assertEqual(len(versions), 3)
+        # The three snapshots captured states A, B, C (D is current, never snapshotted).
+        captured = {v.markdown for v in versions}
+        self.assertEqual(captured, {"m-a", "m-b", "m-c"})
+        # Newest-first: id is monotonically increasing, so versions should be
+        # ordered by descending id (the most recently snapshotted = "m-c" first).
+        ids = [v.id for v in versions]
+        self.assertEqual(ids, sorted(ids, reverse=True))
+        self.assertEqual(versions[0].markdown, "m-c")
+
+    def test_save_version_nonexistent_page_returns_none(self):
+        self.assertIsNone(self.store.save_version(99999, vault_id=1))
+
+    def test_list_versions_respects_limit(self):
+        page = self.store.create_page(vault_id=1, title="T", page_type="entity")
+        for i in range(5):
+            self.store.update_page(page.id, vault_id=1, markdown=f"v{i}")
+        self.assertEqual(len(self.store.list_versions(page.id)), 5)
+        self.assertEqual(len(self.store.list_versions(page.id, limit=2)), 2)
+
+
+class TestWikiStoreFileAttachments(unittest.TestCase):
+    """attach_file + list_page_files + detach_file (DD-C019)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_attach_list_detach(self):
+        page = self.store.create_page(vault_id=1, title="P", page_type="entity")
+        file_id = _seed_file(self.conn)
+
+        attached = self.store.attach_file(page.id, file_id, vault_id=1)
+        self.assertIsNotNone(attached)
+        self.assertEqual(attached.page_id, page.id)
+        self.assertEqual(attached.file_id, file_id)
+        self.assertEqual(attached.vault_id, 1)
+
+        files = self.store.list_page_files(page.id)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0].file_id, file_id)
+
+        self.assertTrue(self.store.detach_file(page.id, file_id, vault_id=1))
+        self.assertEqual(self.store.list_page_files(page.id), [])
+
+    def test_duplicate_attach_raises_integrity_error(self):
+        # attach_file uses a plain INSERT so a duplicate (page_id, file_id) raises
+        # sqlite3.IntegrityError (which the route maps to 409). The failed insert
+        # is rolled back, leaving exactly one attachment row.
+        page = self.store.create_page(vault_id=1, title="P", page_type="entity")
+        file_id = _seed_file(self.conn)
+        self.store.attach_file(page.id, file_id, vault_id=1)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.store.attach_file(page.id, file_id, vault_id=1)
+        self.assertEqual(len(self.store.list_page_files(page.id)), 1)
+
+    def test_duplicate_raw_insert_raises_integrity_error(self):
+        # The UNIQUE(page_id, file_id) constraint is enforced at the schema level:
+        # a raw duplicate INSERT (without OR IGNORE) must raise IntegrityError.
+        page = self.store.create_page(vault_id=1, title="P", page_type="entity")
+        file_id = _seed_file(self.conn)
+        self.store.attach_file(page.id, file_id, vault_id=1)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.conn.execute(
+                "INSERT INTO wiki_page_files (page_id, file_id, vault_id, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (page.id, file_id, 1, "2026-01-01T00:00:00"),
+            )
+
+    def test_detach_nonexistent_returns_false(self):
+        page = self.store.create_page(vault_id=1, title="P", page_type="entity")
+        self.assertFalse(self.store.detach_file(page.id, 99999, vault_id=1))
+
+
+class TestWikiStoreLinksAndBacklinks(unittest.TestCase):
+    """sync_page_links + list_backlinks (DD-C030, F-002, F-006)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_backlink_appears_after_sync(self):
+        target = self.store.create_page(vault_id=1, title="Target Page", page_type="entity")
+        source = self.store.create_page(vault_id=1, title="Source Page", page_type="entity")
+        links = self.store.sync_page_links(
+            source.id, vault_id=1, markdown=f"See [[{target.slug}]] for details."
+        )
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0].target_page_id, target.id)
+
+        backlinks = self.store.list_backlinks(target.id, vault_id=1)
+        self.assertEqual(len(backlinks), 1)
+        self.assertEqual(backlinks[0].source_page_id, source.id)
+
+    def test_pipe_display_text_resolves_target_and_strips_display(self):
+        # F-006: [[slug|Display Text]] resolves to the same target; the part after
+        # the pipe is stored as the link_text, the part before is the target slug.
+        target = self.store.create_page(vault_id=1, title="Target Page", page_type="entity")
+        source = self.store.create_page(vault_id=1, title="Source Page", page_type="entity")
+        links = self.store.sync_page_links(
+            source.id, vault_id=1, markdown=f"Read [[{target.slug}|Human Label]] now.",
+        )
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0].target_page_id, target.id)
+        self.assertEqual(links[0].link_text, "Human Label")
+
+        backlinks = self.store.list_backlinks(target.id, vault_id=1)
+        self.assertEqual(len(backlinks), 1)
+        self.assertEqual(backlinks[0].source_page_id, source.id)
+
+    def test_backlinks_exclude_other_vaults(self):
+        # F-002: list_backlinks is vault-scoped. The UNIQUE constraint is only on
+        # (source_page_id, target_page_id), so a cross-vault link row with the same
+        # target can exist — it must NOT be returned for vault 1.
+        self.conn.execute("INSERT OR IGNORE INTO vaults (id, name) VALUES (2, 'Vault Two')")
+        target = self.store.create_page(vault_id=1, title="Target Page", page_type="entity")
+        source = self.store.create_page(vault_id=1, title="Source Page", page_type="entity")
+        # A real same-vault backlink.
+        self.store.sync_page_links(source.id, vault_id=1, markdown=f"[[{target.slug}]]")
+        # A cross-vault row pointing at the same target but tagged vault_id=2.
+        # Use a distinct source_page_id so it doesn't trip the UNIQUE constraint.
+        other_src = self.store.create_page(vault_id=2, title="Other Vault Src", page_type="entity")
+        self.conn.execute(
+            "INSERT INTO wiki_page_links (source_page_id, target_page_id, vault_id, link_text, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (other_src.id, target.id, 2, "cross", "2026-01-01T00:00:00"),
+        )
+        self.conn.commit()
+
+        backlinks_v1 = self.store.list_backlinks(target.id, vault_id=1)
+        self.assertEqual(len(backlinks_v1), 1)
+        self.assertEqual(backlinks_v1[0].source_page_id, source.id)
+        self.assertEqual(backlinks_v1[0].vault_id, 1)
+
+        backlinks_v2 = self.store.list_backlinks(target.id, vault_id=2)
+        self.assertEqual(len(backlinks_v2), 1)
+        self.assertEqual(backlinks_v2[0].vault_id, 2)
+
+    def test_empty_and_whitespace_slugs_skipped(self):
+        source = self.store.create_page(vault_id=1, title="Source Page", page_type="entity")
+        # [[]] and [[   ]] normalize to empty slugs and must be skipped (not errors).
+        links = self.store.sync_page_links(
+            source.id, vault_id=1, markdown="noise [[]] and [[   ]] and [[unknown-slug]]",
+        )
+        # Empty slugs skipped; unknown-slug does not resolve to any page -> no links.
+        self.assertEqual(links, [])
+
+    def test_unresolved_slug_creates_no_link(self):
+        source = self.store.create_page(vault_id=1, title="Source Page", page_type="entity")
+        links = self.store.sync_page_links(
+            source.id, vault_id=1, markdown="[[does-not-exist]]"
+        )
+        self.assertEqual(links, [])
+
+    def test_resync_replaces_old_links(self):
+        t1 = self.store.create_page(vault_id=1, title="Target One", page_type="entity")
+        t2 = self.store.create_page(vault_id=1, title="Target Two", page_type="entity")
+        source = self.store.create_page(vault_id=1, title="Source", page_type="entity")
+        self.store.sync_page_links(source.id, vault_id=1, markdown=f"[[{t1.slug}]]")
+        self.assertEqual(len(self.store.list_backlinks(t1.id, vault_id=1)), 1)
+        # Re-sync with a different target should drop the old link.
+        self.store.sync_page_links(source.id, vault_id=1, markdown=f"[[{t2.slug}]]")
+        self.assertEqual(len(self.store.list_backlinks(t1.id, vault_id=1)), 0)
+        self.assertEqual(len(self.store.list_backlinks(t2.id, vault_id=1)), 1)
+
+
+class TestWikiStoreBulkOps(unittest.TestCase):
+    """bulk_update_pages + bulk_delete_pages (DD-C025, F-007 atomicity)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_bulk_update_all_succeed(self):
+        p1 = self.store.create_page(vault_id=1, title="A", page_type="entity")
+        p2 = self.store.create_page(vault_id=1, title="B", page_type="entity")
+        p3 = self.store.create_page(vault_id=1, title="C", page_type="entity")
+        results = self.store.bulk_update_pages(
+            [p1.id, p2.id, p3.id], vault_id=1, status="verified"
+        )
+        self.assertEqual(len(results), 3)
+        for pid in (p1.id, p2.id, p3.id):
+            self.assertEqual(self.store.get_page(pid).status, "verified")
+
+    def test_bulk_delete_multiple(self):
+        p1 = self.store.create_page(vault_id=1, title="A", page_type="entity")
+        p2 = self.store.create_page(vault_id=1, title="B", page_type="entity")
+        count = self.store.bulk_delete_pages([p1.id, p2.id], vault_id=1)
+        self.assertEqual(count, 2)
+        self.assertIsNone(self.store.get_page(p1.id))
+        self.assertIsNone(self.store.get_page(p2.id))
+
+    def test_bulk_update_rolls_back_on_mid_batch_failure(self):
+        # F-007 atomicity: if any page in the batch raises, NOTHING is committed.
+        # Force a mid-batch failure by monkeypatching update_page so the 2nd call
+        # raises after the 1st has already executed its (uncommitted) UPDATE.
+        p1 = self.store.create_page(vault_id=1, title="A", page_type="entity", status="draft")
+        p2 = self.store.create_page(vault_id=1, title="B", page_type="entity", status="draft")
+
+        real_update = self.store.update_page
+        calls = {"n": 0}
+
+        def flaky_update(pid, vault_id, commit=True, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("simulated mid-batch failure")
+            return real_update(pid, vault_id, commit=commit, **kwargs)
+
+        self.store.update_page = flaky_update
+        try:
+            with self.assertRaises(RuntimeError):
+                self.store.bulk_update_pages([p1.id, p2.id], vault_id=1, status="verified")
+        finally:
+            self.store.update_page = real_update
+
+        # Rollback must have discarded p1's uncommitted UPDATE.
+        self.assertEqual(self.store.get_page(p1.id).status, "draft")
+        self.assertEqual(self.store.get_page(p2.id).status, "draft")
+
+    def test_bulk_delete_rolls_back_on_mid_batch_failure(self):
+        p1 = self.store.create_page(vault_id=1, title="A", page_type="entity")
+        p2 = self.store.create_page(vault_id=1, title="B", page_type="entity")
+
+        real_delete = self.store.delete_page
+        calls = {"n": 0}
+
+        def flaky_delete(pid, vault_id, commit=True):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("simulated mid-batch failure")
+            return real_delete(pid, vault_id, commit=commit)
+
+        self.store.delete_page = flaky_delete
+        try:
+            with self.assertRaises(RuntimeError):
+                self.store.bulk_delete_pages([p1.id, p2.id], vault_id=1)
+        finally:
+            self.store.delete_page = real_delete
+
+        # Rollback must restore both pages (p1's uncommitted DELETE discarded).
+        self.assertIsNotNone(self.store.get_page(p1.id))
+        self.assertIsNotNone(self.store.get_page(p2.id))
+
+
+class TestWikiStoreActivityLog(unittest.TestCase):
+    """log_activity + list_activity (DD-C026)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_page_lifecycle_appends_activity(self):
+        page = self.store.create_page(vault_id=1, title="P", page_type="entity")
+        self.store.update_page(page.id, vault_id=1, title="P2")
+        self.store.delete_page(page.id, vault_id=1)
+
+        actions = [a.action for a in self.store.list_activity(vault_id=1)]
+        self.assertIn("page_created", actions)
+        self.assertIn("page_updated", actions)
+        self.assertIn("page_deleted", actions)
+
+    def test_list_activity_newest_first_and_limit(self):
+        e1 = self.store.log_activity(1, "page_created", "page", 100)
+        e2 = self.store.log_activity(1, "page_updated", "page", 100)
+        e3 = self.store.log_activity(1, "page_deleted", "page", 100)
+        entries = self.store.list_activity(vault_id=1)
+        # Newest-first: monotonic ids => descending id order.
+        ids = [e.id for e in entries]
+        self.assertEqual(ids, sorted(ids, reverse=True))
+        self.assertEqual(entries[0].id, e3.id)
+        self.assertEqual(entries[-1].id, e1.id)
+        # Limit bounds the result set.
+        limited = self.store.list_activity(vault_id=1, limit=2)
+        self.assertEqual(len(limited), 2)
+        self.assertEqual(limited[0].id, e3.id)
+        self.assertEqual(limited[1].id, e2.id)
+
+    def test_activity_is_vault_scoped(self):
+        self.conn.execute("INSERT OR IGNORE INTO vaults (id, name) VALUES (2, 'V2')")
+        self.conn.commit()
+        self.store.log_activity(1, "page_created", "page", 1)
+        self.store.log_activity(2, "page_created", "page", 2)
+        self.assertEqual(len(self.store.list_activity(vault_id=1)), 1)
+        self.assertEqual(len(self.store.list_activity(vault_id=2)), 1)
+
+
+class TestWikiStoreOptimisticLocking(unittest.TestCase):
+    """update_page expected_version + TOCTOU conflict (F-005, DD-C020)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_correct_expected_version_bumps_version(self):
+        page = self.store.create_page(vault_id=1, title="T", page_type="entity")
+        self.assertEqual(page.version, 1)
+        updated = self.store.update_page(
+            page.id, vault_id=1, expected_version=1, title="T2"
+        )
+        self.assertEqual(updated.version, 2)
+        # A second correct update bumps again.
+        updated2 = self.store.update_page(
+            page.id, vault_id=1, expected_version=2, title="T3"
+        )
+        self.assertEqual(updated2.version, 3)
+
+    def test_stale_expected_version_raises_value_error(self):
+        page = self.store.create_page(vault_id=1, title="T", page_type="entity")
+        self.store.update_page(page.id, vault_id=1, title="T2")  # version -> 2
+        with self.assertRaises(ValueError) as ctx:
+            self.store.update_page(page.id, vault_id=1, expected_version=1, title="T3")
+        self.assertIn("Version conflict", str(ctx.exception))
+        # The failed update must not have changed the row.
+        self.assertEqual(self.store.get_page(page.id).title, "T2")
+        self.assertEqual(self.store.get_page(page.id).version, 2)
+
+    def test_lost_update_toctou_conflict_path(self):
+        # Simulate the lost-update window: a concurrent writer bumps the row's
+        # version AFTER update_page reads it but BEFORE its UPDATE runs. The
+        # rowcount==0 guard must turn this into an explicit conflict.
+        page = self.store.create_page(vault_id=1, title="T", page_type="entity")
+
+        real_save_version = self.store.save_version
+
+        def bump_then_save(page_id, vault_id, edited_by=None, commit=True):
+            # save_version is called inside update_page AFTER the version read and
+            # BEFORE the UPDATE. Mutate the row's version here to invalidate the
+            # pinned WHERE clause.
+            self.conn.execute(
+                "UPDATE wiki_pages SET version = version + 1 WHERE id = ?", (page_id,)
+            )
+            return real_save_version(page_id, vault_id, edited_by=edited_by, commit=commit)
+
+        self.store.save_version = bump_then_save
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                # expected_version=None so we bypass the early check and reach the
+                # pinned UPDATE / rowcount guard.
+                self.store.update_page(page.id, vault_id=1, title="T2")
+        finally:
+            self.store.save_version = real_save_version
+        self.assertIn("Version conflict", str(ctx.exception))
+
+    def test_nonexistent_page_returns_none(self):
+        self.assertIsNone(self.store.update_page(99999, vault_id=1, title="x"))
+
+
+class TestWikiStoreClaimDedup(unittest.TestCase):
+    """normalized_text dedup (F-004, DD-C011)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_create_claim_stores_normalized_text(self):
+        claim = self.store.create_claim(
+            vault_id=1, claim_text="Hello, World!  Extra   Spaces.", source_type="manual"
+        )
+        row = self.conn.execute(
+            "SELECT normalized_text FROM wiki_claims WHERE id = ?", (claim.id,)
+        ).fetchone()
+        self.assertEqual(row["normalized_text"], "hello world extra spaces")
+
+    def test_find_by_exact_and_normalized(self):
+        original = "Justice Sakyi is the AFOMIS Chief"
+        claim = self.store.create_claim(vault_id=1, claim_text=original, source_type="manual")
+
+        # Exact match locates it.
+        self.assertEqual(self.store.find_claim_by_text(1, original).id, claim.id)
+        # Normalized match also locates it.
+        self.assertEqual(
+            self.store.find_claim_by_normalized_text(1, original).id, claim.id
+        )
+
+        # A variant differing only by case/punctuation/extra spaces:
+        variant = "justice  sakyi is THE afomis, chief!!"
+        # Exact lookup must NOT find it.
+        self.assertIsNone(self.store.find_claim_by_text(1, variant))
+        # Normalized lookup MUST find the same claim.
+        self.assertEqual(
+            self.store.find_claim_by_normalized_text(1, variant).id, claim.id
+        )
+
+    def test_find_normalized_empty_returns_none(self):
+        self.assertIsNone(self.store.find_claim_by_normalized_text(1, "!!!  "))
+
+    def test_update_claim_refreshes_normalized_text(self):
+        claim = self.store.create_claim(
+            vault_id=1, claim_text="Original Text", source_type="manual"
+        )
+        self.store.update_claim(claim.id, vault_id=1, claim_text="Brand New, Claim!")
+        row = self.conn.execute(
+            "SELECT normalized_text FROM wiki_claims WHERE id = ?", (claim.id,)
+        ).fetchone()
+        self.assertEqual(row["normalized_text"], "brand new claim")
+        # Old normalized text no longer locates the claim.
+        self.assertIsNone(self.store.find_claim_by_normalized_text(1, "Original Text"))
+        self.assertEqual(
+            self.store.find_claim_by_normalized_text(1, "brand new claim").id, claim.id
+        )
+
+    def test_normalized_lookup_is_vault_scoped(self):
+        self.conn.execute("INSERT OR IGNORE INTO vaults (id, name) VALUES (2, 'V2')")
+        self.conn.commit()
+        self.store.create_claim(vault_id=1, claim_text="Shared Claim", source_type="manual")
+        self.assertIsNone(self.store.find_claim_by_normalized_text(2, "Shared Claim"))
+
+
+class TestWikiStorePagination(unittest.TestCase):
+    """list_entities / list_claims / list_jobs windowing & filtering (F-012)."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_list_entities_limit_offset(self):
+        names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]
+        for n in names:
+            self.store.upsert_entity(vault_id=1, canonical_name=n)
+        # Ordered by canonical_name ASC.
+        first_two = self.store.list_entities(1, limit=2, offset=0)
+        self.assertEqual([e.canonical_name for e in first_two], ["Alpha", "Bravo"])
+        next_two = self.store.list_entities(1, limit=2, offset=2)
+        self.assertEqual([e.canonical_name for e in next_two], ["Charlie", "Delta"])
+        # No limit returns all.
+        self.assertEqual(len(self.store.list_entities(1)), 5)
+
+    def test_list_claims_limit_offset(self):
+        for i in range(5):
+            self.store.create_claim(vault_id=1, claim_text=f"claim {i}", source_type="manual")
+        page1 = self.store.list_claims(1, limit=2, offset=0)
+        page2 = self.store.list_claims(1, limit=2, offset=2)
+        self.assertEqual(len(page1), 2)
+        self.assertEqual(len(page2), 2)
+        # Distinct windows (ordered by created_at DESC; ids monotonic).
+        self.assertNotEqual(
+            {c.id for c in page1}, {c.id for c in page2}
+        )
+        self.assertEqual(len(self.store.list_claims(1)), 5)
+
+    def test_list_jobs_filter_and_bound(self):
+        # trigger_type is constrained to the wiki_compile_jobs CHECK enum
+        # ('ingest','query','memory','manual','settings_reindex').
+        j1 = self.store.create_job(vault_id=1, trigger_type="manual", trigger_id="A")
+        j2 = self.store.create_job(vault_id=1, trigger_type="manual", trigger_id="B")
+        j3 = self.store.create_job(vault_id=1, trigger_type="query", trigger_id="A")
+
+        # Filter by trigger_type.
+        manual = self.store.list_jobs(1, trigger_type="manual")
+        self.assertEqual({j.id for j in manual}, {j1.id, j2.id})
+        # Filter by trigger_id.
+        by_id = self.store.list_jobs(1, trigger_id="A")
+        self.assertEqual({j.id for j in by_id}, {j1.id, j3.id})
+        # Combined filter.
+        combo = self.store.list_jobs(1, trigger_type="query", trigger_id="A")
+        self.assertEqual({j.id for j in combo}, {j3.id})
+        # Limit bounds the result set.
+        bounded = self.store.list_jobs(1, limit=1)
+        self.assertEqual(len(bounded), 1)
+        self.assertIn(bounded[0].id, {j1.id, j2.id, j3.id})
+        # Limit caps a larger set.
+        self.assertEqual(len(self.store.list_jobs(1, limit=2)), 2)
+        self.assertEqual(len(self.store.list_jobs(1)), 3)
+
+
+class TestWikiStoreSearchFacetsAndHierarchy(unittest.TestCase):
+    """search facets (page_type/status/sort_by) + parent_id hierarchy."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_search_filters_by_page_type(self):
+        self.store.create_page(vault_id=1, title="AFOMIS overview", page_type="overview")
+        self.store.create_page(vault_id=1, title="AFOMIS system", page_type="system")
+        result = self.store.search(vault_id=1, query="AFOMIS", page_type="system")
+        titles = [p.title for p in result["pages"]]
+        self.assertEqual(titles, ["AFOMIS system"])
+
+    def test_search_filters_by_status(self):
+        self.store.create_page(
+            vault_id=1, title="AFOMIS draft", page_type="overview", status="draft"
+        )
+        self.store.create_page(
+            vault_id=1, title="AFOMIS verified", page_type="overview", status="verified"
+        )
+        result = self.store.search(vault_id=1, query="AFOMIS", status="verified")
+        titles = [p.title for p in result["pages"]]
+        self.assertEqual(titles, ["AFOMIS verified"])
+
+    def test_search_sort_by_title_ascending(self):
+        self.store.create_page(vault_id=1, title="AFOMIS Zebra", page_type="overview")
+        self.store.create_page(vault_id=1, title="AFOMIS Apple", page_type="overview")
+        result = self.store.search(vault_id=1, query="AFOMIS", sort_by="title")
+        titles = [p.title for p in result["pages"]]
+        self.assertEqual(titles, ["AFOMIS Apple", "AFOMIS Zebra"])
+
+    def test_create_page_parent_id_round_trips(self):
+        parent = self.store.create_page(vault_id=1, title="Parent", page_type="overview")
+        child = self.store.create_page(
+            vault_id=1, title="Child", page_type="entity", parent_id=parent.id
+        )
+        self.assertEqual(child.parent_id, parent.id)
+        # Round-trips through get_page.
+        self.assertEqual(self.store.get_page(child.id).parent_id, parent.id)
+        # Root page has no parent.
+        self.assertIsNone(parent.parent_id)

--- a/frontend/src/components/chat/WikiCards.test.tsx
+++ b/frontend/src/components/chat/WikiCards.test.tsx
@@ -1,7 +1,25 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { WikiCards, WikiCard } from "./WikiCards";
 import type { WikiReference } from "@/lib/api";
+
+// WikiCard calls useNavigate() for in-app navigation; spy on it to assert routing.
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  );
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+// Components calling router hooks need a Router context (see frontend-testing-gotchas).
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, { wrapper: MemoryRouter, ...options });
+
+beforeEach(() => {
+  navigateMock.mockClear();
+});
 
 const makeWiki = (overrides: Partial<WikiReference> = {}): WikiReference => ({
   wiki_label: "W1",
@@ -105,21 +123,21 @@ describe("WikiCard", () => {
     expect(screen.getByLabelText("Open wiki page Task Force Alpha")).toBeInTheDocument();
   });
 
-  it("does not render external link button when slug is null", () => {
-    render(<WikiCard wikiRef={makeWiki({ slug: null })} />);
+  it("does not render external link button when page_id and slug are both null", () => {
+    render(<WikiCard wikiRef={makeWiki({ page_id: null, slug: null })} />);
     expect(screen.queryByRole("button", { name: /open wiki page/i })).not.toBeInTheDocument();
   });
 
-  it("opens wiki page in new tab when external link is clicked", () => {
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-    render(<WikiCard wikiRef={makeWiki({ slug: "task-force-alpha" })} />);
+  it("navigates to the wiki page by id when the open link is clicked", () => {
+    render(<WikiCard wikiRef={makeWiki({ page_id: 1, slug: "task-force-alpha" })} />);
     fireEvent.click(screen.getByLabelText("Open wiki page Task Force Alpha"));
-    expect(openSpy).toHaveBeenCalledWith(
-      "/wiki?page=task-force-alpha",
-      "_blank",
-      "noopener"
-    );
-    openSpy.mockRestore();
+    expect(navigateMock).toHaveBeenCalledWith("/wiki?page=1");
+  });
+
+  it("navigates by slug when page_id is null", () => {
+    render(<WikiCard wikiRef={makeWiki({ page_id: null, slug: "task-force-alpha" })} />);
+    fireEvent.click(screen.getByLabelText("Open wiki page Task Force Alpha"));
+    expect(navigateMock).toHaveBeenCalledWith("/wiki?page=task-force-alpha");
   });
 
   it("truncates long body and shows More button", () => {

--- a/frontend/src/components/chat/WikiCards.tsx
+++ b/frontend/src/components/chat/WikiCards.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { BookOpen, ChevronDown, ChevronUp, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { WikiReference } from "@/lib/api";
@@ -9,6 +10,7 @@ interface WikiCardProps {
 
 function WikiCard({ wikiRef }: WikiCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const navigate = useNavigate();
   const body = wikiRef.claim_text ?? wikiRef.excerpt ?? "";
   const isLong = body.length > 160;
   const display = expanded || !isLong ? body : body.slice(0, 160) + "…";
@@ -16,8 +18,10 @@ function WikiCard({ wikiRef }: WikiCardProps) {
   const conf = wikiRef.confidence != null ? `${Math.round(wikiRef.confidence * 100)}%` : null;
 
   const handleNavigate = () => {
-    if (wikiRef.slug) {
-      window.open(`/wiki?page=${encodeURIComponent(wikiRef.slug)}`, "_blank", "noopener");
+    if (wikiRef.page_id != null) {
+      navigate(`/wiki?page=${wikiRef.page_id}`);
+    } else if (wikiRef.slug) {
+      navigate(`/wiki?page=${encodeURIComponent(wikiRef.slug)}`);
     }
   };
 
@@ -60,7 +64,7 @@ function WikiCard({ wikiRef }: WikiCardProps) {
                 <span className="capitalize">{statusLabel}</span>
               </>
             )}
-            {wikiRef.slug && (
+            {(wikiRef.page_id != null || wikiRef.slug) && (
               <button
                 type="button"
                 onClick={handleNavigate}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2072,6 +2072,46 @@ export async function getMemoryWikiStatus(memoryId: number, vaultId: number): Pr
   return response.data;
 }
 
+// Version history
+export async function getWikiPageVersions(pageId: number, vaultId: number) {
+  const response = await apiClient.get(`/wiki/pages/${pageId}/versions`, { params: { vault_id: vaultId } });
+  return response.data;
+}
+
+// File attachments
+export async function getWikiPageFiles(pageId: number, vaultId: number) {
+  const response = await apiClient.get(`/wiki/pages/${pageId}/files`, { params: { vault_id: vaultId } });
+  return response.data;
+}
+
+export async function attachWikiPageFile(pageId: number, vaultId: number, fileId: number) {
+  const response = await apiClient.post(`/wiki/pages/${pageId}/files`, { vault_id: vaultId, file_id: fileId });
+  return response.data;
+}
+
+export async function detachWikiPageFile(pageId: number, fileId: number, vaultId: number) {
+  const response = await apiClient.delete(`/wiki/pages/${pageId}/files/${fileId}`, { params: { vault_id: vaultId } });
+  return response.data;
+}
+
+// Backlinks
+export async function getWikiPageBacklinks(pageId: number, vaultId: number) {
+  const response = await apiClient.get(`/wiki/pages/${pageId}/backlinks`, { params: { vault_id: vaultId } });
+  return response.data;
+}
+
+// Activity feed
+export async function getWikiActivityFeed(vaultId: number, limit: number = 50) {
+  const response = await apiClient.get("/wiki/activity", { params: { vault_id: vaultId, limit } });
+  return response.data;
+}
+
+// Bulk operations
+export async function bulkWikiPageAction(vaultId: number, pageIds: number[], action: "delete" | "update", updates?: Record<string, unknown>) {
+  const response = await apiClient.post("/wiki/pages/bulk", { vault_id: vaultId, page_ids: pageIds, action, updates });
+  return response.data;
+}
+
 export async function resolveWikiLintFinding(
   findingId: number,
   vaultId: number,

--- a/frontend/src/pages/WikiEditDialog.test.tsx
+++ b/frontend/src/pages/WikiEditDialog.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type { WikiPage } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Radix Select cannot be opened in jsdom (gotcha #2). WikiEditDialog is the
+// sole ui/select consumer in this isolated file, so mock the primitive with a
+// context (approach a) and drive onValueChange by clicking the SelectItem stub.
+// Each <Select> wraps its own items in its own provider, so a single context
+// correctly routes a clicked item to its own Select's onValueChange.
+// Factory is hoisted, so import React dynamically inside it (gotcha #4).
+// ---------------------------------------------------------------------------
+vi.mock("@/components/ui/select", async () => {
+  const React = await import("react");
+  const Ctx = React.createContext<(v: string) => void>(() => {});
+  return {
+    Select: ({ onValueChange, children }: any) =>
+      React.createElement(Ctx.Provider, { value: onValueChange }, children),
+    SelectTrigger: ({ children, id }: any) =>
+      React.createElement("div", { role: "group", id }, children),
+    SelectValue: ({ placeholder }: any) =>
+      React.createElement("span", null, placeholder),
+    SelectContent: ({ children }: any) => React.createElement("div", null, children),
+    SelectItem: ({ value, children }: any) => {
+      const onValueChange = React.useContext(Ctx);
+      return React.createElement(
+        "button",
+        { type: "button", "data-select-item": value, onClick: () => onValueChange(value) },
+        children,
+      );
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+import { WikiEditDialog } from "./WikiEditDialog";
+
+// rAF is used by the toolbar for caret restore. Run it synchronously so the
+// scheduled callback fires deterministically; we assert on the textarea VALUE
+// (onChange result), never caret position, to avoid flakiness.
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const markdownField = () =>
+  screen.getByLabelText("Content (Markdown)") as HTMLTextAreaElement;
+const titleField = () => screen.getByLabelText("Title") as HTMLInputElement;
+
+function renderDialog(props: Partial<React.ComponentProps<typeof WikiEditDialog>> = {}) {
+  const onSave = props.onSave ?? vi.fn().mockResolvedValue(undefined);
+  const onClose = props.onClose ?? vi.fn();
+  const utils = render(
+    <WikiEditDialog
+      open={props.open ?? true}
+      page={props.page}
+      vaultId={props.vaultId ?? 1}
+      onClose={onClose}
+      onSave={onSave}
+    />,
+  );
+  return { ...utils, onSave, onClose };
+}
+
+describe("WikiEditDialog", () => {
+  // 1. Render gating
+  it("renders title and markdown fields when open", () => {
+    renderDialog({ open: true });
+    expect(titleField()).toBeInTheDocument();
+    expect(markdownField()).toBeInTheDocument();
+    expect(screen.getByText("New Wiki Page")).toBeInTheDocument();
+  });
+
+  it("does not render dialog content when open={false}", () => {
+    renderDialog({ open: false });
+    expect(screen.queryByLabelText("Title")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Content (Markdown)")).not.toBeInTheDocument();
+  });
+
+  // 2. Toolbar insertion
+  it("inserts bold markers around the selection when Bold is clicked", () => {
+    renderDialog({ open: true });
+    const ta = markdownField();
+    // Replace content with a known string and select the word "world".
+    fireEvent.change(ta, { target: { value: "hello world" } });
+    ta.selectionStart = 6;
+    ta.selectionEnd = 11;
+    fireEvent.click(screen.getByTitle("Bold"));
+    expect(ta.value).toBe("hello **world**");
+  });
+
+  it("inserts the Code placeholder when nothing is selected", () => {
+    renderDialog({ open: true });
+    const ta = markdownField();
+    fireEvent.change(ta, { target: { value: "" } });
+    ta.selectionStart = 0;
+    ta.selectionEnd = 0;
+    fireEvent.click(screen.getByTitle("Code"));
+    expect(ta.value).toBe("`code`");
+  });
+
+  // 3. Save validation + payload
+  it("blocks save and shows an error when the title is empty", () => {
+    const { onSave } = renderDialog({ open: true });
+    // Default create-mode title is empty; click Save.
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Title is required")).toBeInTheDocument();
+  });
+
+  it("calls onSave once with the entered data when title is valid", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { onClose } = renderDialog({ open: true, onSave });
+
+    fireEvent.change(titleField(), { target: { value: "My Entity" } });
+    fireEvent.change(screen.getByLabelText("Summary"), {
+      target: { value: "A summary" },
+    });
+    fireEvent.change(markdownField(), { target: { value: "# Body" } });
+    // Drive the status Select to "verified" via the mocked SelectItem.
+    fireEvent.click(screen.getByRole("button", { name: "verified" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith({
+      title: "My Entity",
+      page_type: "entity",
+      slug: undefined,
+      markdown: "# Body",
+      summary: "A summary",
+      status: "verified",
+      confidence: 0,
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  // 4. onSave rejection
+  it("surfaces an error and resets saving state when onSave rejects", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Server exploded"));
+    const { onClose } = renderDialog({ open: true, onSave });
+
+    fireEvent.change(titleField(), { target: { value: "Valid Title" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Server exploded")).toBeInTheDocument(),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    // saving state reset → button is re-enabled and back to "Save".
+    const saveBtn = screen.getByRole("button", { name: "Save" });
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  // 5. Template auto-fill
+  it("fills the markdown with the template for a newly chosen page type (create mode)", () => {
+    renderDialog({ open: true });
+    // Default markdown is the entity template; switch to "procedure".
+    fireEvent.click(screen.getByRole("button", { name: "procedure" }));
+    const ta = markdownField();
+    expect(ta.value).toContain("## Purpose");
+    expect(ta.value).toContain("## Steps");
+  });
+
+  it("does NOT overwrite user-edited markdown when the page type changes", () => {
+    renderDialog({ open: true });
+    const ta = markdownField();
+    // User types custom content that is not a template.
+    fireEvent.change(ta, { target: { value: "My own notes, untouched." } });
+    fireEvent.click(screen.getByRole("button", { name: "system" }));
+    expect(ta.value).toBe("My own notes, untouched.");
+  });
+
+  it("does not auto-fill template in edit mode (existing page)", () => {
+    const page: WikiPage = {
+      id: 5,
+      vault_id: 1,
+      slug: "existing",
+      title: "Existing Page",
+      page_type: "entity",
+      markdown: "Original content body.",
+      summary: "sum",
+      status: "draft",
+      confidence: 0.5,
+      created_by: null,
+      created_at: "",
+      updated_at: "",
+      last_compiled_at: null,
+      claims: [],
+      entities: [],
+      lint_findings: [],
+    };
+    renderDialog({ open: true, page });
+    expect(screen.getByText("Edit Page")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "procedure" }));
+    expect(markdownField().value).toBe("Original content body.");
+  });
+});

--- a/frontend/src/pages/WikiEditDialog.tsx
+++ b/frontend/src/pages/WikiEditDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Bold, Italic, Heading1, Link, List, Code } from "lucide-react";
 import type { WikiPage } from "@/lib/api";
 
 const PAGE_TYPES = [
@@ -25,6 +26,91 @@ const PAGE_TYPES = [
 ] as const;
 
 const STATUSES = ["draft", "needs_review", "verified", "stale", "archived"] as const;
+
+const TEMPLATES: Record<string, string> = {
+  entity: "# {title}\n\n## Overview\n\n## Key Facts\n\n## Related Entities\n",
+  procedure: "# {title}\n\n## Purpose\n\n## Steps\n\n1. \n2. \n3. \n\n## Notes\n",
+  system: "# {title}\n\n## Architecture\n\n## Components\n\n## Interfaces\n",
+  acronym: "# {title}\n\n**Stands for:** \n\n## Context\n\n## Usage\n",
+  qa: "# {title}\n\n## Question\n\n## Answer\n\n## Sources\n",
+  manual: "# {title}\n\n",
+};
+
+function getTemplate(pageType: string, title: string): string {
+  const tmpl = TEMPLATES[pageType] ?? "# {title}\n\n";
+  return tmpl.replace("{title}", title || "Untitled");
+}
+
+/** Returns true if `content` matches any template (with any title). */
+function isTemplateContent(content: string): boolean {
+  if (!content) return true;
+  for (const tmpl of Object.values(TEMPLATES)) {
+    // Build a regex from the template: escape special chars, replace {title} with .*
+    const escaped = tmpl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = escaped.replace("\\{title\\}", ".*");
+    if (new RegExp(`^${pattern}$`, "s").test(content)) return true;
+  }
+  // Also match the fallback
+  if (/^# .*\n\n$/.test(content)) return true;
+  return false;
+}
+
+interface MarkdownToolbarProps {
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  onChange: (v: string) => void;
+}
+
+function MarkdownToolbar({ textareaRef, value, onChange }: MarkdownToolbarProps) {
+  const insertMarkdown = useCallback(
+    (before: string, after: string, placeholder: string) => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const selected = value.slice(start, end);
+      const insertion = selected || placeholder;
+      const newValue =
+        value.slice(0, start) + before + insertion + after + value.slice(end);
+      onChange(newValue);
+      // Restore focus and select the inserted text after React re-renders
+      requestAnimationFrame(() => {
+        ta.focus();
+        const selStart = start + before.length;
+        const selEnd = selStart + insertion.length;
+        ta.setSelectionRange(selStart, selEnd);
+      });
+    },
+    [textareaRef, value, onChange],
+  );
+
+  const buttons = [
+    { icon: Bold, label: "Bold", before: "**", after: "**", placeholder: "bold" },
+    { icon: Italic, label: "Italic", before: "_", after: "_", placeholder: "italic" },
+    { icon: Heading1, label: "Heading", before: "# ", after: "", placeholder: "heading" },
+    { icon: Link, label: "Link", before: "[", after: "](url)", placeholder: "link text" },
+    { icon: List, label: "List", before: "- ", after: "", placeholder: "list item" },
+    { icon: Code, label: "Code", before: "`", after: "`", placeholder: "code" },
+  ] as const;
+
+  return (
+    <div className="flex gap-1 border rounded-md p-1 bg-muted/50">
+      {buttons.map((btn) => (
+        <Button
+          key={btn.label}
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title={btn.label}
+          onClick={() => insertMarkdown(btn.before, btn.after, btn.placeholder)}
+        >
+          <btn.icon className="h-4 w-4" />
+        </Button>
+      ))}
+    </div>
+  );
+}
 
 interface WikiEditDialogProps {
   open: boolean;
@@ -52,6 +138,9 @@ export function WikiEditDialog({ open, page, vaultId: _vaultId, onClose, onSave 
   const [confidence, setConfidence] = useState(0);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const isCreating = !page;
 
   useEffect(() => {
     if (page) {
@@ -66,13 +155,21 @@ export function WikiEditDialog({ open, page, vaultId: _vaultId, onClose, onSave 
       setTitle("");
       setPageType("entity");
       setSlug("");
-      setMarkdown("");
+      setMarkdown(getTemplate("entity", ""));
       setSummary("");
       setStatus("draft");
       setConfidence(0);
     }
     setError(null);
   }, [page, open]);
+
+  // Auto-fill template when page type changes during creation
+  useEffect(() => {
+    if (!isCreating) return;
+    if (isTemplateContent(markdown)) {
+      setMarkdown(getTemplate(pageType, title));
+    }
+  }, [pageType]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleSave() {
     if (!title.trim()) {
@@ -145,13 +242,19 @@ export function WikiEditDialog({ open, page, vaultId: _vaultId, onClose, onSave 
 
           <div>
             <Label htmlFor="wiki-markdown">Content (Markdown)</Label>
+            <MarkdownToolbar
+              textareaRef={textareaRef}
+              value={markdown}
+              onChange={setMarkdown}
+            />
             <Textarea
+              ref={textareaRef}
               id="wiki-markdown"
               value={markdown}
               onChange={(e) => setMarkdown(e.target.value)}
               placeholder="Page content…"
               rows={6}
-              className="font-mono text-sm"
+              className="font-mono text-sm mt-1"
             />
           </div>
 

--- a/frontend/src/pages/WikiLintPanel.test.tsx
+++ b/frontend/src/pages/WikiLintPanel.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+
+// Mock API module before importing the component.
+vi.mock("@/lib/api", () => ({
+  resolveWikiLintFinding: vi.fn().mockResolvedValue({}),
+}));
+
+import { WikiLintPanel } from "./WikiLintPanel";
+import { resolveWikiLintFinding } from "@/lib/api";
+import type { WikiLintFinding } from "@/lib/api";
+
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, { wrapper: MemoryRouter, ...options });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const makeFinding = (overrides: Partial<WikiLintFinding> = {}): WikiLintFinding => ({
+  id: 1,
+  vault_id: 1,
+  finding_type: "contradiction",
+  severity: "high",
+  title: "Conflicting claim detected",
+  details: "Two claims disagree.",
+  related_page_ids_json: "[]",
+  related_claim_ids_json: "[]",
+  status: "open",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const defaultProps = () => ({
+  findings: [makeFinding()],
+  loading: false,
+  onRunLint: vi.fn(),
+  vaultId: 5 as number | null,
+});
+
+describe("WikiLintPanel", () => {
+  it("renders the finding count and finding title", () => {
+    render(<WikiLintPanel {...defaultProps()} />);
+    expect(screen.getByText("Lint Findings (1)")).toBeInTheDocument();
+    expect(screen.getByText("Conflicting claim detected")).toBeInTheDocument();
+  });
+
+  it("renders severity and finding type metadata", () => {
+    render(<WikiLintPanel {...defaultProps()} />);
+    expect(screen.getByText("high · contradiction")).toBeInTheDocument();
+  });
+
+  it("Run Lint button calls onRunLint", () => {
+    const props = defaultProps();
+    render(<WikiLintPanel {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: /run lint/i }));
+    expect(props.onRunLint).toHaveBeenCalledTimes(1);
+  });
+
+  it("Run Lint button is disabled while loading", () => {
+    render(<WikiLintPanel {...defaultProps()} loading={true} />);
+    expect(screen.getByRole("button", { name: /running/i })).toBeDisabled();
+  });
+
+  it("shows the empty state when there are no findings and not loading", () => {
+    render(<WikiLintPanel {...defaultProps()} findings={[]} />);
+    expect(screen.getByText("No findings. Run lint to check.")).toBeInTheDocument();
+  });
+
+  it("Resolve calls resolveWikiLintFinding(id, vaultId, 'resolved') then onRunLint", async () => {
+    const props = defaultProps();
+    render(<WikiLintPanel {...props} />);
+    fireEvent.click(screen.getByTitle("Resolve"));
+    await waitFor(() => {
+      expect(resolveWikiLintFinding).toHaveBeenCalledWith(1, 5, "resolved");
+    });
+    await waitFor(() => {
+      expect(props.onRunLint).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("Dismiss calls resolveWikiLintFinding(id, vaultId, 'dismissed') then onRunLint", async () => {
+    const props = defaultProps();
+    render(<WikiLintPanel {...props} />);
+    fireEvent.click(screen.getByTitle("Dismiss"));
+    await waitFor(() => {
+      expect(resolveWikiLintFinding).toHaveBeenCalledWith(1, 5, "dismissed");
+    });
+    await waitFor(() => {
+      expect(props.onRunLint).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does NOT render Resolve/Dismiss buttons when vaultId is null", () => {
+    render(<WikiLintPanel {...defaultProps()} vaultId={null} />);
+    expect(screen.queryByTitle("Resolve")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Dismiss")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WikiLintPanel.tsx
+++ b/frontend/src/pages/WikiLintPanel.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Play } from "lucide-react";
+import { Play, Check, X } from "lucide-react";
+import { resolveWikiLintFinding } from "@/lib/api";
 import type { WikiLintFinding } from "@/lib/api";
 
 const SEVERITY_COLORS: Record<string, string> = {
@@ -21,9 +23,23 @@ interface WikiLintPanelProps {
   findings: WikiLintFinding[];
   loading: boolean;
   onRunLint: () => void;
+  vaultId: number | null;
 }
 
-export function WikiLintPanel({ findings, loading, onRunLint }: WikiLintPanelProps) {
+export function WikiLintPanel({ findings, loading, onRunLint, vaultId }: WikiLintPanelProps) {
+  const [resolving, setResolving] = useState<number | null>(null);
+
+  const handleResolve = async (findingId: number, status: "resolved" | "dismissed") => {
+    if (!vaultId) return;
+    setResolving(findingId);
+    try {
+      await resolveWikiLintFinding(findingId, vaultId, status);
+      onRunLint();
+    } finally {
+      setResolving(null);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
@@ -50,8 +66,34 @@ export function WikiLintPanel({ findings, loading, onRunLint }: WikiLintPanelPro
             {finding.details && (
               <div className="text-xs text-muted-foreground mt-0.5">{finding.details}</div>
             )}
-            <div className="text-xs text-muted-foreground mt-1 uppercase tracking-wide">
-              {finding.severity} · {finding.finding_type.replace(/_/g, " ")}
+            <div className="flex items-center justify-between mt-1">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                {finding.severity} · {finding.finding_type.replace(/_/g, " ")}
+              </div>
+              {vaultId && (
+                <div className="flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-1.5 text-xs"
+                    disabled={resolving === finding.id}
+                    onClick={() => handleResolve(finding.id, "resolved")}
+                    title="Resolve"
+                  >
+                    <Check className="w-3 h-3" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-1.5 text-xs"
+                    disabled={resolving === finding.id}
+                    onClick={() => handleResolve(finding.id, "dismissed")}
+                    title="Dismiss"
+                  >
+                    <X className="w-3 h-3" />
+                  </Button>
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/pages/WikiPage.sse.test.tsx
+++ b/frontend/src/pages/WikiPage.sse.test.tsx
@@ -47,7 +47,7 @@ vi.mock("./WikiEditDialog", () => ({
 }));
 
 vi.mock("./WikiLintPanel", () => ({
-  WikiLintPanel: () => <div data-testid="wiki-lint" />,
+  WikiLintPanel: ({ vaultId: _v }: { vaultId: number | null }) => <div data-testid="wiki-lint" />,
 }));
 
 vi.mock("./WikiJobsPanel", () => ({

--- a/frontend/src/pages/WikiPage.test.tsx
+++ b/frontend/src/pages/WikiPage.test.tsx
@@ -55,8 +55,8 @@ vi.mock("@/pages/WikiEditDialog", () => ({
 }));
 
 vi.mock("@/pages/WikiLintPanel", () => ({
-  WikiLintPanel: ({ onRunLint }: { onRunLint: () => void }) => (
-    <div data-testid="wiki-lint-panel">
+  WikiLintPanel: ({ onRunLint, vaultId }: { onRunLint: () => void; vaultId: number | null }) => (
+    <div data-testid="wiki-lint-panel" data-vault-id={vaultId}>
       <button onClick={onRunLint} data-testid="run-lint-btn">Run Lint</button>
     </div>
   ),

--- a/frontend/src/pages/WikiPage.tsx
+++ b/frontend/src/pages/WikiPage.tsx
@@ -9,8 +9,8 @@ import { WikiJobsPanel } from "./WikiJobsPanel";
 import { useWikiData } from "@/hooks/useWikiData";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { AlertCircle, Layers } from "lucide-react";
-import { API_BASE_URL } from "@/lib/api";
+import { AlertCircle, Layers, Activity } from "lucide-react";
+import { API_BASE_URL, getWikiActivityFeed } from "@/lib/api";
 
 export function wikiEventsUrl(vaultId: number | string): string {
   return `${API_BASE_URL}/wiki/events?vault_id=${encodeURIComponent(String(vaultId))}`;
@@ -22,6 +22,9 @@ export default function WikiPage() {
   const [editingPage, setEditingPage] = useState<import("@/lib/api").WikiPage | null>(null);
   const [lintPanelOpen, setLintPanelOpen] = useState(false);
   const [jobsPanelOpen, setJobsPanelOpen] = useState(false);
+  const [activityPanelOpen, setActivityPanelOpen] = useState(false);
+  const [activityEntries, setActivityEntries] = useState<Array<{ id: number; action: string; page_title?: string; user?: string; created_at: string }>>([]);
+  const [activityLoading, setActivityLoading] = useState(false);
   const [jobsRefreshSignal, setJobsRefreshSignal] = useState(0);
   const eventSourceRef = useRef<EventSource | null>(null);
 
@@ -87,6 +90,16 @@ export default function WikiPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeVaultId]);
 
+  // Fetch activity feed when panel opens
+  useEffect(() => {
+    if (!activityPanelOpen || !activeVaultId) return;
+    setActivityLoading(true);
+    getWikiActivityFeed(activeVaultId, 50)
+      .then((data) => setActivityEntries(Array.isArray(data) ? data : data.entries ?? []))
+      .catch(() => setActivityEntries([]))
+      .finally(() => setActivityLoading(false));
+  }, [activityPanelOpen, activeVaultId]);
+
   function handleCreateClick() {
     setEditingPage(null);
     setEditDialogOpen(true);
@@ -138,7 +151,15 @@ export default function WikiPage() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => { setJobsPanelOpen((v) => !v); setLintPanelOpen(false); }}
+            onClick={() => { setActivityPanelOpen((v) => !v); setJobsPanelOpen(false); setLintPanelOpen(false); }}
+          >
+            <Activity className="w-4 h-4 mr-1" />
+            Activity
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => { setJobsPanelOpen((v) => !v); setLintPanelOpen(false); setActivityPanelOpen(false); }}
           >
             <Layers className="w-4 h-4 mr-1" />
             Jobs
@@ -146,7 +167,7 @@ export default function WikiPage() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => { setLintPanelOpen((v) => !v); setJobsPanelOpen(false); }}
+            onClick={() => { setLintPanelOpen((v) => !v); setJobsPanelOpen(false); setActivityPanelOpen(false); }}
           >
             <AlertCircle className="w-4 h-4 mr-1" />
             Lint {lintFindings.length > 0 && `(${lintFindings.length})`}
@@ -171,6 +192,7 @@ export default function WikiPage() {
               onSelect={openPage}
               onFilter={(params) => fetchPages(params)}
               onCreateClick={handleCreateClick}
+              vaultId={activeVaultId}
             />
           )}
           {error && (
@@ -197,6 +219,7 @@ export default function WikiPage() {
               findings={lintFindings}
               loading={loading}
               onRunLint={handleRunLint}
+              vaultId={activeVaultId}
             />
           </div>
         )}
@@ -205,6 +228,35 @@ export default function WikiPage() {
         {jobsPanelOpen && activeVaultId && (
           <div className="w-80 border-l border-border p-4 overflow-y-auto shrink-0">
             <WikiJobsPanel vaultId={activeVaultId} refreshSignal={jobsRefreshSignal} />
+          </div>
+        )}
+
+        {/* Activity panel: right side overlay */}
+        {activityPanelOpen && activeVaultId && (
+          <div className="w-80 border-l border-border p-4 overflow-y-auto shrink-0">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold">Activity Feed</h3>
+            </div>
+            {activityLoading && <p className="text-xs text-muted-foreground">Loading...</p>}
+            {!activityLoading && activityEntries.length === 0 && (
+              <p className="text-xs text-muted-foreground">No recent activity.</p>
+            )}
+            {!activityLoading && activityEntries.length > 0 && (
+              <div className="flex flex-col gap-2">
+                {activityEntries.map((entry) => (
+                  <div key={entry.id} className="rounded-md border border-border px-3 py-2 text-xs">
+                    <div className="font-medium capitalize">{entry.action.replace(/_/g, " ")}</div>
+                    {entry.page_title && (
+                      <div className="text-muted-foreground truncate">{entry.page_title}</div>
+                    )}
+                    <div className="flex items-center gap-2 mt-1 text-muted-foreground">
+                      {entry.user && <span>{entry.user}</span>}
+                      <span>{new Date(entry.created_at).toLocaleString()}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/WikiPageDetail.sections.test.tsx
+++ b/frontend/src/pages/WikiPageDetail.sections.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * WikiPageDetail header callbacks + lazy-fetch collapsible sections.
+ *
+ * Covers (distinct from WikiPageDetail.curator.test.tsx, which owns the
+ * ClaimRow provenance / needs-review chips):
+ *   - Header Back/Edit/Delete buttons invoke onBack/onEdit/onDelete.
+ *   - VersionHistorySection lazy-fetches getWikiPageVersions on expand only,
+ *     tolerating both array and {versions:[...]} shapes.
+ *   - AttachmentsSection lazy-fetches getWikiPageFiles; empty -> empty state.
+ *   - BacklinksSection lazy-fetches getWikiPageBacklinks and renders entries.
+ *   - A rejected fetch is swallowed to [] and shows the empty state.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { WikiPage } from "@/lib/api";
+import {
+  getWikiPageVersions,
+  getWikiPageFiles,
+  getWikiPageBacklinks,
+} from "@/lib/api";
+import { WikiPageDetail } from "./WikiPageDetail";
+
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, { wrapper: MemoryRouter, ...options });
+
+// Partial-spread so unrelated api exports (types, other fns) keep working.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getWikiPageVersions: vi.fn(),
+    getWikiPageFiles: vi.fn(),
+    getWikiPageBacklinks: vi.fn(),
+  };
+});
+
+const mockGetVersions = vi.mocked(getWikiPageVersions);
+const mockGetFiles = vi.mocked(getWikiPageFiles);
+const mockGetBacklinks = vi.mocked(getWikiPageBacklinks);
+
+function makePage(overrides: Partial<WikiPage> = {}): WikiPage {
+  return {
+    id: 10,
+    vault_id: 2,
+    slug: "doc/alice",
+    title: "Alice doc",
+    page_type: "entity",
+    summary: "",
+    markdown: "",
+    status: "draft",
+    confidence: 0.0,
+    created_by: null,
+    created_at: "2024-01-01T00:00:00",
+    updated_at: "2024-01-01T00:00:00",
+    last_compiled_at: null,
+    claims: [],
+    entities: [],
+    lint_findings: [],
+    ...overrides,
+  } as unknown as WikiPage;
+}
+
+function renderDetail(
+  cbs: Partial<{
+    onBack: () => void;
+    onEdit: () => void;
+    onDelete: () => void;
+  }> = {},
+) {
+  const page = makePage();
+  return render(
+    <WikiPageDetail
+      page={page}
+      onBack={cbs.onBack ?? (() => {})}
+      onEdit={cbs.onEdit ?? (() => {})}
+      onDelete={cbs.onDelete ?? (() => {})}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default each fetcher to a resolved empty list so sections never throw
+  // unless a test explicitly overrides the resolution.
+  mockGetVersions.mockResolvedValue([]);
+  mockGetFiles.mockResolvedValue([]);
+  mockGetBacklinks.mockResolvedValue([]);
+});
+
+describe("WikiPageDetail header callbacks", () => {
+  it("calls onBack when the Back button is clicked", () => {
+    const onBack = vi.fn();
+    renderDetail({ onBack });
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onEdit when the Edit button is clicked", () => {
+    const onEdit = vi.fn();
+    renderDetail({ onEdit });
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDelete when the Delete button is clicked", () => {
+    const onDelete = vi.fn();
+    // The delete button has only a Trash2 icon (no text label); it is the
+    // sole outline button that is neither Back nor Edit. Grab it by position.
+    renderDetail({ onDelete });
+    const buttons = screen.getAllByRole("button");
+    // Back, Edit, Delete + three collapsible section headers (not buttons).
+    const deleteBtn = buttons.find((b) =>
+      b.className.includes("text-destructive"),
+    );
+    expect(deleteBtn).toBeTruthy();
+    fireEvent.click(deleteBtn!);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WikiPageDetail VersionHistorySection", () => {
+  it("does not fetch until expanded, then fetches once (array shape)", async () => {
+    mockGetVersions.mockResolvedValue([
+      {
+        version: 1,
+        edited_by: "alice",
+        edited_at: "2024-01-01T00:00:00",
+        diff_summary: "initial revision",
+      },
+    ]);
+    renderDetail();
+
+    // Collapsed: fetch not called.
+    expect(mockGetVersions).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Version History"));
+
+    await waitFor(() => expect(mockGetVersions).toHaveBeenCalledTimes(1));
+    expect(mockGetVersions).toHaveBeenCalledWith(10, 2);
+    expect(await screen.findByText("v1")).toBeInTheDocument();
+    expect(screen.getByText("initial revision")).toBeInTheDocument();
+  });
+
+  it("tolerates the {versions:[...]} object shape", async () => {
+    mockGetVersions.mockResolvedValue({
+      versions: [
+        {
+          version: 7,
+          edited_by: null,
+          edited_at: "2024-02-02T00:00:00",
+          diff_summary: null,
+        },
+      ],
+    });
+    renderDetail();
+    fireEvent.click(screen.getByText("Version History"));
+    expect(await screen.findByText("v7")).toBeInTheDocument();
+  });
+});
+
+describe("WikiPageDetail AttachmentsSection", () => {
+  it("fetches files on expand and renders them", async () => {
+    mockGetFiles.mockResolvedValue([
+      { file_id: 5, filename: "spec.pdf", attached_at: "2024-01-01T00:00:00" },
+    ]);
+    renderDetail();
+    expect(mockGetFiles).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Attachments"));
+
+    await waitFor(() => expect(mockGetFiles).toHaveBeenCalledTimes(1));
+    expect(mockGetFiles).toHaveBeenCalledWith(10, 2);
+    expect(await screen.findByText("spec.pdf")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when no files are returned", async () => {
+    mockGetFiles.mockResolvedValue([]);
+    renderDetail();
+    fireEvent.click(screen.getByText("Attachments"));
+    expect(await screen.findByText("No attachments.")).toBeInTheDocument();
+  });
+});
+
+describe("WikiPageDetail BacklinksSection", () => {
+  it("fetches backlinks on expand and renders them (array shape)", async () => {
+    mockGetBacklinks.mockResolvedValue([
+      { page_id: 42, title: "Linking Page", slug: "doc/linking" },
+    ]);
+    renderDetail();
+    expect(mockGetBacklinks).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Backlinks"));
+
+    await waitFor(() => expect(mockGetBacklinks).toHaveBeenCalledTimes(1));
+    expect(mockGetBacklinks).toHaveBeenCalledWith(10, 2);
+    expect(await screen.findByText("Linking Page")).toBeInTheDocument();
+    expect(screen.getByText("doc/linking")).toBeInTheDocument();
+  });
+
+  it("tolerates the {backlinks:[...]} object shape", async () => {
+    mockGetBacklinks.mockResolvedValue({
+      backlinks: [{ page_id: 99, title: "Wrapped Link", slug: "doc/wrapped" }],
+    });
+    renderDetail();
+    fireEvent.click(screen.getByText("Backlinks"));
+    expect(await screen.findByText("Wrapped Link")).toBeInTheDocument();
+  });
+});
+
+describe("WikiPageDetail fetch error handling", () => {
+  it("swallows a rejected versions fetch and shows the empty state", async () => {
+    mockGetVersions.mockRejectedValue(new Error("network down"));
+    renderDetail();
+    fireEvent.click(screen.getByText("Version History"));
+
+    await waitFor(() => expect(mockGetVersions).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText("No version history available."),
+    ).toBeInTheDocument();
+  });
+
+  it("swallows a rejected backlinks fetch and shows the empty state", async () => {
+    mockGetBacklinks.mockRejectedValue(new Error("boom"));
+    renderDetail();
+    fireEvent.click(screen.getByText("Backlinks"));
+
+    await waitFor(() => expect(mockGetBacklinks).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText("No pages link to this page."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WikiPageDetail.tsx
+++ b/frontend/src/pages/WikiPageDetail.tsx
@@ -1,9 +1,11 @@
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { ArrowLeft, Edit, Trash2 } from "lucide-react";
+import { ArrowLeft, ChevronDown, ChevronRight, Edit, FileText, Link2, Trash2, History } from "lucide-react";
 import type { WikiPage, WikiClaim, WikiLintFinding } from "@/lib/api";
+import { getWikiPageVersions, getWikiPageFiles, getWikiPageBacklinks } from "@/lib/api";
 
 interface WikiPageDetailProps {
   page: WikiPage;
@@ -90,6 +92,166 @@ function LintFindingRow({ finding }: { finding: WikiLintFinding }) {
       <div className="font-medium">{finding.title}</div>
       {finding.details && <div className="text-xs mt-0.5 opacity-75">{finding.details}</div>}
     </div>
+  );
+}
+
+interface VersionEntry {
+  version: number;
+  edited_by: string | null;
+  edited_at: string;
+  diff_summary: string | null;
+}
+
+interface FileAttachment {
+  file_id: number;
+  filename: string;
+  attached_at: string;
+}
+
+interface BacklinkEntry {
+  page_id: number;
+  title: string;
+  slug: string;
+}
+
+function VersionHistorySection({ pageId, vaultId }: { pageId: number; vaultId: number }) {
+  const [open, setOpen] = useState(false);
+  const [versions, setVersions] = useState<VersionEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    getWikiPageVersions(pageId, vaultId)
+      .then((data) => setVersions(Array.isArray(data) ? data : data.versions ?? []))
+      .catch(() => setVersions([]))
+      .finally(() => setLoading(false));
+  }, [open, pageId, vaultId]);
+
+  return (
+    <Card>
+      <CardHeader
+        className="pb-2 pt-3 px-4 cursor-pointer select-none"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <CardTitle className="text-sm flex items-center gap-1">
+          {open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          <History className="w-4 h-4" />
+          Version History
+        </CardTitle>
+      </CardHeader>
+      {open && (
+        <CardContent className="px-4 pb-3">
+          {loading && <p className="text-xs text-muted-foreground">Loading...</p>}
+          {!loading && versions.length === 0 && (
+            <p className="text-xs text-muted-foreground">No version history available.</p>
+          )}
+          {!loading &&
+            versions.map((v) => (
+              <div key={v.version} className="border-b border-border pb-2 mb-2 last:border-0 last:mb-0 last:pb-0">
+                <div className="flex items-center gap-2 text-xs">
+                  <Badge variant="outline" className="text-[10px]">v{v.version}</Badge>
+                  <span className="text-muted-foreground">{new Date(v.edited_at).toLocaleString()}</span>
+                  {v.edited_by && <span className="text-muted-foreground">by {v.edited_by}</span>}
+                </div>
+                {v.diff_summary && <p className="text-xs text-muted-foreground mt-0.5">{v.diff_summary}</p>}
+              </div>
+            ))}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+function AttachmentsSection({ pageId, vaultId }: { pageId: number; vaultId: number }) {
+  const [open, setOpen] = useState(false);
+  const [files, setFiles] = useState<FileAttachment[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    getWikiPageFiles(pageId, vaultId)
+      .then((data) => setFiles(Array.isArray(data) ? data : data.files ?? []))
+      .catch(() => setFiles([]))
+      .finally(() => setLoading(false));
+  }, [open, pageId, vaultId]);
+
+  return (
+    <Card>
+      <CardHeader
+        className="pb-2 pt-3 px-4 cursor-pointer select-none"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <CardTitle className="text-sm flex items-center gap-1">
+          {open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          <FileText className="w-4 h-4" />
+          Attachments
+        </CardTitle>
+      </CardHeader>
+      {open && (
+        <CardContent className="px-4 pb-3">
+          {loading && <p className="text-xs text-muted-foreground">Loading...</p>}
+          {!loading && files.length === 0 && (
+            <p className="text-xs text-muted-foreground">No attachments.</p>
+          )}
+          {!loading &&
+            files.map((f) => (
+              <div key={f.file_id} className="flex items-center gap-2 text-xs border-b border-border pb-2 mb-2 last:border-0 last:mb-0 last:pb-0">
+                <FileText className="w-3 h-3 text-muted-foreground" />
+                <span className="truncate">{f.filename}</span>
+                <span className="text-muted-foreground ml-auto">{new Date(f.attached_at).toLocaleDateString()}</span>
+              </div>
+            ))}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+function BacklinksSection({ pageId, vaultId }: { pageId: number; vaultId: number }) {
+  const [open, setOpen] = useState(false);
+  const [backlinks, setBacklinks] = useState<BacklinkEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    getWikiPageBacklinks(pageId, vaultId)
+      .then((data) => setBacklinks(Array.isArray(data) ? data : data.backlinks ?? []))
+      .catch(() => setBacklinks([]))
+      .finally(() => setLoading(false));
+  }, [open, pageId, vaultId]);
+
+  return (
+    <Card>
+      <CardHeader
+        className="pb-2 pt-3 px-4 cursor-pointer select-none"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <CardTitle className="text-sm flex items-center gap-1">
+          {open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          <Link2 className="w-4 h-4" />
+          Backlinks
+        </CardTitle>
+      </CardHeader>
+      {open && (
+        <CardContent className="px-4 pb-3">
+          {loading && <p className="text-xs text-muted-foreground">Loading...</p>}
+          {!loading && backlinks.length === 0 && (
+            <p className="text-xs text-muted-foreground">No pages link to this page.</p>
+          )}
+          {!loading &&
+            backlinks.map((bl) => (
+              <div key={bl.page_id} className="flex items-center gap-2 text-xs border-b border-border pb-2 mb-2 last:border-0 last:mb-0 last:pb-0">
+                <Link2 className="w-3 h-3 text-muted-foreground" />
+                <span className="truncate font-medium">{bl.title}</span>
+                <span className="text-muted-foreground ml-auto">{bl.slug}</span>
+              </div>
+            ))}
+        </CardContent>
+      )}
+    </Card>
   );
 }
 
@@ -191,6 +353,15 @@ export function WikiPageDetail({ page, onBack, onEdit, onDelete }: WikiPageDetai
             </CardContent>
           </Card>
         )}
+
+        {/* Version History */}
+        <VersionHistorySection pageId={page.id} vaultId={page.vault_id} />
+
+        {/* Attachments */}
+        <AttachmentsSection pageId={page.id} vaultId={page.vault_id} />
+
+        {/* Backlinks */}
+        <BacklinksSection pageId={page.id} vaultId={page.vault_id} />
       </div>
     </ScrollArea>
   );

--- a/frontend/src/pages/WikiPageList.test.tsx
+++ b/frontend/src/pages/WikiPageList.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+
+// Mock API module before importing the component.
+vi.mock("@/lib/api", () => ({
+  bulkWikiPageAction: vi.fn().mockResolvedValue({}),
+}));
+
+// Radix Tabs cannot be activated via fireEvent.click in jsdom (pointer-capture /
+// activation semantics). Mock the primitive so TabsTrigger is a plain button that
+// invokes onValueChange — same approach the repo uses for ui/tabs and ui/select
+// (see frontend-testing-gotchas + RightPane.test.tsx). WikiPageList is the sole
+// ui/tabs consumer in this file, so reshaping the module here is safe.
+vi.mock("@/components/ui/tabs", async () => {
+  const React = await import("react");
+  const Ctx = React.createContext<(v: string) => void>(() => {});
+  return {
+    Tabs: ({ onValueChange, children }: any) =>
+      React.createElement(Ctx.Provider, { value: onValueChange }, children),
+    TabsList: ({ children }: any) => React.createElement("div", null, children),
+    TabsTrigger: ({ value, children }: any) => {
+      const onValueChange = React.useContext(Ctx);
+      return React.createElement(
+        "button",
+        { role: "tab", onClick: () => onValueChange(value) },
+        children
+      );
+    },
+  };
+});
+
+import { WikiPageList } from "./WikiPageList";
+import { bulkWikiPageAction } from "@/lib/api";
+import type { WikiPage } from "@/lib/api";
+
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, { wrapper: MemoryRouter, ...options });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const makePage = (overrides: Partial<WikiPage> = {}): WikiPage => ({
+  id: 1,
+  vault_id: 1,
+  slug: "page-one",
+  title: "Page One",
+  page_type: "entity",
+  markdown: "",
+  summary: "First page summary",
+  status: "draft",
+  confidence: 0.9,
+  created_by: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  last_compiled_at: null,
+  claims: [],
+  entities: [],
+  lint_findings: [],
+  ...overrides,
+});
+
+const defaultProps = () => ({
+  pages: [
+    makePage({ id: 1, title: "Page One", slug: "page-one" }),
+    makePage({ id: 2, title: "Page Two", slug: "page-two", status: "verified" }),
+  ],
+  loading: false,
+  onSelect: vi.fn(),
+  onFilter: vi.fn(),
+  onCreateClick: vi.fn(),
+  vaultId: 7,
+});
+
+describe("WikiPageList", () => {
+  it("renders a row for each page", () => {
+    render(<WikiPageList {...defaultProps()} />);
+    expect(screen.getByText("Page One")).toBeInTheDocument();
+    expect(screen.getByText("Page Two")).toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no pages and not loading", () => {
+    render(<WikiPageList {...defaultProps()} pages={[]} />);
+    expect(screen.getByText("No pages found.")).toBeInTheDocument();
+  });
+
+  it("calls onSelect with the page id when a row is clicked", () => {
+    const props = defaultProps();
+    render(<WikiPageList {...props} />);
+    fireEvent.click(screen.getByText("Page One"));
+    expect(props.onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it("selecting a row reveals the bulk action bar", () => {
+    render(<WikiPageList {...defaultProps()} />);
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("select-all checkbox selects every page", () => {
+    render(<WikiPageList {...defaultProps()} />);
+    fireEvent.click(screen.getByLabelText("Select all pages"));
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+  });
+
+  it("Delete with confirm=true calls bulkWikiPageAction(vaultId, ids, 'delete')", async () => {
+    (window.confirm as ReturnType<typeof vi.fn>).mockReturnValueOnce(true);
+    render(<WikiPageList {...defaultProps()} />);
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+    await waitFor(() => {
+      expect(bulkWikiPageAction).toHaveBeenCalledWith(7, [1], "delete");
+    });
+  });
+
+  it("Delete with confirm=false does NOT call bulkWikiPageAction", () => {
+    (window.confirm as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+    render(<WikiPageList {...defaultProps()} />);
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(bulkWikiPageAction).not.toHaveBeenCalled();
+  });
+
+  it("Set Draft calls bulkWikiPageAction(vaultId, ids, 'update', { status: 'draft' })", async () => {
+    render(<WikiPageList {...defaultProps()} />);
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    fireEvent.click(screen.getByRole("button", { name: /set draft/i }));
+    await waitFor(() => {
+      expect(bulkWikiPageAction).toHaveBeenCalledWith(7, [1], "update", { status: "draft" });
+    });
+  });
+
+  it("Archive calls bulkWikiPageAction with status 'archived'", async () => {
+    render(<WikiPageList {...defaultProps()} />);
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    fireEvent.click(screen.getByRole("button", { name: /archive/i }));
+    await waitFor(() => {
+      expect(bulkWikiPageAction).toHaveBeenCalledWith(7, [1], "update", { status: "archived" });
+    });
+  });
+
+  it("Clear deselects all and hides the bulk bar", () => {
+    render(<WikiPageList {...defaultProps()} />);
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+    expect(screen.queryByText("1 selected")).not.toBeInTheDocument();
+  });
+
+  it("search submit (button) calls onFilter with the query", () => {
+    const props = defaultProps();
+    render(<WikiPageList {...props} />);
+    fireEvent.change(screen.getByPlaceholderText("Search wiki..."), {
+      target: { value: "alpha" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(props.onFilter).toHaveBeenCalledWith({ page_type: undefined, search: "alpha" });
+  });
+
+  it("search submit on Enter calls onFilter with the query", () => {
+    const props = defaultProps();
+    render(<WikiPageList {...props} />);
+    const input = screen.getByPlaceholderText("Search wiki...");
+    fireEvent.change(input, { target: { value: "beta" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(props.onFilter).toHaveBeenCalledWith({ page_type: undefined, search: "beta" });
+  });
+
+  it("changing the activeType tab fires onFilter with the page_type", async () => {
+    const props = defaultProps();
+    render(<WikiPageList {...props} />);
+    props.onFilter.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: "Entities" }));
+    await waitFor(() => {
+      expect(props.onFilter).toHaveBeenCalledWith({ page_type: "entity", search: undefined });
+    });
+  });
+
+  it("changing the pages prop clears the current selection", () => {
+    const props = defaultProps();
+    const { rerender } = render(<WikiPageList {...props} />);
+    fireEvent.click(screen.getByLabelText("Select Page One"));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    // rerender re-injects into the same MemoryRouter wrapper supplied by render().
+    rerender(
+      <WikiPageList {...props} pages={[makePage({ id: 3, title: "Page Three", slug: "page-three" })]} />
+    );
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WikiPageList.tsx
+++ b/frontend/src/pages/WikiPageList.tsx
@@ -4,8 +4,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, Trash2, RefreshCw } from "lucide-react";
 import type { WikiPage } from "@/lib/api";
+import { bulkWikiPageAction } from "@/lib/api";
 
 const PAGE_TYPES = [
   { value: "", label: "All" },
@@ -33,11 +34,63 @@ interface WikiPageListProps {
   onSelect: (pageId: number) => void;
   onFilter: (params: { page_type?: string; search?: string }) => void;
   onCreateClick: () => void;
+  vaultId?: number | null;
 }
 
-export function WikiPageList({ pages, loading, onSelect, onFilter, onCreateClick }: WikiPageListProps) {
+export function WikiPageList({ pages, loading, onSelect, onFilter, onCreateClick, vaultId }: WikiPageListProps) {
   const [search, setSearch] = useState("");
   const [activeType, setActiveType] = useState("");
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  // Clear selection when pages change
+  useEffect(() => {
+    setSelectedIds([]);
+  }, [pages]);
+
+  function toggleSelect(pageId: number, e: React.MouseEvent) {
+    e.stopPropagation();
+    setSelectedIds((prev) =>
+      prev.includes(pageId) ? prev.filter((id) => id !== pageId) : [...prev, pageId]
+    );
+  }
+
+  function toggleSelectAll() {
+    if (selectedIds.length === pages.length) {
+      setSelectedIds([]);
+    } else {
+      setSelectedIds(pages.map((p) => p.id));
+    }
+  }
+
+  async function handleBulkDelete() {
+    if (!vaultId || selectedIds.length === 0) return;
+    if (!window.confirm(`Delete ${selectedIds.length} selected page(s)?`)) return;
+    setBulkLoading(true);
+    try {
+      await bulkWikiPageAction(vaultId, selectedIds, "delete");
+      setSelectedIds([]);
+      onFilter({ page_type: activeType || undefined, search: search || undefined });
+    } catch {
+      // error handled by api interceptor
+    } finally {
+      setBulkLoading(false);
+    }
+  }
+
+  async function handleBulkStatusChange(status: string) {
+    if (!vaultId || selectedIds.length === 0) return;
+    setBulkLoading(true);
+    try {
+      await bulkWikiPageAction(vaultId, selectedIds, "update", { status });
+      setSelectedIds([]);
+      onFilter({ page_type: activeType || undefined, search: search || undefined });
+    } catch {
+      // error handled by api interceptor
+    } finally {
+      setBulkLoading(false);
+    }
+  }
 
   useEffect(() => {
     onFilter({ page_type: activeType || undefined, search: search || undefined });
@@ -79,37 +132,103 @@ export function WikiPageList({ pages, loading, onSelect, onFilter, onCreateClick
         </TabsList>
       </Tabs>
 
+      {/* Bulk action bar */}
+      {selectedIds.length > 0 && (
+        <div className="flex items-center gap-2 px-2 py-2 bg-muted/50 rounded-md border border-border">
+          <span className="text-xs font-medium">{selectedIds.length} selected</span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBulkDelete}
+            disabled={bulkLoading}
+            className="text-destructive hover:text-destructive text-xs h-7"
+          >
+            <Trash2 className="w-3 h-3 mr-1" />
+            Delete
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleBulkStatusChange("draft")}
+            disabled={bulkLoading}
+            className="text-xs h-7"
+          >
+            <RefreshCw className="w-3 h-3 mr-1" />
+            Set Draft
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleBulkStatusChange("archived")}
+            disabled={bulkLoading}
+            className="text-xs h-7"
+          >
+            Archive
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setSelectedIds([])}
+            className="text-xs h-7 ml-auto"
+          >
+            Clear
+          </Button>
+        </div>
+      )}
+
       {/* Page list */}
       <div className="flex flex-col gap-2 overflow-y-auto flex-1">
         {loading && (
-          <p className="text-sm text-muted-foreground text-center py-8">Loading…</p>
+          <p className="text-sm text-muted-foreground text-center py-8">Loading...</p>
         )}
         {!loading && pages.length === 0 && (
           <p className="text-sm text-muted-foreground text-center py-8">No pages found.</p>
         )}
+        {!loading && pages.length > 0 && (
+          <div className="flex items-center gap-2 px-1 mb-1">
+            <input
+              type="checkbox"
+              checked={selectedIds.length === pages.length && pages.length > 0}
+              onChange={toggleSelectAll}
+              className="h-3.5 w-3.5 rounded border-border"
+              aria-label="Select all pages"
+            />
+            <span className="text-xs text-muted-foreground">Select all</span>
+          </div>
+        )}
         {pages.map((page) => (
           <Card
             key={page.id}
-            className="cursor-pointer hover:bg-secondary/50 transition-colors"
+            className={`cursor-pointer hover:bg-secondary/50 transition-colors ${selectedIds.includes(page.id) ? "ring-2 ring-primary/50" : ""}`}
             onClick={() => onSelect(page.id)}
             role="button"
             tabIndex={0}
             onKeyDown={(e) => e.key === "Enter" && onSelect(page.id)}
           >
             <CardContent className="py-3 px-4">
-              <div className="flex items-start justify-between gap-2">
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-sm truncate">{page.title}</p>
-                  <p className="text-xs text-muted-foreground truncate">{page.slug}</p>
-                  {page.summary && (
-                    <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{page.summary}</p>
-                  )}
-                </div>
-                <div className="flex flex-col items-end gap-1 shrink-0">
-                  <Badge variant="outline" className="text-xs capitalize">{page.page_type}</Badge>
-                  <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${STATUS_COLORS[page.status] ?? ""}`}>
-                    {page.status}
-                  </span>
+              <div className="flex items-start gap-2">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.includes(page.id)}
+                  onClick={(e) => toggleSelect(page.id, e)}
+                  onChange={() => {}}
+                  className="h-3.5 w-3.5 mt-1 rounded border-border shrink-0"
+                  aria-label={`Select ${page.title}`}
+                />
+                <div className="flex items-start justify-between gap-2 flex-1 min-w-0">
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-sm truncate">{page.title}</p>
+                    <p className="text-xs text-muted-foreground truncate">{page.slug}</p>
+                    {page.summary && (
+                      <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{page.summary}</p>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-end gap-1 shrink-0">
+                    <Badge variant="outline" className="text-xs capitalize">{page.page_type}</Badge>
+                    <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${STATUS_COLORS[page.status] ?? ""}`}>
+                      {page.status}
+                    </span>
+                  </div>
                 </div>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- Implements all 25 confirmed findings from issue #120 (DEEP DIVE: Wiki/KMS & RAG Integration Analysis), covering correctness fixes, retrieval quality improvements, data integrity guards, and full-stack feature additions to the wiki subsystem
- Backend changes: freshness gating on wiki evidence bypass, parallel wiki+KMS retrieval, alias dedup guard, optimistic locking, version history, file attachments, backlinks, activity log, bulk ops, search facets, claim dedup, curator rejection feedback, schema migrations, and fix for source_kind=manual→wiki
- Frontend changes: markdown toolbar with templates, version history/attachments/backlinks in page detail, multi-select bulk actions, resolve/dismiss lint findings, activity feed panel, and in-app WikiCards navigation

## Test plan
- [x] `python -m ruff check .` (backend) — all checks passed
- [x] `npx tsc --noEmit` (frontend) — clean
- [x] `npx eslint src/pages/WikiPage.tsx src/pages/WikiPageDetail.tsx src/pages/WikiPageList.tsx src/pages/WikiEditDialog.tsx src/pages/WikiLintPanel.tsx src/components/chat/WikiCards.tsx src/lib/api.ts` — clean
- [x] `npx vitest run src/pages/WikiPage.test.tsx src/pages/WikiPage.sse.test.tsx` — 16/16 passed
- [x] `python -m pytest tests/ -q -k "wiki and not TestPutClaimReverify"` — 244/244 passed

## Known issues
- `TestPutClaimReverify` (4 tests) fail in the worktree environment with "CSRF service unavailable" — these 4 tests pass on `master` with identical code; confirmed environment-specific CSRF init issue unrelated to this PR's changes

## Findings addressed (25 total)

| ID | Description |
|----|-------------|
| DD-C001 | Add `parent_id` / `version` to `wiki_pages`; 4 new supporting tables with migrations |
| DD-C002 | Markdown toolbar (Bold/Italic/Heading/Link/List/Code) in WikiEditDialog |
| DD-C003 | Wiki page version history — save on update, list/view in detail panel |
| DD-C005 | Fix `source_kind="manual"` → `"wiki"` in citation helpers |
| DD-C006 | Parallelize wiki + KMS retrieval with `asyncio.gather` |
| DD-C009 | Freshness field surfaced from `last_compiled_at` on WikiEvidence |
| DD-C010 | Curator rejection summary included in `CuratorResult.to_summary()` |
| DD-C011 | `find_claim_by_normalized_text()` for fuzzy claim deduplication |
| DD-C012 | Relax FTS page search threshold from `< 3` to `< 5` candidates |
| DD-C013 | `UNIQUE(subject_entity_id, predicate, object_entity_id)` on `wiki_relations` |
| DD-C014 | Dedup wiki claim text against document chunks before prompt injection |
| DD-C015 | WikiCards navigation uses `useNavigate` for in-app routing |
| DD-C016 | WikiLintPanel resolve/dismiss buttons with API integration |
| DD-C018 | Page-type-based content templates auto-fill on type change |
| DD-C019 | File attachment CRUD on wiki pages (attach/detach/list) |
| DD-C020 | Optimistic locking on page update via `expected_version` + 409 on conflict |
| DD-C021 | Error truncation limit raised from 2000 → 8000 chars in `fail_job` |
| DD-C023 | Alias guard in `upsert_entity()` to prevent canonical name conflicts |
| DD-C024 | `publish_page_change` / `publish_claim_change` helpers on WikiEventBus |
| DD-C025 | Bulk wiki page actions (delete/draft/archive) with multi-select UI |
| DD-C026 | Activity log (create/update/delete events) with feed panel in UI |
| DD-C027 | Search facets: `page_type`, `status`, `sort_by` params on search endpoint |
| DD-C028 | Deterministic sort of merged claims by `(claim_text, chunk_id)` before dedup |
| DD-C029 | Freshness check in `_raw_rag_required()` — stale wiki evidence forces RAG |
| DD-C030 | `[[slug]]` link parsing, `sync_page_links`, `list_backlinks`; backlinks section in UI |

Closes #120