### PR TITLE
fix(auth): resolve 403 errors in user creation and management lifecycle

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import secrets
 import sqlite3
 from collections.abc import Callable
@@ -19,6 +20,8 @@ from app.services.auth_service import (
     TokenInvalidError,
     decode_access_token,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class UserRole(IntEnum):
@@ -268,7 +271,7 @@ async def get_current_active_user(
 
     # Enforce must_change_password: flagged users can only access exempt routes
     if user.get("must_change_password"):
-        exempt_paths = {"/auth/change-password", "/auth/login"}
+        exempt_paths = {"/auth/change-password", "/auth/login", "/api/auth/change-password", "/api/auth/login"}
         # Normalize path to prevent bypass via trailing slash variants
         normalized_path = request.url.path.rstrip("/") or "/"
         if normalized_path not in exempt_paths:
@@ -589,3 +592,33 @@ async def get_user_primary_org(user_id: int, db: sqlite3.Connection) -> int | No
     if len(orgs) == 1:
         return orgs[0]
     raise MultipleOrgError(f"User {user_id} belongs to multiple organizations: {orgs}")
+
+
+def assign_user_to_default_vault(db: sqlite3.Connection, user_id: int) -> None:
+    """
+    Assign a user to the Default vault with read permission.
+
+    Idempotent — uses INSERT OR IGNORE. Creates the Default vault if it
+    doesn't exist. Gracefully handles pre-migration state when the vaults
+    or vault_members tables don't exist yet.
+    """
+    try:
+        cursor = db.execute("SELECT id FROM vaults WHERE name = ?", ("Default",))
+        row = cursor.fetchone()
+        if row:
+            vault_id = row[0]
+        else:
+            cursor = db.execute(
+                "INSERT OR IGNORE INTO vaults (name, description) VALUES (?, ?)",
+                ("Default", "Default vault for all users"),
+            )
+            vault_id = cursor.lastrowid or db.execute(
+                "SELECT id FROM vaults WHERE name = ?", ("Default",)
+            ).fetchone()[0]
+        db.execute(
+            "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission) VALUES (?, ?, ?)",
+            (vault_id, user_id, "read"),
+        )
+    except sqlite3.OperationalError:
+        # vaults or vault_members table doesn't exist yet (pre-migration)
+        logger.warning("Could not assign user %d to Default vault (tables may not exist yet)", user_id)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -10,7 +10,7 @@ from typing import Optional
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 
-from app.api.deps import get_current_active_user, get_db
+from app.api.deps import assign_user_to_default_vault, get_current_active_user, get_db
 from app.limiter import limiter
 from app.security import csrf_protect, get_csrf_manager, issue_csrf_token
 from app.services.auth_service import (
@@ -164,7 +164,7 @@ async def register(
     db=Depends(get_db),
     _csrf_token: str = Depends(csrf_protect),
 ):
-    """Register a new user. First user becomes superadmin."""
+    """Register a new user. First user becomes superadmin. Issues CSRF token on success."""
     if not body.username or len(body.username) < 3:
         raise HTTPException(
             status_code=400, detail="Username must be at least 3 characters"
@@ -183,23 +183,21 @@ async def register(
     if existing:
         raise HTTPException(status_code=409, detail="Username already exists")
 
-    # First user becomes superadmin
-    user_count = await asyncio.to_thread(
-        lambda: db.execute("SELECT COUNT(*) FROM users").fetchone()[0]
-    )
-    role = "superadmin" if user_count == 0 else "member"
-
     hashed_pw = await async_hash_password(body.password)
 
     try:
         def _register_db():
             try:
+                # Atomic: count read and insert are in the same transaction
+                user_count = db.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+                role = "superadmin" if user_count == 0 else "member"
                 user_id = db.execute(
                     "INSERT INTO users (username, hashed_password, full_name, role, is_active) VALUES (?, ?, ?, ?, 1)",
                     (body.username, hashed_pw, body.full_name, role),
                 ).lastrowid
+                assign_user_to_default_vault(db, user_id)
                 db.commit()
-                return user_id
+                return user_id, role
             except Exception:
                 try:
                     db.rollback()
@@ -207,7 +205,7 @@ async def register(
                     pass
                 raise
 
-        user_id = await asyncio.to_thread(_register_db)
+        user_id, role = await asyncio.to_thread(_register_db)
     except Exception:
         logger.error("Failed to create user with default assignments", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again later.")
@@ -251,6 +249,10 @@ async def register(
         max_age=REFRESH_TOKEN_MAX_AGE_DAYS * 24 * 60 * 60,
         path=refresh_cookie_path(),
     )
+
+    # Issue CSRF token matching login/refresh pattern
+    csrf_manager = get_csrf_manager(request)
+    issue_csrf_token(response, csrf_manager)
 
     return {
         "id": user_id,
@@ -508,13 +510,14 @@ async def setup_status(db=Depends(get_db)):
 
 @router.get("/me")
 async def get_me(user: dict = Depends(get_current_active_user)):
-    """Get current user profile."""
+    """Get current user profile. Includes must_change_password flag."""
     return {
         "id": user["id"],
         "username": user["username"],
         "full_name": user.get("full_name", ""),
         "role": user["role"],
         "is_active": user["is_active"],
+        "must_change_password": user.get("must_change_password", False),
     }
 
 
@@ -589,7 +592,7 @@ async def change_password(
     _csrf_token: str = Depends(csrf_protect),
 ):
     """Change current user's password. Requires current password verification.
-    Revokes all existing sessions and returns new tokens.
+    Revokes all existing sessions, clears must_change_password flag, and returns new tokens.
     """
     user_id = user["id"]
     username = user["username"]
@@ -630,6 +633,10 @@ async def change_password(
                 )
                 db.execute(
                     "DELETE FROM user_sessions WHERE user_id = ?",
+                    (user_id,),
+                )
+                db.execute(
+                    "UPDATE users SET must_change_password = 0 WHERE id = ?",
                     (user_id,),
                 )
                 db.commit()

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -9,10 +9,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from app.api.deps import (
+    assign_user_to_default_vault,
     get_db,
     require_admin_role,
     require_role,
 )
+from app.api.routes.auth import async_hash_password
 from app.config import settings
 from app.models.database import get_pool
 from app.security import csrf_protect
@@ -115,7 +117,7 @@ async def create_user(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     # Hash the password
-    hashed_password = hash_password(body.password)
+    hashed_password = await async_hash_password(body.password)
 
     pool = get_pool(str(settings.sqlite_path))
     conn = pool.get_connection()
@@ -140,6 +142,8 @@ async def create_user(
         row = await asyncio.to_thread(cursor.fetchone)
         if row is None:
             raise RuntimeError("Failed to retrieve created user")
+
+        assign_user_to_default_vault(conn, user_id)
 
         await asyncio.to_thread(conn.commit)
 
@@ -279,6 +283,18 @@ async def update_user(
         # Prevent changing own role
         if user_id == user.get("id"):
             raise HTTPException(status_code=400, detail="Cannot change your own role")
+
+        # Only superadmin can assign superadmin role
+        if body.role == "superadmin" and user.get("role") != "superadmin":
+            raise HTTPException(
+                status_code=403,
+                detail="Only superadmin can assign superadmin role",
+            )
+        if target_row[3] == "superadmin" and user.get("role") != "superadmin":
+            raise HTTPException(
+                status_code=403,
+                detail="Only superadmin can change role of superadmin users",
+            )
 
         valid_roles = ["superadmin", "admin", "member", "viewer"]
         if body.role not in valid_roles:

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -850,6 +850,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_page_hierarchy_and_versioning(sqlite_path)
     migrate_add_wiki_supporting_tables(sqlite_path)
     migrate_add_wiki_claims_normalized_text(sqlite_path)
+    migrate_assign_orphan_users_to_default_vault(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
     # Wrapped in IntegrityError handler: existing databases may have duplicate
@@ -2739,3 +2740,43 @@ def transaction_context(conn: sqlite3.Connection):
     except Exception:
         conn.rollback()
         raise
+
+
+def migrate_assign_orphan_users_to_default_vault(sqlite_path: str) -> None:
+    """
+    Migration: Assign existing users without vault access to the Default vault.
+
+    Idempotent — uses INSERT OR IGNORE and a NOT IN subquery to only insert
+    rows for users who have zero vault_members entries.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+
+        # Find the Default vault ID
+        cursor = conn.execute("SELECT id FROM vaults WHERE name = ?", ("Default",))
+        row = cursor.fetchone()
+        if not row:
+            # Create Default vault if it doesn't exist
+            cursor = conn.execute(
+                "INSERT INTO vaults (name, description) VALUES (?, ?)",
+                ("Default", "Default vault for all users"),
+            )
+            default_vault_id = cursor.lastrowid
+        else:
+            default_vault_id = row[0]
+
+        # Assign all users without any vault_members to Default vault
+        conn.execute(
+            """INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission)
+               SELECT ?, id, 'read' FROM users
+               WHERE id NOT IN (SELECT DISTINCT user_id FROM vault_members)""",
+            (default_vault_id,),
+        )
+        conn.commit()
+        logger.info("Orphan users assigned to Default vault")
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()

--- a/backend/tests/test_change_password_must_change_flag.py
+++ b/backend/tests/test_change_password_must_change_flag.py
@@ -1,0 +1,271 @@
+"""Tests for must_change_password flag clearing on password change.
+
+Tests cover:
+- User with must_change_password=1 changes password → flag is cleared to 0
+- User with must_change_password=0 changes password → flag stays 0 (no-op)
+- Existing change-password tests still pass (regression)
+
+Uses FastAPI TestClient with dependency overrides for isolated testing.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies
+try:
+    import lancedb
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition
+except ImportError:
+    import types
+
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType(
+        "unstructured.documents.elements"
+    )
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _unstructured
+    sys.modules["unstructured.partition"] = _unstructured.partition
+    sys.modules["unstructured.partition.auto"] = _unstructured.partition.auto
+    sys.modules["unstructured.chunking"] = _unstructured.chunking
+    sys.modules["unstructured.chunking.title"] = _unstructured.chunking.title
+    sys.modules["unstructured.documents"] = _unstructured.documents
+    sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.models.database import SQLiteConnectionPool, init_db, run_migrations
+
+
+class TestMustChangePasswordFlagClearing(unittest.TestCase):
+    """Test suite for must_change_password flag clearing on password change."""
+
+    def setUp(self):
+        """Set up test client with temporary database."""
+        # Create temporary database
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+
+        # Initialize database with schema
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+
+        # Store original settings to restore later
+        self._original_jwt_secret = settings.jwt_secret_key
+        self._original_users_enabled = settings.users_enabled
+        self._original_app_root_path = settings.app_root_path
+
+        # Override JWT secret for testing
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+        settings.app_root_path = ""
+
+        # Create a test pool for the temporary database
+        self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        # Create FastAPI app and configure dependency overrides
+        from app.api.deps import get_db
+        from app.main import app as main_app
+        from app.security import csrf_protect
+
+        class TestCSRFManager:
+            def generate_token(self):
+                return "test-csrf-token"
+
+            def validate_token(self, token):
+                return token == "test-csrf-token"
+
+        # Override the get_db dependency to use our test pool
+        def get_test_db():
+            conn = self.test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.test_pool.release_connection(conn)
+
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        main_app.state.csrf_manager = TestCSRFManager()
+
+        # Create test client with dependency overrides
+        self.client = TestClient(main_app)
+        self.app = main_app
+
+    def tearDown(self):
+        """Clean up after each test."""
+        # Restore original settings
+        settings.jwt_secret_key = self._original_jwt_secret
+        settings.users_enabled = self._original_users_enabled
+        settings.app_root_path = self._original_app_root_path
+
+        # Clear dependency overrides
+        self.app.dependency_overrides.clear()
+
+        # Close the test pool
+        self.test_pool.close_all()
+
+        # Clean up temp directory
+        import shutil
+
+        try:
+            shutil.rmtree(self.temp_dir)
+        except Exception:
+            pass
+
+    def _get_user_id(self, username: str) -> int:
+        """Helper to get user ID by username."""
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT id FROM users WHERE username = ?", (username,)
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _get_must_change_password(self, user_id: int) -> int:
+        """Helper to get must_change_password flag for a user."""
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT must_change_password FROM users WHERE id = ?", (user_id,)
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row else None
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _set_must_change_password(self, user_id: int, value: int) -> None:
+        """Helper to set must_change_password flag for a user."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "UPDATE users SET must_change_password = ? WHERE id = ?",
+                (value, user_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def test_change_password_clears_must_change_password_flag(self):
+        """User with must_change_password=1 changes password → flag is cleared to 0.
+
+        Regression test: the change-password endpoint now clears the
+        must_change_password flag after successfully updating the password.
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "forcepwuser", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "forcepwuser", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and verify must_change_password is initially 0 (default)
+        user_id = self._get_user_id("forcepwuser")
+        initial_flag = self._get_must_change_password(user_id)
+        self.assertEqual(initial_flag, 0)
+
+        # Set must_change_password = 1 (simulate admin password reset)
+        self._set_must_change_password(user_id, 1)
+        flag_before = self._get_must_change_password(user_id)
+        self.assertEqual(flag_before, 1)
+
+        # Change password
+        response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+
+        # Should succeed
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("access_token", data)
+        self.assertIn("refresh_token", data)
+
+        # must_change_password should now be 0 (flag cleared)
+        flag_after = self._get_must_change_password(user_id)
+        self.assertEqual(flag_after, 0)
+
+    def test_change_password_keeps_must_change_password_zero(self):
+        """User with must_change_password=0 changes password → flag stays 0 (no-op).
+
+        This verifies the UPDATE ... SET must_change_password = 0 is safe
+        when the flag is already 0 (no false-positive failures).
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "normalpwuser", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "normalpwuser", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and verify must_change_password is 0 (default)
+        user_id = self._get_user_id("normalpwuser")
+        flag_before = self._get_must_change_password(user_id)
+        self.assertEqual(flag_before, 0)
+
+        # Change password
+        response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+
+        # Should succeed
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("access_token", data)
+        self.assertIn("refresh_token", data)
+
+        # must_change_password should still be 0 (unchanged)
+        flag_after = self._get_must_change_password(user_id)
+        self.assertEqual(flag_after, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_must_change_password_exempt_paths.py
+++ b/backend/tests/test_must_change_password_exempt_paths.py
@@ -1,0 +1,593 @@
+"""Tests for must_change_password exempt-paths fix and flag clearing.
+
+Tests cover:
+1. User with must_change_password=1 can call POST /api/auth/change-password (403 NOT returned)
+2. After successful change-password, DB flag is cleared (must_change_password=0)
+3. User can then access protected routes (GET /api/auth/me) without 403
+4. User without must_change_password (already 0) changing password stays 0
+5. Users without must_change_password can still call login and change-password normally
+
+The exempt_paths fix in deps.py adds /api/auth/change-password and /api/auth/login
+so that flagged users can actually reach the change-password endpoint (routers are
+mounted at /api in main.py, so the request path is /api/auth/change-password).
+
+Uses FastAPI TestClient with dependency overrides for isolated testing.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies
+try:
+    import lancedb
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition
+except ImportError:
+    import types
+
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType(
+        "unstructured.documents.elements"
+    )
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _unstructured
+    sys.modules["unstructured.partition"] = _unstructured.partition
+    sys.modules["unstructured.partition.auto"] = _unstructured.partition.auto
+    sys.modules["unstructured.chunking"] = _unstructured.chunking
+    sys.modules["unstructured.chunking.title"] = _unstructured.chunking.title
+    sys.modules["unstructured.documents"] = _unstructured.documents
+    sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.models.database import SQLiteConnectionPool, init_db, run_migrations
+
+
+class TestMustChangePasswordExemptPaths(unittest.TestCase):
+    """Test suite for must_change_password exempt paths fix (deps.py)."""
+
+    def setUp(self):
+        """Set up test client with temporary database."""
+        # Create temporary database
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+
+        # Initialize database with schema
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+
+        # Store original settings to restore later
+        self._original_jwt_secret = settings.jwt_secret_key
+        self._original_users_enabled = settings.users_enabled
+        self._original_app_root_path = settings.app_root_path
+
+        # Override JWT secret for testing
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+        settings.app_root_path = ""
+
+        # Create a test pool for the temporary database
+        self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        # Create FastAPI app and configure dependency overrides
+        from app.api.deps import get_db
+        from app.main import app as main_app
+        from app.security import csrf_protect
+
+        class TestCSRFManager:
+            def generate_token(self):
+                return "test-csrf-token"
+
+            def validate_token(self, token):
+                return token == "test-csrf-token"
+
+        # Override the get_db dependency to use our test pool
+        def get_test_db():
+            conn = self.test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.test_pool.release_connection(conn)
+
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        main_app.state.csrf_manager = TestCSRFManager()
+
+        # Create test client with dependency overrides
+        self.client = TestClient(main_app)
+        self.app = main_app
+
+    def tearDown(self):
+        """Clean up after each test."""
+        # Restore original settings
+        settings.jwt_secret_key = self._original_jwt_secret
+        settings.users_enabled = self._original_users_enabled
+        settings.app_root_path = self._original_app_root_path
+
+        # Clear dependency overrides
+        self.app.dependency_overrides.clear()
+
+        # Close the test pool
+        self.test_pool.close_all()
+
+        # Clean up temp directory
+        import shutil
+
+        try:
+            shutil.rmtree(self.temp_dir)
+        except Exception:
+            pass
+
+    def _get_user_id(self, username: str) -> int:
+        """Helper to get user ID by username."""
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT id FROM users WHERE username = ?", (username,)
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _get_must_change_password(self, user_id: int) -> int:
+        """Helper to get must_change_password flag for a user."""
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT must_change_password FROM users WHERE id = ?", (user_id,)
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row else None
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _set_must_change_password(self, user_id: int, value: int) -> None:
+        """Helper to set must_change_password flag for a user."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "UPDATE users SET must_change_password = ? WHERE id = ?",
+                (value, user_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+    # ------------------------------------------------------------------
+    # Test 1: User with must_change_password=1 CAN call change-password
+    # (exempt paths fix: /api/auth/change-password is now in exempt_paths)
+    # ------------------------------------------------------------------
+    def test_flagged_user_can_call_change_password_endpoint(self):
+        """User with must_change_password=1 can call POST /api/auth/change-password.
+
+        Before the exempt_paths fix, the must_change_password check in
+        get_current_active_user blocked access to /api/auth/change-password
+        because exempt_paths only contained /auth/change-password (without /api
+        prefix). Since routers are mounted at /api in main.py, the actual
+        request path is /api/auth/change-password, which was NOT exempt.
+        This test verifies the fix allows flagged users to reach the endpoint.
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "flaggeduser", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "flaggeduser", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and set must_change_password = 1 (simulate admin reset)
+        user_id = self._get_user_id("flaggeduser")
+        self._set_must_change_password(user_id, 1)
+
+        # Verify flag is set
+        flag_before = self._get_must_change_password(user_id)
+        self.assertEqual(flag_before, 1)
+
+        # Attempt to change password — should NOT return 403
+        # This is the key assertion: before the fix, this returned 403
+        # "must_change_password" because /api/auth/change-password was not exempt
+        response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+
+        self.assertEqual(
+            response.status_code, 200,
+            f"Expected 200 but got {response.status_code}: {response.json()}"
+        )
+        data = response.json()
+        self.assertIn("access_token", data)
+        self.assertEqual(data["token_type"], "bearer")
+
+    # ------------------------------------------------------------------
+    # Test 2: After change-password, flag is cleared in DB
+    # ------------------------------------------------------------------
+    def test_flag_cleared_in_db_after_successful_change_password(self):
+        """After successful change-password, must_change_password=0 in the database.
+
+        Verifies the UPDATE users SET must_change_password = 0 WHERE id = ?
+        executes correctly inside _change_password_db.
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "flaggeduser2", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "flaggeduser2", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and set must_change_password = 1
+        user_id = self._get_user_id("flaggeduser2")
+        self._set_must_change_password(user_id, 1)
+
+        # Change password
+        response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Verify flag is cleared in the database
+        flag_after = self._get_must_change_password(user_id)
+        self.assertEqual(flag_after, 0)
+
+    # ------------------------------------------------------------------
+    # Test 3: After clearing flag, user can access protected routes (GET /api/auth/me)
+    # ------------------------------------------------------------------
+    def test_user_can_access_protected_routes_after_flag_cleared(self):
+        """After must_change_password is cleared, user can access GET /api/auth/me.
+
+        Before the flag is cleared, accessing /api/auth/me returns 403 with
+        "must_change_password". After a successful change-password (which clears
+        the flag), the same user can access it without 403.
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "flaggeduser3", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "flaggeduser3", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and set must_change_password = 1
+        user_id = self._get_user_id("flaggeduser3")
+        self._set_must_change_password(user_id, 1)
+
+        # Before flag is cleared: accessing /api/auth/me should be blocked
+        me_response_before = self.client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        self.assertEqual(
+            me_response_before.status_code, 403,
+            f"Expected 403 before flag clear, got {me_response_before.status_code}"
+        )
+        self.assertEqual(me_response_before.json()["detail"], "must_change_password")
+
+        # Change password (clears the flag)
+        cp_response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+        self.assertEqual(cp_response.status_code, 200)
+
+        # Use the new access token to access /api/auth/me
+        new_access_token = cp_response.json()["access_token"]
+        me_response_after = self.client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {new_access_token}"},
+        )
+        self.assertEqual(
+            me_response_after.status_code, 200,
+            f"Expected 200 after flag clear, got {me_response_after.status_code}: {me_response_after.json()}"
+        )
+        me_data = me_response_after.json()
+        self.assertEqual(me_data["username"], "flaggeduser3")
+
+    # ------------------------------------------------------------------
+    # Test 4: User without must_change_password (already 0) changing password stays 0
+    # ------------------------------------------------------------------
+    def test_user_without_flag_changing_password_stays_zero(self):
+        """User with must_change_password=0 changes password → flag stays 0.
+
+        This verifies the UPDATE ... SET must_change_password = 0 is safe
+        when the flag is already 0 (no false-positive failures / no regression).
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "normaluser", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "normaluser", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and verify must_change_password is 0 (default)
+        user_id = self._get_user_id("normaluser")
+        flag_before = self._get_must_change_password(user_id)
+        self.assertEqual(flag_before, 0)
+
+        # Change password
+        response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+
+        # Should succeed
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("access_token", data)
+        self.assertEqual(data["token_type"], "bearer")
+
+        # must_change_password should still be 0 (unchanged)
+        flag_after = self._get_must_change_password(user_id)
+        self.assertEqual(flag_after, 0)
+
+    # ------------------------------------------------------------------
+    # Test 5: Users without must_change_password can call login and change-password
+    # ------------------------------------------------------------------
+    def test_unflagged_user_can_still_login_and_change_password(self):
+        """User without must_change_password can call login and change-password normally.
+
+        Regression test: the exempt_paths addition should not break normal auth flow.
+        """
+        # Register user
+        register_response = self.client.post(
+            "/api/auth/register",
+            json={"username": "normaluser2", "password": "OldPass123"},
+        )
+        self.assertEqual(register_response.status_code, 200)
+
+        # Login should work
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "normaluser2", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+        self.assertIn("access_token", login_response.json())
+
+        # Get user ID and verify flag is 0
+        user_id = self._get_user_id("normaluser2")
+        flag_before = self._get_must_change_password(user_id)
+        self.assertEqual(flag_before, 0)
+
+        # Change password should work
+        cp_response = self.client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"current_password": "OldPass123", "new_password": "NewPass456"},
+        )
+        self.assertEqual(cp_response.status_code, 200)
+        self.assertIn("access_token", cp_response.json())
+
+        # Flag should still be 0
+        flag_after = self._get_must_change_password(user_id)
+        self.assertEqual(flag_after, 0)
+
+
+class TestMustChangePasswordExemptPathsVariants(unittest.TestCase):
+    """Additional edge case tests for must_change_password exempt paths."""
+
+    def setUp(self):
+        """Set up test client with temporary database."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+
+        self._original_jwt_secret = settings.jwt_secret_key
+        self._original_users_enabled = settings.users_enabled
+        self._original_app_root_path = settings.app_root_path
+
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+        settings.app_root_path = ""
+
+        self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        from app.api.deps import get_db
+        from app.main import app as main_app
+        from app.security import csrf_protect
+
+        class TestCSRFManager:
+            def generate_token(self):
+                return "test-csrf-token"
+
+            def validate_token(self, token):
+                return token == "test-csrf-token"
+
+        def get_test_db():
+            conn = self.test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.test_pool.release_connection(conn)
+
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        main_app.state.csrf_manager = TestCSRFManager()
+
+        self.client = TestClient(main_app)
+        self.app = main_app
+
+    def tearDown(self):
+        """Clean up after each test."""
+        settings.jwt_secret_key = self._original_jwt_secret
+        settings.users_enabled = self._original_users_enabled
+        settings.app_root_path = self._original_app_root_path
+
+        self.app.dependency_overrides.clear()
+        self.test_pool.close_all()
+
+        import shutil
+
+        try:
+            shutil.rmtree(self.temp_dir)
+        except Exception:
+            pass
+
+    def _get_user_id(self, username: str) -> int:
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT id FROM users WHERE username = ?", (username,)
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _set_must_change_password(self, user_id: int, value: int) -> None:
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "UPDATE users SET must_change_password = ? WHERE id = ?",
+                (value, user_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _get_must_change_password(self, user_id: int) -> int:
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT must_change_password FROM users WHERE id = ?", (user_id,)
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row else None
+        finally:
+            self.test_pool.release_connection(conn)
+
+    # ------------------------------------------------------------------
+    # Edge case: login endpoint is also exempt (both with and without /api prefix)
+    # ------------------------------------------------------------------
+    def test_flagged_user_can_still_login(self):
+        """User with must_change_password=1 can call POST /api/auth/login.
+
+        The login endpoint is also exempt (for the case where a user was flagged
+        after a prior session and needs to re-authenticate after changing password).
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "flaggedloginuser", "password": "OldPass123"},
+        )
+
+        # Get user ID and set must_change_password = 1 BEFORE first login
+        user_id = self._get_user_id("flaggedloginuser")
+        self._set_must_change_password(user_id, 1)
+
+        # Verify flag is set
+        flag_before = self._get_must_change_password(user_id)
+        self.assertEqual(flag_before, 1)
+
+        # Login should NOT be blocked — login is an exempt path
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "flaggedloginuser", "password": "OldPass123"},
+        )
+
+        self.assertEqual(
+            login_response.status_code, 200,
+            f"Expected 200 but got {login_response.status_code}: {login_response.json()}"
+        )
+        self.assertIn("access_token", login_response.json())
+
+    # ------------------------------------------------------------------
+    # Edge case: unflagged user cannot access non-exempt routes when flagged
+    # ------------------------------------------------------------------
+    def test_flagged_user_blocked_on_non_exempt_routes(self):
+        """User with must_change_password=1 is blocked on non-exempt routes.
+
+        Verifies that the must_change_password check only exempts the specific
+        login and change-password paths; other routes still return 403.
+        """
+        # Register user
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "flaggedblockuser", "password": "OldPass123"},
+        )
+
+        # Login to get access token
+        login_response = self.client.post(
+            "/api/auth/login",
+            json={"username": "flaggedblockuser", "password": "OldPass123"},
+        )
+        self.assertEqual(login_response.status_code, 200)
+        access_token = login_response.json()["access_token"]
+
+        # Get user ID and set must_change_password = 1
+        user_id = self._get_user_id("flaggedblockuser")
+        self._set_must_change_password(user_id, 1)
+
+        # Attempting to access /api/auth/me (non-exempt) should return 403
+        me_response = self.client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        self.assertEqual(me_response.status_code, 403)
+        self.assertEqual(me_response.json()["detail"], "must_change_password")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -751,7 +751,7 @@ const handleCreateUser = async () => {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {ROLE_OPTIONS.map((opt) => (
+                  {ROLE_OPTIONS.filter((r) => r.value !== "superadmin" || isSuperAdmin).map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>
                       {opt.label}
                     </SelectItem>


### PR DESCRIPTION
## Summary
- Fix must_change_password flag never cleared after password change (permanent lockout)
- Fix exempt paths missing /api prefix so flagged users can reach change-password endpoint
- Expose must_change_password in GET /auth/me so frontend can detect forced-pw state
- Auto-assign new users to Default vault on registration and admin create-user
- Migrate existing orphan users without vault access to Default vault
- Guard superadmin promotion via generic PATCH /users/{id} endpoint
- Filter superadmin from frontend edit dialog for non-superadmin users
- Issue CSRF token on registration (matching login/refresh pattern)

## Test plan
- [x] \python -m pytest tests/test_deps_auth_must_change_password.py\ — 12 passed
- [x] \python -m pytest tests/test_must_change_password_exempt_paths.py\ — 7 passed
- [x] \python -m pytest tests/test_deps_auth.py::TestMustChangePassword\ — 4 passed
- [x] \python -m pytest tests/test_users_routes.py::TestCreateUser\ — 8 passed
- [x] \python -m pytest tests/test_vault_permission_migration.py\ — 11 passed
- [x] \py_compile\ on all 4 modified Python files — syntax OK
- [x] Migration idempotency verified (re-running creates no duplicates)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 403s during forced password changes and user management by correcting auth-exempt paths, clearing the must_change_password flag, and exposing it via /api/auth/me. Also auto-assigns users to a Default vault and restricts superadmin role changes; registration now issues a CSRF token.

- **Bug Fixes**
  - Allow flagged users to reach /api/auth/change-password and /api/auth/login.
  - Clear must_change_password after a successful password change.
  - Include must_change_password in GET /api/auth/me.

- **New Features**
  - Auto-create a “Default” vault and auto-assign users on registration and admin create; idempotent migration assigns existing orphan users.
  - Only a superadmin can assign the `superadmin` role or change a superadmin’s role via PATCH /users/{id}; frontend hides this for non-superadmins.
  - Issue a CSRF token on registration (matching login/refresh).

<sup>Written for commit 8d00943081ad0a52284eb8eda1c39ae04012b1d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

