### PR TITLE
fix(frontend): stop NavigationRail crashing every authenticated page

### DIFF
--- a/frontend/src/components/layout/NavigationRail.test.tsx
+++ b/frontend/src/components/layout/NavigationRail.test.tsx
@@ -6,15 +6,12 @@ import type { NavItemId } from "./navigationTypes";
 
 const mockLogout = vi.hoisted(() => vi.fn());
 
-// Under vitest, the named icons from "@hugeicons/core-free-icons" resolve to
-// undefined, so the real HugeiconsIcon throws "currentIcon is not iterable" and
-// crashes every render. Mock the renderer to a harmless stub so the rebranded
-// component mounts. Identity of the SVG is not assertable; tests assert on the
-// stable aria-labels instead.
-vi.mock("@hugeicons/react", () => ({
-  HugeiconsIcon: () => null,
-  IconSvgElement: undefined,
-}));
+// NOTE: We intentionally do NOT mock "@hugeicons/react". The real HugeiconsIcon
+// spreads its `icon` prop (`[...icon]`), so it throws "currentIcon is not
+// iterable" if a non-array (e.g. a lucide forwardRef component such as the KMS
+// "Library" icon) is ever routed to it. Rendering the real component here is a
+// regression guard for that production crash (every authenticated page mounts
+// this rail). See the Array.isArray discriminator in NavRow.
 
 // Mock useThemeStore before importing NavigationRail (NavigationRail imports useThemeStore)
 vi.mock("@/stores/useThemeStore", () => ({
@@ -69,6 +66,24 @@ describe("NavigationRail", () => {
       expect(screen.getByLabelText("Users")).toBeInTheDocument();
       expect(screen.getByLabelText("Organizations")).toBeInTheDocument();
       expect(screen.getByLabelText("Profile")).toBeInTheDocument();
+    });
+
+    // Regression: the KMS nav item uses a lucide icon (`Library`), which is a
+    // forwardRef object, not an array. With the real HugeiconsIcon mounted,
+    // routing it through HugeiconsIcon would throw "currentIcon is not iterable"
+    // and crash every authenticated page. The KMS row must render a real icon.
+    it("renders the lucide-iconed KMS item without crashing (regression)", () => {
+      render(
+        <MemoryRouter>
+          <NavigationRail healthStatus={mockHealthStatus} />
+        </MemoryRouter>
+      );
+
+      const kmsLink = screen.getByLabelText("KMS");
+      expect(kmsLink).toBeInTheDocument();
+      // The lucide icon renders as an inline <svg>, proving it was NOT misrouted
+      // into HugeiconsIcon (which would have thrown before rendering anything).
+      expect(kmsLink.querySelector("svg")).toBeInTheDocument();
     });
 
     it("does not render chatNew item", () => {

--- a/frontend/src/components/layout/NavigationRail.tsx
+++ b/frontend/src/components/layout/NavigationRail.tsx
@@ -48,6 +48,16 @@ const sectionLabels: Record<NavSection, string> = {
   account: "Account",
 };
 
+// Hugeicons icons are IconSvgElement arrays; everything else (lucide icons,
+// etc.) is a React component. lucide icons are forwardRef OBJECTS, not
+// functions, so a `typeof === "function"` check would misroute them into
+// HugeiconsIcon, which spreads its icon prop (`[...icon]`) and crashes with
+// "currentIcon is not iterable". Array.isArray is the correct discriminator,
+// and as a user-defined type guard it also narrows the component branch.
+function isHugeicon(icon: NavConfigItem["icon"]): icon is IconSvgElement {
+  return Array.isArray(icon);
+}
+
 function StatusIndicator({ isUp, label, loading, isExpanded }: { isUp: boolean; label: string; loading?: boolean; isExpanded?: boolean }) {
   return (
     <div className="flex items-center min-h-4 gap-2.5">
@@ -250,10 +260,10 @@ function NavRow({
       aria-label={item.label}
       title={isExpanded ? undefined : item.label}
     >
-      {typeof Icon === "function" ? (
-        <Icon className="w-4 h-4 flex-shrink-0" />
-      ) : (
+      {isHugeicon(Icon) ? (
         <HugeiconsIcon strokeWidth={1.2} icon={Icon} size={16} className="flex-shrink-0" />
+      ) : (
+        <Icon className="w-4 h-4 flex-shrink-0" />
       )}
       {isExpanded && <span className="truncate whitespace-nowrap">{item.label}</span>}
     </NavLink>


### PR DESCRIPTION
## Summary
- **Root cause:** `NavRow` in `NavigationRail.tsx` discriminated icon types with `typeof Icon === "function"`. lucide-react icons (e.g. the KMS `Library` icon) are `forwardRef` **objects**, not functions, so they fell through to `<HugeiconsIcon icon={Library}/>`. `HugeiconsIcon` spreads its `icon` prop (`[...icon]`), which throws **`TypeError: currentIcon is not iterable`** during render.
- The KMS item is in **every** user's workspace nav, so the `ErrorBoundary` caught this on every authenticated page — only `/login` (which renders no nav rail) survived. This matches the reported production symptom exactly.
- **Fix:** replace the discriminator with an `isHugeicon` type guard (`Array.isArray` — hugeicons are `IconSvgElement` arrays). Arrays → `HugeiconsIcon`; everything else (function or forwardRef components) → `<Icon/>`. The guard also narrows the component branch for `tsc`.
- **Why CI never caught it:** `NavigationRail.test.tsx` mocked `HugeiconsIcon` to `() => null` based on a wrong diagnosis ("icons resolve to undefined under vitest" — they actually resolve to valid arrays). That mock stubbed out the exact component that crashes. Removed the mock so the real component renders, and added a regression test.

## How it was found
Reproduced locally by rendering `<App/>` in dev TEST_MODE at `/meridian/documents` (the authenticated tree, no backend needed) under Vitest, which surfaced the unminified stack: `currentIcon is not iterable` at `@hugeicons/react` → `NavRow` (`NavigationRail.tsx`). Confirmed `typeof Library === "object"` / `Array.isArray(Library) === false` vs `Array.isArray(<hugeicon>) === true`.

## Test plan
- [x] Added regression test "renders the lucide-iconed KMS item without crashing" — **verified it FAILS with `currentIcon is not iterable` on the unfixed code** and passes with the fix
- [x] `npm run typecheck` — clean
- [x] `npm run lint` (`--max-warnings 0`) — clean
- [x] `npm run build` (default root) — ok
- [x] `VITE_APP_BASENAME=/meridian npm run build` (subpath) — ok
- [x] `npm test` — 83 files, 1315 passed, 1 skipped