### PR TITLE
docs(skills): add SSE auth pitfall, console triage, and swarm-pr-feedback skill

### DIFF
--- a/.agents/skills/issue-tracer/SKILL.md
+++ b/.agents/skills/issue-tracer/SKILL.md
@@ -72,8 +72,32 @@ Read the relevant reference before starting that phase.
 
 ## Phase 0: Setup and Scope Control
 
+### Console error dump intake (when input is a raw browser console paste)
+
+When the user provides a raw console dump instead of a GitHub issue number,
+triage the dump before entering the standard Phase 0 flow. Console dumps
+typically contain 3–4 distinct signal types that must be separated first:
+
+1. **App HTTP errors** — `Failed to load resource: the server responded with a
+   status of NNN` for paths that match the app's API prefix (`/api/`, `/meridian/api/`,
+   etc.). These are the actionable signals.
+2. **Config/info logs** — prefixed with the app name (e.g., `[KnowledgeVault]`).
+   Informational; not errors.
+3. **Browser extension noise** — `A listener indicated an asynchronous response
+   by returning true, but the message channel closed before a response was received`
+   (and `Unchecked runtime.lastError: …`). These originate from `chrome.runtime`
+   content scripts, not app code. Source document label is the page URL
+   (e.g., `chat:1`), not a module path. Confirm by grepping the repo for the
+   exact string — it will not be found. Scope out immediately.
+4. **App JS errors** — uncaught exceptions from module paths. Trace these only
+   if they accompany an HTTP error and are plausibly related.
+
+Document the triage in `01-issue-summary.md` under "Signal separation" before
+any exploration. Only carry the app HTTP errors forward as the investigation
+target. Do not chase extension noise or config logs.
+
 1. Parse the user request into:
-   - issue URL, issue number, or bug description
+   - issue URL, issue number, or bug description (including raw console dump)
    - repo path or GitHub owner/repo if provided
    - requested mode: plan-only, plan-then-approval, or approved implementation
 2. Check repo state:

--- a/.agents/skills/subpath-deployment/SKILL.md
+++ b/.agents/skills/subpath-deployment/SKILL.md
@@ -181,6 +181,35 @@ the streaming UX. See deployment docs for the corresponding NGINX directives.
 
 ---
 
+## SSE streaming auth — DO NOT use EventSource for authenticated endpoints
+
+**Locked decision (N-7):** Any SSE endpoint guarded by `get_current_active_user`
+must be consumed via `fetch`, not the browser `EventSource` API.
+
+**Why:** This app's auth is Bearer-token-in-memory. The access JWT lives in a JS
+module variable (`_jwtAccessToken` in `frontend/src/lib/api.ts`) and is attached
+to requests by an axios interceptor. No `access_token` cookie is ever set
+(only `refresh_token` scoped to `/api/auth/refresh` and the CSRF cookie are
+issued). The browser `EventSource` API cannot set custom headers, so it arrives
+at the backend with no usable credential and always gets `401 Not Authenticated`.
+The browser's native EventSource auto-reconnect then floods the console with 401s.
+
+**The established pattern** is `frontend/src/hooks/useWikiEventStream.ts`:
+- `fetch(url, { method: "GET", headers: { Authorization: "Bearer <token>" }, signal })`
+- Read `response.body.getReader()` and parse SSE lines with a dedicated dispatcher
+  (split on `\n`, strip `data:`, dispatch on `data.type`; do NOT reuse `parseSSEStream`
+  from `api.ts` — it is chat-specific and uses `parsed.type` to gate content forwarding,
+  not `data.type` as the terminal-event key)
+- On `401 token_expired`: call `refreshAccessToken()` and retry
+- On `401 token_invalid` / `user_inactive`: stop; do not reconnect
+- Return `'clean' | 'error' | 'stop'` from the connection function so the outer
+  reconnect loop can reset backoff to the base delay after a clean server close
+
+**Do not reach for EventSource** when adding new SSE endpoints to this codebase,
+regardless of whether the deployment is at root or under a subpath prefix.
+
+---
+
 ## Contract atomicity rule
 
 When changing any env var default across this system, all of these must be

--- a/.agents/skills/swarm-pr-feedback/SKILL.md
+++ b/.agents/skills/swarm-pr-feedback/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: swarm-pr-feedback
+description: Ingest an external PR review bundle (from swarm-pr-review, a human reviewer, or CI), verify each finding against current code, fix confirmed findings, add regression tests, amend the commit, and push. Use when given a structured review output with classified findings to resolve on an existing PR branch.
+disable-model-invocation: true
+---
+
+# /swarm-pr-feedback
+
+Use this skill to resolve an external review bundle on a PR branch. It covers
+the full loop: ingest → verify → fix → test → amend → push → update PR body.
+
+This skill is the counterpart to `swarm-pr-review` (which *generates* a review)
+and `commit-pr` (which opens a fresh PR). Use it when a review already exists
+and you need to act on its findings.
+
+---
+
+## Inputs
+
+The user provides one or more of:
+- A structured review bundle (from `swarm-pr-review` output, a human reviewer,
+  or an AI code review tool) containing findings with severity, file:line
+  references, and classification status.
+- A PR number or branch name.
+- An explicit list of findings to accept, defer, or reject.
+
+---
+
+## Non-negotiable rules
+
+1. Verify every finding against actual current code before fixing. A finding
+   classified as CONFIRMED by the reviewer is still a candidate until you open
+   the file and read the cited lines.
+2. Fix confirmed findings only. Do not broaden scope with adjacent cleanup.
+3. For every fix, add or update a regression test that would have caught the
+   bug. The test must fail without the fix and pass with it, or document why
+   a test is not feasible.
+4. Amend the existing commit (not a new one) so the PR history stays clean,
+   then force-push with `--force-with-lease`. Note: amending is explicitly
+   correct here — PR review follow-up is a well-defined amend use case.
+   This overrides the general convention to prefer new commits.
+5. Update the PR body with an explicit `## Review follow-up` section listing
+   Accepted, Rejected, and Deferred findings with short evidence.
+6. Run all frontend/backend CI gates locally before pushing. A CI-only failure
+   costs a full push → fail → fixup round trip.
+
+---
+
+## Workflow
+
+### Step 1 — Ingest and classify
+
+Parse the review bundle into a structured list. For each finding record:
+- Finding ID (e.g., F-001)
+- Severity (CRITICAL / HIGH / MEDIUM / LOW)
+- Claim (what the reviewer said is wrong)
+- Cited file:line
+- Reviewer classification (CONFIRMED / DISPROVED / UNVERIFIED / PRE_EXISTING)
+- Coverage gap vs correctness bug (coverage gaps may be deferred)
+
+If the bundle lacks explicit classification, treat every finding as UNVERIFIED
+until you verify it yourself.
+
+### Step 2 — Verify findings against current code
+
+Open every cited file and line. Do not trust line numbers from a review bundle —
+the branch may have changed. For each finding:
+
+- **CONFIRMED by reviewer + code matches**: accept for fixing.
+- **CONFIRMED by reviewer but code does not match**: classify as `not reproduced`;
+  document the discrepancy; do not fix.
+- **UNVERIFIED**: open the file, read the logic, make your own judgment.
+- **Coverage gap (not a correctness bug)**: decide whether to add the test now
+  or defer. Prefer adding if the test is simple and the code path is real.
+- **PRE_EXISTING / out of scope**: document; do not fix.
+
+Use the `review-finding-validator` skill for large bundles (>5 findings) or
+when findings are ambiguous or high-risk.
+
+### Step 3 — Plan fixes
+
+For each accepted finding, state:
+- The exact code change (file, function, what changes and why).
+- The regression test to add (what it asserts, why it would catch this).
+- Any behavioral-change test trap: pre-existing tests that assert the old
+  behavior and will fail after the fix. Update them with a comment.
+
+For correctness fixes that touch auth, session handling, payments, migrations,
+or concurrency: treat as high-risk and apply extra scrutiny before fixing.
+
+### Step 4 — Implement
+
+Apply fixes in dependency order (fix foundations before things that depend on
+them). After each fix:
+- Re-read the changed function to confirm the fix is complete and no dead
+  branches were introduced.
+- Confirm the regression test fails without the fix (reason through it if a
+  live failing run isn't practical).
+
+### Step 5 — Validate
+
+Run all applicable gates from the project's CI contract. Use the exact npm
+script and direct-executable forms that CI uses — bare `npx`/`python -m`
+invocations may miss config flags the scripts encode.
+
+**Frontend** (from `frontend/`):
+```
+npm run typecheck         # tsc --noEmit, matches CI
+npm run lint              # eslint with project config, matches CI
+npm test                  # vitest run, matches CI
+npm run build             # production build (for path-critical changes)
+```
+
+**Backend** (from `backend/`):
+```
+ruff check .              # matches CI directly
+pytest <touched modules>  # matches CI directly
+```
+
+Do not push until all gates are green. A single CI-only lint or type error
+costs an extra push → fail → fixup commit.
+
+### Step 6 — Amend and push
+
+```bash
+git add <changed files>               # stage explicitly; never git add -A
+git commit --amend                    # keep PR to one meaningful commit
+                                      # (explicit amend use case — overrides
+                                      #  the general prefer-new-commit rule)
+git push --force-with-lease -u origin <branch>
+```
+
+Never use plain `--force`. If `--force-with-lease` fails, check for concurrent
+pushes before retrying.
+
+### Step 7 — Update PR body
+
+Add or update a `## Review follow-up` section in the PR description:
+
+```md
+## Review follow-up
+
+**F-001 — ACCEPTED** (short title)
+[What was wrong, what changed, what test was added.]
+
+**F-002 — REJECTED** (short title)
+[Why: not reproduced / pre-existing / out of scope + evidence.]
+
+**F-003 — DEFERRED** (short title)
+[Why deferred (coverage gap, separate issue, out of PR scope) + issue link if filed.]
+```
+
+---
+
+## Handling coverage gaps
+
+Coverage gaps (correct code, missing test) are lower priority than correctness
+bugs. Default behavior:
+
+- **Simple, in-scope gap**: add the test now. One assertion is better than zero.
+- **Complex or out-of-scope gap**: file a GitHub issue, add the issue link to
+  the PR body under Deferred, and move on.
+
+Do not add speculative tests for hypothetical inputs the code will never see.
+
+---
+
+## Handling a review with no confirmed findings
+
+If every finding is DISPROVED or PRE_EXISTING:
+- Document all classifications in the PR body.
+- Do not amend the commit (nothing changed).
+- Confirm the PR is ready for merge as-is.
+
+---
+
+## Quick reference — common finding patterns
+
+| Pattern | Usual fix | Regression test shape |
+|---|---|---|
+| Backoff/timer not reset after clean path | Reset variable in the correct branch | Fake timers; verify next attempt fires in base delay |
+| Missing null guard on optional | Add guard; decide error vs silent skip | Pass `null` / `undefined`; assert no crash |
+| Silent event drop (wrong dispatcher) | Route event to correct handler | Emit the event; assert callback fires |
+| Cookie path mismatch under subpath | Use path helper, not hardcoded string | Monkeypatch `app_root_path`; assert cookie path |
+| Token in URL (security) | Move to header or POST body | Assert no token in logged URL |

--- a/.claude/skills/subpath-deployment/SKILL.md
+++ b/.claude/skills/subpath-deployment/SKILL.md
@@ -181,6 +181,35 @@ the streaming UX. See deployment docs for the corresponding NGINX directives.
 
 ---
 
+## SSE streaming auth — DO NOT use EventSource for authenticated endpoints
+
+**Locked decision (N-7):** Any SSE endpoint guarded by `get_current_active_user`
+must be consumed via `fetch`, not the browser `EventSource` API.
+
+**Why:** This app's auth is Bearer-token-in-memory. The access JWT lives in a JS
+module variable (`_jwtAccessToken` in `frontend/src/lib/api.ts`) and is attached
+to requests by an axios interceptor. No `access_token` cookie is ever set
+(only `refresh_token` scoped to `/api/auth/refresh` and the CSRF cookie are
+issued). The browser `EventSource` API cannot set custom headers, so it arrives
+at the backend with no usable credential and always gets `401 Not Authenticated`.
+The browser's native EventSource auto-reconnect then floods the console with 401s.
+
+**The established pattern** is `frontend/src/hooks/useWikiEventStream.ts`:
+- `fetch(url, { method: "GET", headers: { Authorization: "Bearer <token>" }, signal })`
+- Read `response.body.getReader()` and parse SSE lines with a dedicated dispatcher
+  (split on `\n`, strip `data:`, dispatch on `data.type`; do NOT reuse `parseSSEStream`
+  from `api.ts` — it is chat-specific and uses `parsed.type` to gate content forwarding,
+  not `data.type` as the terminal-event key)
+- On `401 token_expired`: call `refreshAccessToken()` and retry
+- On `401 token_invalid` / `user_inactive`: stop; do not reconnect
+- Return `'clean' | 'error' | 'stop'` from the connection function so the outer
+  reconnect loop can reset backoff to the base delay after a clean server close
+
+**Do not reach for EventSource** when adding new SSE endpoints to this codebase,
+regardless of whether the deployment is at root or under a subpath prefix.
+
+---
+
 ## Contract atomicity rule
 
 When changing any env var default across this system, all of these must be

--- a/.claude/skills/swarm-pr-feedback/SKILL.md
+++ b/.claude/skills/swarm-pr-feedback/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: swarm-pr-feedback
+description: Ingest an external PR review bundle (from swarm-pr-review, a human reviewer, or CI), verify each finding against current code, fix confirmed findings, add regression tests, amend the commit, and push. Use when given a structured review output with classified findings to resolve on an existing PR branch.
+disable-model-invocation: true
+---
+
+# /swarm-pr-feedback
+
+Use this skill to resolve an external review bundle on a PR branch. It covers
+the full loop: ingest → verify → fix → test → amend → push → update PR body.
+
+This skill is the counterpart to `swarm-pr-review` (which *generates* a review)
+and `commit-pr` (which opens a fresh PR). Use it when a review already exists
+and you need to act on its findings.
+
+---
+
+## Inputs
+
+The user provides one or more of:
+- A structured review bundle (from `swarm-pr-review` output, a human reviewer,
+  or an AI code review tool) containing findings with severity, file:line
+  references, and classification status.
+- A PR number or branch name.
+- An explicit list of findings to accept, defer, or reject.
+
+---
+
+## Non-negotiable rules
+
+1. Verify every finding against actual current code before fixing. A finding
+   classified as CONFIRMED by the reviewer is still a candidate until you open
+   the file and read the cited lines.
+2. Fix confirmed findings only. Do not broaden scope with adjacent cleanup.
+3. For every fix, add or update a regression test that would have caught the
+   bug. The test must fail without the fix and pass with it, or document why
+   a test is not feasible.
+4. Amend the existing commit (not a new one) so the PR history stays clean,
+   then force-push with `--force-with-lease`. Note: amending is explicitly
+   correct here — PR review follow-up is a well-defined amend use case.
+   This overrides the general convention to prefer new commits.
+5. Update the PR body with an explicit `## Review follow-up` section listing
+   Accepted, Rejected, and Deferred findings with short evidence.
+6. Run all frontend/backend CI gates locally before pushing. A CI-only failure
+   costs a full push → fail → fixup round trip.
+
+---
+
+## Workflow
+
+### Step 1 — Ingest and classify
+
+Parse the review bundle into a structured list. For each finding record:
+- Finding ID (e.g., F-001)
+- Severity (CRITICAL / HIGH / MEDIUM / LOW)
+- Claim (what the reviewer said is wrong)
+- Cited file:line
+- Reviewer classification (CONFIRMED / DISPROVED / UNVERIFIED / PRE_EXISTING)
+- Coverage gap vs correctness bug (coverage gaps may be deferred)
+
+If the bundle lacks explicit classification, treat every finding as UNVERIFIED
+until you verify it yourself.
+
+### Step 2 — Verify findings against current code
+
+Open every cited file and line. Do not trust line numbers from a review bundle —
+the branch may have changed. For each finding:
+
+- **CONFIRMED by reviewer + code matches**: accept for fixing.
+- **CONFIRMED by reviewer but code does not match**: classify as `not reproduced`;
+  document the discrepancy; do not fix.
+- **UNVERIFIED**: open the file, read the logic, make your own judgment.
+- **Coverage gap (not a correctness bug)**: decide whether to add the test now
+  or defer. Prefer adding if the test is simple and the code path is real.
+- **PRE_EXISTING / out of scope**: document; do not fix.
+
+Use the `review-finding-validator` skill for large bundles (>5 findings) or
+when findings are ambiguous or high-risk.
+
+### Step 3 — Plan fixes
+
+For each accepted finding, state:
+- The exact code change (file, function, what changes and why).
+- The regression test to add (what it asserts, why it would catch this).
+- Any behavioral-change test trap: pre-existing tests that assert the old
+  behavior and will fail after the fix. Update them with a comment.
+
+For correctness fixes that touch auth, session handling, payments, migrations,
+or concurrency: treat as high-risk and apply extra scrutiny before fixing.
+
+### Step 4 — Implement
+
+Apply fixes in dependency order (fix foundations before things that depend on
+them). After each fix:
+- Re-read the changed function to confirm the fix is complete and no dead
+  branches were introduced.
+- Confirm the regression test fails without the fix (reason through it if a
+  live failing run isn't practical).
+
+### Step 5 — Validate
+
+Run all applicable gates from the project's CI contract. Use the exact npm
+script and direct-executable forms that CI uses — bare `npx`/`python -m`
+invocations may miss config flags the scripts encode.
+
+**Frontend** (from `frontend/`):
+```
+npm run typecheck         # tsc --noEmit, matches CI
+npm run lint              # eslint with project config, matches CI
+npm test                  # vitest run, matches CI
+npm run build             # production build (for path-critical changes)
+```
+
+**Backend** (from `backend/`):
+```
+ruff check .              # matches CI directly
+pytest <touched modules>  # matches CI directly
+```
+
+Do not push until all gates are green. A single CI-only lint or type error
+costs an extra push → fail → fixup commit.
+
+### Step 6 — Amend and push
+
+```bash
+git add <changed files>               # stage explicitly; never git add -A
+git commit --amend                    # keep PR to one meaningful commit
+                                      # (explicit amend use case — overrides
+                                      #  the general prefer-new-commit rule)
+git push --force-with-lease -u origin <branch>
+```
+
+Never use plain `--force`. If `--force-with-lease` fails, check for concurrent
+pushes before retrying.
+
+### Step 7 — Update PR body
+
+Add or update a `## Review follow-up` section in the PR description:
+
+```md
+## Review follow-up
+
+**F-001 — ACCEPTED** (short title)
+[What was wrong, what changed, what test was added.]
+
+**F-002 — REJECTED** (short title)
+[Why: not reproduced / pre-existing / out of scope + evidence.]
+
+**F-003 — DEFERRED** (short title)
+[Why deferred (coverage gap, separate issue, out of PR scope) + issue link if filed.]
+```
+
+---
+
+## Handling coverage gaps
+
+Coverage gaps (correct code, missing test) are lower priority than correctness
+bugs. Default behavior:
+
+- **Simple, in-scope gap**: add the test now. One assertion is better than zero.
+- **Complex or out-of-scope gap**: file a GitHub issue, add the issue link to
+  the PR body under Deferred, and move on.
+
+Do not add speculative tests for hypothetical inputs the code will never see.
+
+---
+
+## Handling a review with no confirmed findings
+
+If every finding is DISPROVED or PRE_EXISTING:
+- Document all classifications in the PR body.
+- Do not amend the commit (nothing changed).
+- Confirm the PR is ready for merge as-is.
+
+---
+
+## Quick reference — common finding patterns
+
+| Pattern | Usual fix | Regression test shape |
+|---|---|---|
+| Backoff/timer not reset after clean path | Reset variable in the correct branch | Fake timers; verify next attempt fires in base delay |
+| Missing null guard on optional | Add guard; decide error vs silent skip | Pass `null` / `undefined`; assert no crash |
+| Silent event drop (wrong dispatcher) | Route event to correct handler | Emit the event; assert callback fires |
+| Cookie path mismatch under subpath | Use path helper, not hardcoded string | Monkeypatch `app_root_path`; assert cookie path |
+| Token in URL (security) | Move to header or POST body | Assert no token in logged URL |


### PR DESCRIPTION
## Summary
- **`subpath-deployment` skill** — new locked decision N-7: authenticated SSE endpoints must use `fetch` + Bearer header (not `EventSource`, which cannot set auth headers). Documents `useWikiEventStream` as the canonical pattern and explicitly warns against reusing `parseSSEStream` (chat-specific). Directly captures the root cause discovered in PR #142 so future developers don't repeat it.
- **`issue-tracer` skill** — new console error dump intake triage at Phase 0. Documents the repeatable signal-separation pattern for raw browser console paste inputs: app HTTP errors (actionable), `[KnowledgeVault]` config logs (informational), `chrome.runtime` message-channel noise (extension, scope out immediately), app JS errors (trace if related).
- **`swarm-pr-feedback` skill** — new skill (in both `.agents/skills/` and `.claude/skills/`) covering the ingest → verify → fix → test → amend → push loop for external PR review bundles. Counterpart to the existing `swarm-pr-review` skill (which generates reviews); fills a gap where the user invoked it by name and no such skill existed.

## Test plan
- [x] Independent reviewer subagent verified all three changes against actual codebase code (auth.py set_cookie calls, api.ts `_jwtAccessToken`, parseSSEStream dispatch logic, useWikiEventStream return type, CI gate command forms)
- [x] Reviewer caught 4 real issues; all fixed before commit:
  - `parseSSEStream` description corrected (dispatches on `parsed.type`, not `parsed.content`)
  - CI gate commands changed from `npx`/`python -m` forms to `npm run` / direct-executable forms that match CI
  - `git commit --amend` override of CLAUDE.md convention made explicit with a note
- [x] `git diff --check` — no whitespace errors
- [x] Skill files are documentation only — no production code, no test suite to run

## Changes
| File | Change |
|---|---|
| `.agents/skills/subpath-deployment/SKILL.md` | Added locked decision N-7 (SSE auth) |
| `.claude/skills/subpath-deployment/SKILL.md` | Synced |
| `.agents/skills/issue-tracer/SKILL.md` | Added console dump triage at Phase 0 |
| `.agents/skills/swarm-pr-feedback/SKILL.md` | New skill (185 lines) |
| `.claude/skills/swarm-pr-feedback/SKILL.md` | New skill (synced) |