### PR TITLE
perf(chat): cut thinking-mode pre-answer latency + fix restart index-rebuild stall

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -130,6 +130,12 @@ class Settings(BaseSettings):
     """Number of chunks to keep after reranking."""
     initial_retrieval_top_k: int = 20
     """Chunks fetched from vector store BEFORE reranking."""
+    reranker_timeout_seconds: float = 12.0
+    """HTTP timeout (seconds) for the TEI reranker endpoint. On timeout or failure the
+    query degrades to un-reranked vector order, so keep this comfortably above the
+    reranker's p99 latency to avoid quality regressions and circuit-breaker trips
+    (reranking_cb fail_max=3 → a 30s outage for all callers). Lower it only to bound
+    worst-case pre-generation latency. Read once when the HTTP client is first created."""
 
     # ── Hybrid search configuration ─────────────────────────────────────────
     hybrid_search_enabled: bool = True
@@ -163,6 +169,13 @@ class Settings(BaseSettings):
     memory_context_top_k: int = 3
     """Maximum memories actually injected into the prompt after relevance filtering.
     Applied after threshold filtering; further limits prompt context pollution."""
+    memory_dense_max_candidates: int = 1000
+    """Maximum memories scanned by the dense (cosine) memory search on the full,
+    unfiltered path, ordered by recency before similarity ranking. Dense is now the
+    sole path to purely-semantic recall (it is no longer pre-filtered to FTS hits), so
+    this bounds the Python-side cosine work while giving semantic recall a wide pool.
+    For vaults larger than this, the oldest memories fall outside the dense scan; raise
+    it (at O(n) CPU cost) if a vault needs deeper recency reach."""
     rag_trace_in_response: bool = False
     """When True, RAG queries emit a ``trace`` field in the streaming
     done event with detailed retrieval/generation observability. Default
@@ -762,6 +775,16 @@ class Settings(BaseSettings):
         """Validate RRF k parameters are >= 1 (prevents ZeroDivisionError in 1/(k+rank))."""
         if v < 1:
             raise ValueError("RRF k must be >= 1")
+        return v
+
+    @field_validator("reranker_timeout_seconds", mode="after")
+    @classmethod
+    def validate_reranker_timeout_seconds(cls, v: float) -> float:
+        """Validate the reranker HTTP timeout is positive. A value <= 0 makes
+        httpx time out on every reranking request, silently degrading every
+        query to un-reranked vector order — so we fail fast at startup instead."""
+        if v <= 0:
+            raise ValueError("reranker_timeout_seconds must be > 0")
         return v
 
     @field_validator("default_chat_mode", mode="after")

--- a/backend/app/services/memory_store.py
+++ b/backend/app/services/memory_store.py
@@ -495,10 +495,13 @@ class MemoryStore:
                 sql += " ORDER BY id DESC LIMIT ?"
                 params += (limit * 3,)
             else:
-                # Full scan: bounded by default 200 to prevent unbounded memory usage
-                # while still providing good recall for vaults with many memories
+                # Full scan: bounded by ``memory_dense_max_candidates`` (ordered by
+                # recency before similarity ranking) to prevent unbounded Python-side
+                # cosine work while giving semantic recall a wide pool. Dense is now
+                # the sole semantic-recall path (no longer pre-filtered to FTS hits),
+                # so this bound is the recall ceiling for very large vaults.
                 sql += " ORDER BY id DESC LIMIT ?"
-                params += (max(limit * 3, 200),)
+                params += (max(limit * 3, settings.memory_dense_max_candidates),)
             rows = conn.execute(sql, params).fetchall()
         finally:
             self.pool.release_connection(conn)
@@ -549,10 +552,7 @@ class MemoryStore:
         # FTS results — always run.
         fts_records = self._fts_search(query, limit, vault_id)
 
-        # Extract candidate IDs for dense search pre-filtering
-        fts_candidate_ids = [r.id for r in fts_records] if fts_records else None
-
-        # Dense results — best-effort, filtered to FTS candidates only.
+        # Dense results — best-effort, run UNFILTERED across the vault.
         # Synchronously embed when we already have an event loop (this method
         # is invoked via to_thread from async code). Never let dense errors
         # break the call.
@@ -572,7 +572,13 @@ class MemoryStore:
                 )
                 query_emb = None
             if query_emb:
-                dense_records = self._dense_search(query_emb, limit, vault_id, candidate_ids=fts_candidate_ids)
+                # Run dense UNFILTERED (no candidate_ids restriction) so a
+                # semantically-relevant memory sharing no lexical tokens with the
+                # query can still surface. Previously dense was pre-filtered to the
+                # FTS hit set, which made semantic-only recall impossible whenever
+                # FTS returned any candidate. RRF fusion below still rewards
+                # memories found by both arms.
+                dense_records = self._dense_search(query_emb, limit, vault_id)
 
         # No dense path → return FTS as-is.
         if not dense_records:

--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -208,8 +208,12 @@ class RAGEngine:
         else:
             self.prompt_builder = PromptBuilderService()
 
-        # Query transformer instance (lazy-loaded)
-        self._query_transformer: Optional[QueryTransformer] = None
+        # Query transformer instances (lazy-loaded per active LLM client) so the
+        # in-process LRU cache persists across requests. Keyed by id(client),
+        # mirroring ``_retrieval_evaluators`` below. A single shared instance would
+        # be incorrect: QueryTransformer binds to one client and bakes that model's
+        # identity into its cache keys, so Thinking/Instant must not share one.
+        self._query_transformers: Dict[int, QueryTransformer] = {}
 
         # Retrieval evaluator instances (lazy-loaded per active LLM client).
         self._retrieval_evaluators: Dict[int, RetrievalEvaluator] = {}
@@ -229,6 +233,23 @@ class RAGEngine:
     def instant_client(self) -> LLMClient:
         """LLM client for Instant mode. Falls back to ``self.llm_client`` when no explicit override was passed at construction."""
         return self._instant_client_override or self.llm_client
+
+    def _get_query_transformer(self, client: LLMClient) -> QueryTransformer:
+        """Return a per-client cached ``QueryTransformer``.
+
+        Caching per ``id(client)`` lets the transformer's in-process LRU cache
+        persist across requests (a fresh instance per request made it dead
+        weight). Thinking and Instant resolve to different clients and thus
+        different cached transformers, so a cache key — which encodes model
+        identity — never crosses models. When no client overrides are configured,
+        both modes resolve to ``self.llm_client`` (same id → one shared instance).
+        """
+        key = id(client)
+        transformer = self._query_transformers.get(key)
+        if transformer is None:
+            transformer = QueryTransformer(client)
+            self._query_transformers[key] = transformer
+        return transformer
 
     # ------------------------------------------------------------------
     # Live settings properties
@@ -456,7 +477,7 @@ class RAGEngine:
             and is_followup_query(user_input)
         ):
             try:
-                followup_transformer = QueryTransformer(active_client)
+                followup_transformer = self._get_query_transformer(active_client)
                 rewritten = await followup_transformer.rewrite_followup(
                     user_input, chat_history
                 )
@@ -487,7 +508,7 @@ class RAGEngine:
             and not skip_query_transformation
         ):
             try:
-                query_transformer = QueryTransformer(active_client)
+                query_transformer = self._get_query_transformer(active_client)
                 transformed_queries = await query_transformer.transform(
                     retrieval_query
                 )
@@ -563,6 +584,39 @@ class RAGEngine:
         )
 
         effective_alpha = self.hybrid_alpha
+
+        # Launch memory retrieval concurrently with the document pipeline.
+        # Memory search (FTS + dense + RRF over SQLite) is independent of document
+        # retrieval, so we start it here — past the embedding-failure early return
+        # above — and await it just before prompt building. The inner coroutine
+        # swallows all errors (→ []), so awaiting it never raises. This overlaps
+        # memory latency with the expensive vector search + rerank + CRAG phase
+        # instead of paying it sequentially afterward.
+        memory_task: Optional[asyncio.Task] = None
+        if settings.memory_retrieval_enabled:
+
+            async def _memory_retrieve() -> List[Any]:
+                try:
+                    candidates = await asyncio.to_thread(
+                        self.memory_store.search_memories,
+                        user_input,
+                        settings.memory_retrieval_top_k,
+                        vault_id=vault_id,
+                    )
+                    # Apply context_top_k cap so prompt context stays bounded
+                    # even when memory_retrieval_top_k is large.
+                    capped = candidates[:effective_memory_top_k]
+                    logger.info(
+                        "[query] Memory: %d candidates → %d after context_top_k cap",
+                        len(candidates),
+                        len(capped),
+                    )
+                    return capped
+                except Exception as exc:
+                    logger.error("Memory search failed: %s", exc)
+                    return []
+
+            memory_task = asyncio.create_task(_memory_retrieve())
 
         # Wiki + KMS retrieval: run in parallel when both are enabled.
         async def _wiki_retrieve() -> List[Any]:
@@ -811,29 +865,13 @@ class RAGEngine:
                 "fallback": True,
             }
 
-        # Search memories (hybrid: FTS + dense + RRF, with FTS fallback).
-        # Gated by ``memory_retrieval_enabled`` so operators can disable
-        # the path during incident response without redeploying.
-        memories = []
-        if settings.memory_retrieval_enabled:
-            try:
-                candidates = await asyncio.to_thread(
-                    self.memory_store.search_memories,
-                    user_input,
-                    settings.memory_retrieval_top_k,
-                    vault_id=vault_id,
-                )
-                # Apply context_top_k cap after relevance filtering so prompt context
-                # stays bounded even when top_k is large.
-                memories = candidates[:effective_memory_top_k]
-                logger.info(
-                    "[query] Memory: %d candidates → %d after context_top_k cap",
-                    len(candidates),
-                    len(memories),
-                )
-            except Exception as exc:
-                logger.error("Memory search failed: %s", exc)
-                memories = []
+        # Collect memories from the task launched concurrently above (hybrid:
+        # FTS + dense + RRF). The inner coroutine already applied the
+        # context_top_k cap and swallowed errors, so awaiting here never raises
+        # and yields [] on any failure or when memory retrieval is disabled.
+        memories: List[Any] = []
+        if memory_task is not None:
+            memories = await memory_task
 
         # Build messages using prompt builder service
         messages = self.prompt_builder.build_messages(

--- a/backend/app/services/reranking.py
+++ b/backend/app/services/reranking.py
@@ -179,7 +179,9 @@ class RerankingService:
         }
         await asyncio.to_thread(assert_url_safe, self.reranker_url)
         if self._http_client is None:
-            self._http_client = httpx.AsyncClient(timeout=30.0)
+            self._http_client = httpx.AsyncClient(
+                timeout=settings.reranker_timeout_seconds
+            )
         try:
             response = await reranking_cb(self._http_client.post)(url, json=payload)
             response.raise_for_status()

--- a/backend/app/services/retrieval_evaluator.py
+++ b/backend/app/services/retrieval_evaluator.py
@@ -90,7 +90,12 @@ class RetrievalEvaluator:
                 return "CONFIDENT"
 
         except Exception as e:
+            # Fail-open to CONFIDENT, matching the documented contract and every
+            # other fallback in this method (empty chunks / empty / unexpected
+            # response). CONFIDENT is the no-op verdict: it injects no relevance
+            # hint into the prompt and does not trigger distillation synthesis, so
+            # an evaluator outage cannot silently degrade an otherwise-good answer.
             logger.warning(
-                "Retrieval evaluation failed: %s, defaulting to AMBIGUOUS", e
+                "Retrieval evaluation failed: %s, defaulting to CONFIDENT", e
             )
-            return "AMBIGUOUS"
+            return "CONFIDENT"

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -195,8 +195,18 @@ class VectorStore:
                     # and the churn-based rebuild path never triggers.
                     try:
                         existing_indices = await self.table.list_indices()
+                        # Detect the existing ANN index by NAME, consistent with
+                        # every other index check in this class. LanceDB names a
+                        # vector index on the "embedding" column "embedding_idx"
+                        # by default. The previous check matched the literal
+                        # "IVF_PQ" against idx.index_type, but LanceDB reports the
+                        # type as "IvfPq" (mixed-case, no underscore) — so the
+                        # check was ALWAYS False, leaving _last_index_build_row_count
+                        # at 0 and forcing a full IVF_PQ rebuild on the first search
+                        # after every startup (a multi-second to multi-minute stall
+                        # on large tables).
                         has_ivfpq = any(
-                            "IVF_PQ" in str(getattr(idx, "index_type", ""))
+                            getattr(idx, "name", None) == "embedding_idx"
                             for idx in existing_indices
                         )
                         if has_ivfpq:
@@ -799,45 +809,70 @@ class VectorStore:
         # NOTE: Using query_type="vector" to bypass LanceDB's buggy auto-detection
         # which can cause UnboundLocalError when embedding_conf is None
         embedding_np = np.array(embedding, dtype=np.float32)
-        query = await self.table.search(embedding_np, query_type="vector")
-        if bypass_vector_index and hasattr(query, "bypass_vector_index"):
-            query = query.bypass_vector_index()
-        if combined_filter:
-            query = query.where(combined_filter)
-        dense_results = await query.limit(fetch_k).to_list()
 
-        # If hybrid disabled, return dense results only
+        async def _run_dense() -> List[Dict[str, Any]]:
+            query = await self.table.search(embedding_np, query_type="vector")
+            if bypass_vector_index and hasattr(query, "bypass_vector_index"):
+                query = query.bypass_vector_index()
+            if combined_filter:
+                query = query.where(combined_filter)
+            return await query.limit(fetch_k).to_list()
+
+        # If hybrid disabled, return dense results only (skip the FTS round-trip).
         if not hybrid or not query_text:
-            return dense_results
+            return await _run_dense()
 
-        # BM25 FTS hybrid search with fts_status tracking
-        fts_status = 'ok'
-        try:
-            fts_query = await self.table.search(query_text, query_type="fts")
-            fts_filter_parts = [scale_filter]
-            if vault_id:
-                safe_vault_id = _lance_escape(vault_id)
-                fts_filter_parts.append(f"vault_id = '{safe_vault_id}'")
-            if filter_expr:
-                fts_filter_parts.append(f"({filter_expr})")
-            fts_combined_filter = " AND ".join(f"({f})" for f in fts_filter_parts)
-            fts_query = fts_query.where(fts_combined_filter)
-            fts_results = await fts_query.limit(fetch_k).to_list()
-            if fts_results:
-                logger.info(
-                    f"Hybrid search (BM25 FTS) succeeded for scale {scale}: {len(fts_results)} FTS results (alpha={hybrid_alpha})"
+        async def _run_fts():
+            # Returns (results, fts_status). Self-contained try/except so a
+            # concurrent gather degrades to dense-only on FTS failure and the
+            # _fts_exceptions counter is still incremented (preserving the
+            # original sequential semantics) rather than aborting the search.
+            try:
+                fts_query = await self.table.search(query_text, query_type="fts")
+                fts_filter_parts = [scale_filter]
+                if vault_id:
+                    safe_vault_id = _lance_escape(vault_id)
+                    fts_filter_parts.append(f"vault_id = '{safe_vault_id}'")
+                if filter_expr:
+                    fts_filter_parts.append(f"({filter_expr})")
+                fts_combined_filter = " AND ".join(f"({f})" for f in fts_filter_parts)
+                fts_query = fts_query.where(fts_combined_filter)
+                results = await fts_query.limit(fetch_k).to_list()
+                if results:
+                    logger.info(
+                        f"Hybrid search (BM25 FTS) succeeded for scale {scale}: {len(results)} FTS results (alpha={hybrid_alpha})"
+                    )
+                    return results, 'ok'
+                return results, 'empty'
+            except Exception as e:
+                logger.warning(
+                    f"FTS search failed for scale {scale} (falling back to dense-only): {type(e).__name__}: {e}"
                 )
-                fts_status = 'ok'
-            else:
-                fts_status = 'empty'
-        except Exception as e:
+                with _fts_lock:
+                    self._fts_exceptions += 1
+                return [], 'failed'
+
+        # Run the dense (ANN) and BM25 FTS arms concurrently — independent
+        # LanceDB queries feeding an order-insensitive RRF fusion. Use
+        # return_exceptions=True (consistent with the multi-scale path) so a
+        # transient dense failure degrades to FTS-only results instead of
+        # aborting the whole hybrid search; _run_fts already self-handles errors.
+        dense_raw, fts_pair = await asyncio.gather(
+            _run_dense(), _run_fts(), return_exceptions=True
+        )
+        if isinstance(dense_raw, BaseException):
             logger.warning(
-                f"FTS search failed for scale {scale} (falling back to dense-only): {type(e).__name__}: {e}"
+                f"Dense search failed for scale {scale} (using FTS-only): "
+                f"{type(dense_raw).__name__}: {dense_raw}"
             )
-            fts_results = []
-            fts_status = 'failed'
-            with _fts_lock:
-                self._fts_exceptions += 1
+            dense_results = []
+        else:
+            dense_results = dense_raw
+        if isinstance(fts_pair, BaseException):
+            # _run_fts swallows its own errors; this is defense-in-depth only.
+            fts_results, fts_status = [], 'failed'
+        else:
+            fts_results, fts_status = fts_pair
 
         # RRF Fusion for this scale
         k_rrf = 60 if settings.rrf_legacy_mode else settings.hybrid_rrf_k
@@ -1021,11 +1056,9 @@ class VectorStore:
             # NOTE: Using query_type="vector" to bypass LanceDB's buggy auto-detection
             # which can cause UnboundLocalError when embedding_conf is None
             embedding_np = np.array(embedding, dtype=np.float32)
-            query = await self.table.search(embedding_np, query_type="vector")
-            if bypass_vector_index and hasattr(query, "bypass_vector_index"):
-                query = query.bypass_vector_index()
 
-            # Apply vault filter if specified
+            # Apply vault filter if specified (pure string building — cheap, done
+            # once and shared by the dense arm).
             _filter_expr = filter_expr
             if vault_id is not None:
                 safe_vault_id = _lance_escape(vault_id)
@@ -1035,41 +1068,67 @@ class VectorStore:
                 else:
                     _filter_expr = vault_filter
 
-            if _filter_expr:
-                query = query.where(_filter_expr)
+            async def _run_dense() -> List[Dict[str, Any]]:
+                query = await self.table.search(embedding_np, query_type="vector")
+                if bypass_vector_index and hasattr(query, "bypass_vector_index"):
+                    query = query.bypass_vector_index()
+                if _filter_expr:
+                    query = query.where(_filter_expr)
+                return await query.limit(fetch_k).to_list()
 
-            dense_results = await query.limit(fetch_k).to_list()
-
-            # If hybrid disabled, return dense results only
+            # If hybrid disabled, return dense results only (skip FTS round-trip).
             if not hybrid or not query_text:
                 logger.debug(
                     "Dense-only search (hybrid disabled or no query text)"
                 )
-                return dense_results
+                return await _run_dense()
 
-            # BM25 FTS hybrid search with fts_status tracking
-            fts_status = 'ok'
-            try:
-                fts_query = await self.table.search(query_text, query_type="fts")
-                if vault_id:
-                    safe_vault_id = _lance_escape(vault_id)
-                    fts_query = fts_query.where(f"vault_id = '{safe_vault_id}'")
-                if filter_expr:
-                    fts_query = fts_query.where(filter_expr)
-                fts_results = await fts_query.limit(fetch_k).to_list()
-                if fts_results:
-                    logger.info(
-                        f"Hybrid search (BM25 FTS) succeeded: {len(fts_results)} FTS results (alpha={hybrid_alpha})"
-                    )
-                    fts_status = 'ok'
-                else:
-                    fts_status = 'empty'
-            except Exception as e:
-                logger.warning(f"FTS search failed (falling back to dense-only): {type(e).__name__}: {e}")
-                fts_results = []
-                fts_status = 'failed'
-                with _fts_lock:
-                    self._fts_exceptions += 1
+            async def _run_fts():
+                # Returns (results, fts_status). Self-contained try/except so a
+                # concurrent gather degrades to dense-only on FTS failure and the
+                # _fts_exceptions counter is still incremented (preserving the
+                # original sequential semantics) rather than aborting the search.
+                try:
+                    fts_query = await self.table.search(query_text, query_type="fts")
+                    if vault_id:
+                        safe_vault_id = _lance_escape(vault_id)
+                        fts_query = fts_query.where(f"vault_id = '{safe_vault_id}'")
+                    if filter_expr:
+                        fts_query = fts_query.where(filter_expr)
+                    results = await fts_query.limit(fetch_k).to_list()
+                    if results:
+                        logger.info(
+                            f"Hybrid search (BM25 FTS) succeeded: {len(results)} FTS results (alpha={hybrid_alpha})"
+                        )
+                        return results, 'ok'
+                    return results, 'empty'
+                except Exception as e:
+                    logger.warning(f"FTS search failed (falling back to dense-only): {type(e).__name__}: {e}")
+                    with _fts_lock:
+                        self._fts_exceptions += 1
+                    return [], 'failed'
+
+            # Run the dense (ANN) and BM25 FTS arms concurrently — independent
+            # LanceDB queries feeding an order-insensitive RRF fusion. Use
+            # return_exceptions=True (consistent with the multi-scale path) so a
+            # transient dense failure degrades to FTS-only results instead of
+            # aborting the whole hybrid search; _run_fts already self-handles errors.
+            dense_raw, fts_pair = await asyncio.gather(
+                _run_dense(), _run_fts(), return_exceptions=True
+            )
+            if isinstance(dense_raw, BaseException):
+                logger.warning(
+                    f"Dense search failed (using FTS-only): "
+                    f"{type(dense_raw).__name__}: {dense_raw}"
+                )
+                dense_results = []
+            else:
+                dense_results = dense_raw
+            if isinstance(fts_pair, BaseException):
+                # _run_fts swallows its own errors; this is defense-in-depth only.
+                fts_results, fts_status = [], 'failed'
+            else:
+                fts_results, fts_status = fts_pair
 
             # RRF Fusion using shared utility
             k_rrf = 60 if settings.rrf_legacy_mode else settings.hybrid_rrf_k

--- a/backend/tests/test_config_alignment.py
+++ b/backend/tests/test_config_alignment.py
@@ -309,6 +309,20 @@ class TestRefactoredValidators:
                 Settings()
             assert "embedding_batch_size must be >= 1" in str(exc_info.value)
 
+    def test_reranker_timeout_seconds_valid(self):
+        """reranker_timeout_seconds should accept positive values."""
+        with patch.dict("os.environ", {"RERANKER_TIMEOUT_SECONDS": "5"}):
+            settings = Settings()
+            assert settings.reranker_timeout_seconds == 5.0
+
+    def test_reranker_timeout_seconds_rejects_zero(self):
+        """reranker_timeout_seconds <= 0 makes httpx time out on every rerank
+        call, silently degrading every query to un-reranked order — reject it."""
+        with patch.dict("os.environ", {"RERANKER_TIMEOUT_SECONDS": "0"}):
+            with pytest.raises(ValidationError) as exc_info:
+                Settings()
+            assert "reranker_timeout_seconds must be > 0" in str(exc_info.value)
+
     def test_document_parsing_strategy_valid_values(self):
         """document_parsing_strategy should accept 'fast', 'hi_res', 'auto'."""
         for strategy in ["fast", "hi_res", "auto"]:

--- a/backend/tests/test_fts_status_tracking.py
+++ b/backend/tests/test_fts_status_tracking.py
@@ -340,6 +340,43 @@ class TestFTSStatusTrackingSingleScale(unittest.IsolatedAsyncioTestCase):
     # ── test_fts_exceptions_not_incremented_on_empty (single-scale) ────────────
 
     @pytest.mark.asyncio
+    async def test_dense_failure_degrades_to_fts_single_scale(self):
+        """If the dense (vector) arm raises, the concurrent dense+FTS gather
+        degrades to FTS-only results instead of aborting the whole hybrid
+        search (gather uses return_exceptions=True)."""
+        fts_results = [{"id": "fts_1", "text": "fts result"}]
+
+        # Dense builder whose .to_list() raises (transient LanceDB failure).
+        dense_builder = MagicMock()
+        dense_builder.where.return_value = dense_builder
+        dense_builder.limit.return_value = dense_builder
+        dense_builder.to_list = AsyncMock(side_effect=RuntimeError("dense boom"))
+
+        fts_builder = _make_fts_mock_builder(fts_results)
+
+        async def search_side_effect(query, query_type=None, **kwargs):
+            if query_type == "vector":
+                return dense_builder
+            elif query_type == "fts":
+                return fts_builder
+            return MagicMock()
+
+        self.store.table.search = AsyncMock(side_effect=search_side_effect)
+
+        with patch("app.services.vector_store.settings"):
+            results = await self.store._search_single_scale(
+                embedding=[0.1] * 384,
+                scale="default",
+                fetch_k=10,
+                query_text="test query",
+                hybrid=True,
+            )
+
+        # FTS results survived the dense failure rather than the search crashing.
+        self.assertGreater(len(results), 0)
+        self.assertIn("fts_1", [r.get("id") for r in results])
+
+    @pytest.mark.asyncio
     async def test_fts_exceptions_not_incremented_on_empty_single_scale(self):
         """FTS empty (not exception) → _fts_exceptions stays 0 in _search_single_scale."""
         dense_builder = _make_dense_mock_builder(self.dense_results)

--- a/backend/tests/test_memory_hybrid_retrieval.py
+++ b/backend/tests/test_memory_hybrid_retrieval.py
@@ -132,6 +132,40 @@ class TestHybridSemanticPath(unittest.TestCase):
         finally:
             os.remove(path)
 
+    def test_semantic_only_memory_surfaces_even_when_fts_has_other_hits(self):
+        """Regression: dense search must run UNFILTERED, not restricted to the
+        FTS candidate set.
+
+        Previously, when FTS returned any lexical hit, dense search was
+        pre-filtered to exactly those ids — so a purely-semantic memory (no
+        shared tokens with the query) became unreachable whenever FTS matched
+        something else. Here memory A lexically matches the query token "brief",
+        while memory B shares no tokens but is a strong dense match; B must still
+        appear in the fused results.
+        """
+        embedder = _StubEmbedder()
+        store, path = _make_store(embedding_service=embedder)
+        try:
+            # A: lexical FTS hit for the single-token query "brief" — so the FTS
+            # candidate set is non-empty (the condition under which the old code
+            # restricted dense to those ids).
+            store.add_memory("brief notes draft", category="task", vault_id=1)
+            # B: semantic-only — shares NO token with "brief", but its concepts
+            # ("concise"→brief dim) make it a strong dense match.
+            store.add_memory("concise summary writing", category="pref", vault_id=1)
+
+            # Query "brief" (single token): FTS matches only A, while dense (now
+            # unfiltered) also finds B. On the old FTS-gated code, dense was
+            # restricted to [A] and B was dropped — this assertion would fail.
+            results = store.search_memories("brief", limit=5, vault_id=1)
+            contents = [r.content for r in results]
+            self.assertTrue(
+                any("summary writing" in c for c in contents),
+                f"semantic-only memory missing (dense was likely FTS-gated): {contents}",
+            )
+        finally:
+            os.remove(path)
+
     def test_score_type_is_rrf_when_both_paths_match(self):
         embedder = _StubEmbedder()
         store, path = _make_store(embedding_service=embedder)

--- a/backend/tests/test_reranking_contract.py
+++ b/backend/tests/test_reranking_contract.py
@@ -295,6 +295,41 @@ async def test_rerank_endpoint_raw_logits_produce_sigmoid_scores(service_with_ur
 
 
 # ---------------------------------------------------------------------------
+# Timeout configuration: TEI client honors settings.reranker_timeout_seconds
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_rerank_endpoint_uses_configured_timeout(service_with_url, sample_chunks, monkeypatch):
+    """The lazily-created TEI HTTP client uses settings.reranker_timeout_seconds
+    rather than a hardcoded value, so operators can bound worst-case latency."""
+    import app.services.reranking as reranking_module
+
+    monkeypatch.setattr(service_with_url, "_http_client", None)
+    monkeypatch.setattr(reranking_module.settings, "reranker_timeout_seconds", 7.5)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [{"index": 0, "score": 1.0}]
+    mock_response.raise_for_status = MagicMock()
+
+    captured = {}
+
+    def fake_client_ctor(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        inst = MagicMock()
+        inst.post = AsyncMock(return_value=mock_response)
+        return inst
+
+    # Patch the SSRF/DNS guard so the test does not depend on resolving the
+    # fake endpoint host — we only care that the lazily-created client picks up
+    # the configured timeout.
+    with patch("app.services.reranking.assert_url_safe", return_value=None), \
+            patch("httpx.AsyncClient", side_effect=fake_client_ctor):
+        await service_with_url.rerank("test query", sample_chunks)
+
+    assert captured["timeout"] == 7.5
+
+
+# ---------------------------------------------------------------------------
 # 7. Unconditional sigmoid normalization tests
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_retrieval_evaluator_failopen.py
+++ b/backend/tests/test_retrieval_evaluator_failopen.py
@@ -1,0 +1,55 @@
+"""Fail-open contract for RetrievalEvaluator.evaluate().
+
+CRAG self-evaluation must NOT degrade an answer when the evaluator itself
+fails. The documented contract (and every in-function fallback) is to return
+``CONFIDENT`` — the no-op verdict that injects no relevance hint and does not
+trigger distillation synthesis. A regression had the exception path returning
+``AMBIGUOUS``, which silently altered prompt framing on evaluator outages.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.retrieval_evaluator import RetrievalEvaluator
+
+
+class TestRetrievalEvaluatorFailOpen(unittest.IsolatedAsyncioTestCase):
+    @pytest.mark.asyncio
+    async def test_exception_fails_open_to_confident(self):
+        """LLM error during evaluation → CONFIDENT (not AMBIGUOUS)."""
+        client = MagicMock()
+        client.chat_completion = AsyncMock(side_effect=RuntimeError("LLM down"))
+        evaluator = RetrievalEvaluator(client)
+
+        verdict = await evaluator.evaluate("q", [{"text": "a relevant chunk"}])
+
+        self.assertEqual(verdict, "CONFIDENT")
+
+    @pytest.mark.asyncio
+    async def test_empty_response_fails_open_to_confident(self):
+        """Empty model response → CONFIDENT, no exception."""
+        client = MagicMock()
+        client.chat_completion = AsyncMock(return_value="")
+        evaluator = RetrievalEvaluator(client)
+
+        verdict = await evaluator.evaluate("q", [{"text": "chunk"}])
+
+        self.assertEqual(verdict, "CONFIDENT")
+
+    @pytest.mark.asyncio
+    async def test_no_chunks_returns_confident_without_calling_llm(self):
+        """No chunks to evaluate → CONFIDENT, LLM not invoked."""
+        client = MagicMock()
+        client.chat_completion = AsyncMock()
+        evaluator = RetrievalEvaluator(client)
+
+        verdict = await evaluator.evaluate("q", [])
+
+        self.assertEqual(verdict, "CONFIDENT")
+        client.chat_completion.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_vector_index_seed_baseline.py
+++ b/backend/tests/test_vector_index_seed_baseline.py
@@ -1,0 +1,96 @@
+"""Regression: startup seeding of the IVF_PQ row-count baseline.
+
+When ``_init_table_unlocked`` opens an existing ``chunks`` table, it must seed
+``_last_index_build_row_count`` from the existing vector index so the first
+search after startup does NOT trigger a full IVF_PQ rebuild (a multi-second to
+multi-minute stall on large tables).
+
+The detection must match how LanceDB actually reports an existing vector index:
+by NAME (``"embedding_idx"``), consistent with every other index check in
+``VectorStore``. A prior bug matched the literal ``"IVF_PQ"`` against
+``idx.index_type`` — but LanceDB reports the type as ``"IvfPq"`` (mixed-case, no
+underscore; verified against lancedb at runtime), so ``"IVF_PQ" in "IvfPq"`` was
+always False and seeding never fired. These tests pin the real ``index_type``
+value so the regression cannot return.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.vector_store import VectorStore
+
+
+def _existing_index(name: str, index_type: str):
+    idx = MagicMock()
+    idx.name = name
+    idx.index_type = index_type
+    return idx
+
+
+def _make_store_opening_existing(indices, row_count):
+    """A VectorStore wired to open an existing 'chunks' table whose
+    list_indices() returns ``indices`` and count_rows() returns ``row_count``."""
+    store = VectorStore(db_path=Path("/tmp/test_lancedb"))
+    store._index_mutation_generation = 0
+    store._last_index_build_row_count = 0
+    store._last_index_build_generation = 0
+
+    mock_table = MagicMock()
+    mock_table.list_indices = AsyncMock(return_value=indices)
+    mock_table.count_rows = AsyncMock(return_value=row_count)
+    mock_table.create_index = AsyncMock()
+
+    mock_db = MagicMock()
+    mock_db.table_names = AsyncMock(return_value=["chunks"])
+    mock_db.open_table = AsyncMock(return_value=mock_table)
+    store.db = mock_db
+    return store
+
+
+class TestVectorIndexSeedBaseline(unittest.IsolatedAsyncioTestCase):
+    async def test_seeds_row_count_from_existing_embedding_idx(self):
+        """Existing vector index (name='embedding_idx', index_type='IvfPq') →
+        baseline seeded to the current row count so first search won't rebuild."""
+        # index_type is the REAL LanceDB value "IvfPq" — the old "IVF_PQ"
+        # substring check would miss this and leave the baseline at 0.
+        store = _make_store_opening_existing(
+            indices=[_existing_index("embedding_idx", "IvfPq")],
+            row_count=40340,
+        )
+
+        with patch("app.services.vector_store.pa") as mock_pa:
+            mock_pa.schema.return_value = MagicMock()
+            with patch("app.services.vector_store.settings") as mock_settings:
+                mock_settings.vector_metric = "cosine"
+                mock_settings.write_lock_timeout_seconds = 5.0
+                with patch("app.services.vector_store.FTS") as mock_fts:
+                    mock_fts.return_value = MagicMock()
+                    await store.init_table(embedding_dim=384)
+
+        self.assertEqual(store._last_index_build_row_count, 40340)
+        self.assertEqual(
+            store._last_index_build_generation, store._index_mutation_generation
+        )
+
+    async def test_does_not_seed_when_only_fts_index_present(self):
+        """No vector index → nothing to seed; baseline stays 0."""
+        store = _make_store_opening_existing(
+            indices=[_existing_index("fts_text", "FTS")],
+            row_count=40340,
+        )
+
+        with patch("app.services.vector_store.pa") as mock_pa:
+            mock_pa.schema.return_value = MagicMock()
+            with patch("app.services.vector_store.settings") as mock_settings:
+                mock_settings.vector_metric = "cosine"
+                mock_settings.write_lock_timeout_seconds = 5.0
+                with patch("app.services.vector_store.FTS") as mock_fts:
+                    mock_fts.return_value = MagicMock()
+                    await store.init_table(embedding_dim=384)
+
+        self.assertEqual(store._last_index_build_row_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reduces end-user latency on the **thinking-mode** RAG chat path without sacrificing retrieval quality, and fixes two correctness/recall bugs found while tracing it. Backend-only; validated against `master` (this branch was cut from `master` and the analysis confirmed `master` is the canonical state).

## Highest-impact: restart index-rebuild stall (the big one)

On startup, `_init_table_unlocked` seeds the IVF_PQ row-count baseline so the first search after a restart doesn't rebuild the whole index. The detection used `"IVF_PQ" in str(idx.index_type)`, but **LanceDB reports the type as `"IvfPq"`** (mixed-case, no underscore — verified at runtime against the installed lancedb), so the check was *always False*. `_last_index_build_row_count` stayed `0`, and the **first search after every restart rebuilt the entire IVF_PQ index** (observed **~113s on 40,340 rows** in production docker logs), then went fast.

Fix: detect the existing index **by name** (`idx.name == "embedding_idx"`), consistent with every other index check in the file. Pinned by a new regression test that encodes the real `index_type="IvfPq"` value.

## Per-query latency (quality-neutral)

- **Parallel dense + FTS** within each search arm (`asyncio.gather`), each branch keeping its own try/except so an FTS failure still degrades to dense-only and increments the exception counter. RRF fusion is order-insensitive → identical results.
- **Concurrent memory retrieval** — launched alongside the document pipeline and awaited just before prompt building, overlapping it with vector search + rerank + CRAG instead of running sequentially after.
- **Per-client `QueryTransformer` cache** (keyed by `id(active_client)`, mirroring the retrieval-evaluator cache) so the in-process LRU persists across requests. (A single shared instance would route transforms to the wrong model.)
- **Configurable reranker timeout** (`reranker_timeout_seconds`, default **12s**) replacing the hardcoded 30s. Conservative default avoids tripping the reranker circuit breaker (`fail_max=3`) into a 30s outage.

## Correctness / recall fixes

- **Memory hybrid recall:** dense search no longer pre-filtered to the FTS candidate set, so a semantically-relevant memory with no lexical overlap can surface (previously unreachable whenever FTS returned any hit). Dense scan bound is now the configurable `memory_dense_max_candidates` (default 1000).
- **CRAG evaluator fail-open:** returns `CONFIDENT` on exception (matching its docstring and every other fallback) instead of `AMBIGUOUS`, which had silently altered prompt framing on evaluator outages.

## Tests

- `test_vector_index_seed_baseline.py` — pins real `index_type="IvfPq"`; fails on old code, passes on fix.
- `test_retrieval_evaluator_failopen.py` — CONFIDENT fail-open contract.
- Memory regression (FTS hit present **and** semantic-only memory still surfaces) + reranker configured-timeout test.

## Validation

- `ruff check .` ✓ · `scripts/check_config_contract.py` ✓ · `scripts/check_pr_scope_drift.py` ✓
- New tests pass on the local interpreter; the index-seed mechanism was verified by introspecting the installed lancedb directly.
- **Test caveat:** the local interpreter is Python 3.14 (CI pins 3.11). Some pre-existing backend tests show false failures locally (`wait_for`+MagicMock, Windows `os.remove` file-lock, fake-host DNS); these are **identical on clean `master`** — this branch introduces no new failures. CI (3.11/Linux) is the authoritative gate.

## Deliberately out of scope

Rerouting thinking-mode step-back/CRAG to the faster instant client. `master`'s own design (PR #148) cuts latency via **instant-only** skip flags while explicitly keeping thinking mode at full quality. Rerouting the thinking path needs eval-harness evidence and a maintainer policy call, so it's excluded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-up

External LOW-severity bundle (7 findings). Each verified against current code.

**F-001 — ACCEPTED** (reranker timeout config validation)
`reranker_timeout_seconds <= 0` makes httpx time out on every rerank call, silently degrading all queries to un-reranked order. Added a `@field_validator` (`> 0`) so it fails fast at startup. The 4 pre-existing timeout fields lack validators, but this new field is in PR scope and the validator is defensive + cheap; broadening to the others is out of scope. Test: `test_config_alignment.py::test_reranker_timeout_seconds_{valid,rejects_zero}`.

**F-002 — ACCEPTED** (dense+FTS gather graceful degradation)
The new single-scale `asyncio.gather(_run_dense(), _run_fts())` lacked `return_exceptions=True`, so a transient dense failure aborted the whole hybrid search (caught upstream → fallback, no partial results). Both single-scale paths now use `return_exceptions=True` with coercion, mirroring the multi-scale path, so a dense failure degrades to FTS-only results (symmetric with the existing FTS→dense fallback). The non-hybrid dense-only path keeps its original error propagation. Test: `test_fts_status_tracking.py::...::test_dense_failure_degrades_to_fts_single_scale`.

**F-003 — ACCEPTED AS DOCUMENTED** (reranker timeout not hot-reloadable)
The httpx client is created once and cached; the timeout is read at creation. This matches the trade-off already stated in the config docstring ("Read once when the HTTP client is first created."). No change — restart picks up new values, consistent with how the cached client already works.

**F-004 — ACCEPTED AS DESIGNED** (dense scan bound 200→1000)
Intentional: dense is now the sole semantic-recall path (no longer FTS-gated), so it needs a wider pool. The bound is the configurable `memory_dense_max_candidates` (default 1000); deployments can tune it. ~1000 Python cosine ops is negligible. Operators with very large vaults can lower it.

**F-005 — ACCEPTED AS DESIGNED** (memory dense recency bias)
`ORDER BY id DESC LIMIT N` biases the dense scan toward recent memories only when a vault exceeds `memory_dense_max_candidates` (no bias below it). Already documented in the `memory_dense_max_candidates` docstring ("the oldest memories fall outside the dense scan; raise it … if a vault needs deeper recency reach").

**F-006 — PRE_EXISTING** (custom-named index detection)
Name-based detection (`idx.name == "embedding_idx"`) misses vector indexes created under a custom name. This is pre-existing architecture (3 sites); the PR makes detection *consistent* (name-based everywhere) and fixes the genuinely-broken type-string check. Custom-name support is out of scope.

**F-007 — PRE_EXISTING (mitigated by this PR)** (write-lock on hot path)
Pre-PR, the broken IVF_PQ detection left the baseline at 0, so the freshness probe always returned True and `search()` took the write lock on every query. The index-seed fix in this PR makes the probe return False on the hot path, so the lock is now taken only for real index maintenance. No further action.

**Deferred coverage gap:** the memory dense path for vaults exceeding `memory_dense_max_candidates` (the recency-bias edge) is untested — it exercises accepted-as-designed behavior, not a fix, so deferred rather than adding a brittle large-vault test.
