### PR TITLE
fix(embeddings): support native TEI /embed endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Native TEI embedding endpoint support**: the embedding client now supports a third provider mode for HuggingFace Text Embeddings Inference (TEI) servers that expose only the native `POST /embed` route (`{"inputs": ...}`, raw array-of-arrays response) and not the OpenAI-compatible `/v1/embeddings` route. Detection: an explicit `/embed` path or a bare `host:8080` URL resolves to native TEI; an explicit `/v1/embeddings` path still selects OpenAI mode. The model-availability check (`ModelChecker`) and the startup `STRICT_EMBEDDING_MODEL_CHECK` now probe TEI's `/info` endpoint (at the server root) for native-TEI URLs. The Settings UI documents the native-TEI URL form.
 - **Wiki master switch enforced (Phase 1)**: `wiki_enabled` is now a hard gate — all wiki routes (GET/POST/PUT/DELETE) return HTTP 503 when disabled. Previously the flag was documented but inert. Job enqueueing in `document_processor.py` is also gated on `wiki_enabled AND wiki_compile_on_ingest`. The flag is now persisted in `NEW_DIRECT_KEYS` for runtime reload.
 - **KMS content search (Phase 1.5)**: Document body text is now searchable via `GET /api/documents?search=`. A new `files_content_fts` FTS5 external-content table indexes `files.parsed_text`; triggers keep it in sync; `list_documents` ORs content-FTS hits alongside metadata-FTS hits. Fixes DD-C002, the critical blocker from issue #119.
 - **KMS RAG integration (Phase 2)**: KMS entries now surface in chat as `[K#]` citations alongside wiki `[W#]` citations. `KMSRetrievalService` performs FTS-backed retrieval (gated by `kms_enabled`), injected into the RAG pipeline after wiki retrieval. The SSE `done` event emits `kms_used`; `kms_refs` is persisted per chat message. The frontend renders `KMSCards` (emerald theme) after assistant messages and adds a "Knowledge" tab in the right-pane source viewer.
@@ -34,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Bare `host:8080` embedding URL now routes to native TEI `/embed`** (previously OpenAI `/v1/embeddings`). This affects only embedding URLs configured with **no path** on port 8080: such URLs previously appended `/v1/embeddings` (OpenAI mode) and now append `/embed` (native TEI mode). Default deployments are unaffected — the shipped `OLLAMA_EMBEDDING_URL` uses an explicit `/v1/embeddings` path, which still selects OpenAI mode. Operators running an OpenAI-compatible embedding server on a bare `:8080` URL should set an explicit `/v1/embeddings` path to keep OpenAI-mode behavior.
 - bcrypt password verification (cost factor 14, ~400ms) now offloaded to dedicated ThreadPoolExecutor(4) via async_verify_password(), preventing event-loop blocking during login and password-change under concurrent load
 - All authentication endpoints now use async bcrypt operations via async_verify_password() and async_hash_password()
 - VectorStore write lock now has configurable asyncio.wait_for timeout (default 30s) via @asynccontextmanager _acquire_write_lock(); all 8 write paths updated

--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -207,6 +207,71 @@ async def _safe_await(coro, name, timeout=10):
         logger.warning(f"{name} failed: {e} (continuing)")
 
 
+async def _validate_tei_embedding_model(embedding_service) -> None:
+    """Validate that the live TEI model matches the configured EMBEDDING_MODEL.
+
+    Probes the embedding server's ``/info`` endpoint (served at the host root,
+    not under the embeddings route) and raises ``RuntimeError`` on a genuine
+    model-id mismatch so startup fails fast on an embedding-space mismatch.
+    Network failures, SSRF blocks, and non-200 responses are treated as
+    "skip validation" (logged, non-fatal) so startup is not blocked when the
+    endpoint simply does not expose ``/info``.
+    """
+    try:
+        import httpx
+
+        # follow_redirects=False so a 30x from the embedding host cannot bypass
+        # the SSRF guard by redirecting to a private/internal address.
+        async with httpx.AsyncClient(
+            timeout=10.0, follow_redirects=False
+        ) as client:
+            # TEI exposes /info at the server root, not under the embeddings
+            # route. Strip the resolved embeddings endpoint suffix (native
+            # /embed, OpenAI /v1/embeddings, or Ollama /api/embeddings) so the
+            # probe reaches <host>/info for native TEI as well as the
+            # OpenAI-compatible variant.
+            _emb_url = embedding_service.embeddings_url.rstrip("/")
+            for _suffix in ("/embed", "/v1/embeddings", "/api/embeddings"):
+                if _emb_url.endswith(_suffix):
+                    _emb_url = _emb_url[: -len(_suffix)]
+                    break
+            info_url = _emb_url.rstrip("/") + "/info"
+            assert_url_safe(info_url)
+            response = await client.get(info_url)
+            if response.status_code == 200:
+                info_data = response.json()
+                live_model_id = info_data.get("model_id", "").split("/")[-1]
+                configured_model = settings.embedding_model.split("/")[-1]
+                if live_model_id and live_model_id != configured_model:
+                    error_msg = (
+                        f"EMBEDDING_MODEL mismatch! Configured: '{configured_model}', "
+                        f"Live TEI: '{live_model_id}'. "
+                        f"Embedding space mismatch will cause incorrect retrieval. "
+                        f"Set STRICT_EMBEDDING_MODEL_CHECK=false to disable this check."
+                    )
+                    logger.error("=" * 60)
+                    logger.error("STARTUP VALIDATION FAILED: %s", error_msg)
+                    logger.error("=" * 60)
+                    raise RuntimeError(error_msg)
+                else:
+                    logger.info("TEI model validation passed: %s", live_model_id)
+            else:
+                logger.warning(
+                    "TEI /info endpoint returned %d, skipping model validation",
+                    response.status_code,
+                )
+    except httpx.TimeoutException:
+        logger.warning("TEI /info endpoint timed out, skipping model validation")
+    except URLBlocked as e:
+        logger.warning(
+            "TEI /info endpoint blocked by SSRF guard: %s (continuing)", e
+        )
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise  # Re-raise our own error
+        logger.warning("TEI model validation failed (continuing): %s", e)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown events."""
@@ -270,47 +335,7 @@ async def lifespan(app: FastAPI):
 
     # Validate that live TEI model matches EMBEDDING_MODEL config
     if settings.strict_embedding_model_check:
-        try:
-            import httpx
-
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                info_url = (
-                    app.state.embedding_service.embeddings_url.rstrip("/") + "/info"
-                )
-                assert_url_safe(info_url)
-                response = await client.get(info_url)
-                if response.status_code == 200:
-                    info_data = response.json()
-                    live_model_id = info_data.get("model_id", "").split("/")[-1]
-                    configured_model = settings.embedding_model.split("/")[-1]
-                    if live_model_id and live_model_id != configured_model:
-                        error_msg = (
-                            f"EMBEDDING_MODEL mismatch! Configured: '{configured_model}', "
-                            f"Live TEI: '{live_model_id}'. "
-                            f"Embedding space mismatch will cause incorrect retrieval. "
-                            f"Set STRICT_EMBEDDING_MODEL_CHECK=false to disable this check."
-                        )
-                        logger.error("=" * 60)
-                        logger.error("STARTUP VALIDATION FAILED: %s", error_msg)
-                        logger.error("=" * 60)
-                        raise RuntimeError(error_msg)
-                    else:
-                        logger.info("TEI model validation passed: %s", live_model_id)
-                else:
-                    logger.warning(
-                        "TEI /info endpoint returned %d, skipping model validation",
-                        response.status_code,
-                    )
-        except httpx.TimeoutException:
-            logger.warning("TEI /info endpoint timed out, skipping model validation")
-        except URLBlocked as e:
-            logger.warning(
-                "TEI /info endpoint blocked by SSRF guard: %s (continuing)", e
-            )
-        except Exception as e:
-            if isinstance(e, RuntimeError):
-                raise  # Re-raise our own error
-            logger.warning("TEI model validation failed (continuing): %s", e)
+        await _validate_tei_embedding_model(app.state.embedding_service)
 
     app.state.vector_store = VectorStore()
     # Critical: fail fast if the vector store cannot connect or initialize its table.

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -142,9 +142,12 @@ class EmbeddingService:
         # Persistent HTTP client — created once, reused for all embedding calls.
         # URL is passed per-request from `embeddings_url`, so this pool survives
         # endpoint changes.
+        # follow_redirects=False so a 30x from the embedding host cannot bypass
+        # the SSRF guard by redirecting to a private/internal address.
         self._client = httpx.AsyncClient(
             timeout=self.timeout,
             limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+            follow_redirects=False,
         )
 
         # LRU cache. Cache keys include the live model/url/prefix fingerprints,
@@ -405,6 +408,8 @@ class EmbeddingService:
 
             return embedding
 
+        except CircuitBreakerError as e:
+            raise EmbeddingError(f"Embedding service circuit breaker is open: {e}")
         except httpx.TimeoutException:
             raise EmbeddingError("Embedding request timed out")
         except httpx.HTTPError:

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -218,9 +218,18 @@ class EmbeddingService:
         Detection strategy:
         - If URL path includes '/api/embeddings' -> Ollama mode
         - If URL path includes '/v1/embeddings' -> OpenAI mode
+        - If URL path ends with '/embed' -> native TEI mode
         - If no explicit embeddings path:
           - Port 1234 -> OpenAI mode (LM Studio default)
+          - Port 8080 -> native TEI mode (Text Embeddings Inference default)
           - Otherwise -> Ollama mode
+
+        Native TEI servers (HuggingFace Text Embeddings Inference) always expose
+        the route ``POST /embed`` with an ``{"inputs": ...}`` payload, but only
+        some deployments additionally expose the OpenAI-compatible
+        ``/v1/embeddings`` route. A bare ``host:8080`` URL is therefore resolved
+        to the native ``/embed`` route so it works against any TEI build, while
+        an explicit ``/v1/embeddings`` path still selects OpenAI mode.
 
         Args:
             base_url: The configured embedding URL
@@ -238,6 +247,9 @@ class EmbeddingService:
         elif "/v1/embeddings" in path:
             # Already has OpenAI path, use as-is
             return ("openai", base_url)
+        elif path.rstrip("/").endswith("/embed"):
+            # Already has native TEI path, use as-is
+            return ("tei", base_url)
 
         # No explicit path - determine by port
         port = parsed.port
@@ -246,9 +258,9 @@ class EmbeddingService:
             base_url = base_url.rstrip("/") + "/v1/embeddings"
             return ("openai", base_url)
         elif port == 8080:
-            # TEI default port - use OpenAI mode
-            base_url = base_url.rstrip("/") + "/v1/embeddings"
-            return ("openai", base_url)
+            # TEI default port - use native TEI mode (POST /embed)
+            base_url = base_url.rstrip("/") + "/embed"
+            return ("tei", base_url)
         else:
             # Default to Ollama mode
             base_url = base_url.rstrip("/") + "/api/embeddings"
@@ -266,15 +278,19 @@ class EmbeddingService:
         """
         if self.provider_mode == "openai":
             return {"model": self.embedding_model, "input": text}
+        elif self.provider_mode == "tei":
+            # Native TEI serves a single model, so no model field is sent.
+            return {"inputs": text}
         else:  # ollama mode
             return {"model": self.embedding_model, "prompt": text}
 
-    def _extract_embedding(self, data: dict) -> List[float]:
+    def _extract_embedding(self, data) -> List[float]:
         """
         Extract embedding vector from API response based on provider mode.
 
         Args:
-            data: Parsed JSON response from the API
+            data: Parsed JSON response from the API. A mapping for OpenAI/Ollama
+                modes, or a list-of-lists for native TEI mode.
 
         Returns:
             List of float values representing the embedding vector
@@ -298,6 +314,19 @@ class EmbeddingService:
             if embedding is None:
                 logger.error(
                     "Embedding API response missing 'data[0].embedding' field in OpenAI mode"
+                )
+                raise EmbeddingError("Embedding API response is invalid")
+        elif self.provider_mode == "tei":
+            # Native TEI format: a raw JSON array of embedding arrays, e.g. [[...]]
+            if not isinstance(data, list) or len(data) == 0:
+                logger.error(
+                    "Embedding API response is not a non-empty array in TEI mode"
+                )
+                raise EmbeddingError("Embedding API response is invalid")
+            embedding = data[0]
+            if not isinstance(embedding, list):
+                logger.error(
+                    "Embedding API response first element is not a list in TEI mode"
                 )
                 raise EmbeddingError("Embedding API response is invalid")
         else:  # ollama mode
@@ -638,6 +667,10 @@ class EmbeddingService:
             # Build payload with array of inputs
             if self.provider_mode == "openai":
                 payload = {"model": self.embedding_model, "input": texts}
+            elif self.provider_mode == "tei":
+                # Native TEI accepts a list under "inputs" and returns a raw
+                # array of embedding arrays in the same order.
+                payload = {"inputs": texts}
             else:  # ollama mode
                 payload = {"model": self.embedding_model, "input": texts}
 
@@ -674,6 +707,15 @@ class EmbeddingService:
             if self.provider_mode == "openai":
                 # OpenAI format: data[].embedding
                 embeddings = [item["embedding"] for item in data["data"]]
+            elif self.provider_mode == "tei":
+                # Native TEI format: a raw JSON array of embedding arrays.
+                if not isinstance(data, list):
+                    logger.error(
+                        f"Unexpected response format for {self.provider_mode} mode: "
+                        f"expected a list, got {type(data).__name__}"
+                    )
+                    raise EmbeddingError("Unexpected response from embedding service")
+                embeddings = data
             else:
                 # Ollama format may vary - try common formats
                 if "embeddings" in data:

--- a/backend/app/services/model_checker.py
+++ b/backend/app/services/model_checker.py
@@ -57,7 +57,11 @@ class ModelChecker:
         await asyncio.to_thread(assert_url_safe, settings.ollama_chat_url)
         await asyncio.to_thread(assert_url_safe, settings.instant_chat_url)
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+        # follow_redirects=False so a 30x from a model host cannot bypass the
+        # SSRF guard by redirecting to a private/internal address.
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=False
+        ) as client:
             # Check embedding model
             result['embedding_model'] = await self._check_model_availability(
                 client,
@@ -83,19 +87,22 @@ class ModelChecker:
 
     def _detect_provider_type(self, base_url: str) -> str:
         """
-        Detect whether the endpoint is Ollama or OpenAI-compatible.
+        Detect whether the endpoint is Ollama, OpenAI-compatible, or native TEI.
 
-        Detection rules:
+        Detection rules (kept consistent with
+        ``EmbeddingService._detect_provider_mode``):
         - explicit /api/tags path => Ollama
         - explicit /v1/models or /v1/embeddings path => OpenAI-compatible
-        - no explicit path + port 1234 => OpenAI-compatible
+        - explicit /embed path => native TEI
+        - no explicit path + port 8080 => native TEI (TEI default)
+        - no explicit path + port 1234/8000/5000/5001 => OpenAI-compatible
         - otherwise Ollama
 
         Args:
             base_url: The base URL of the endpoint
 
         Returns:
-            'ollama' or 'openai_compatible'
+            'ollama', 'openai_compatible', or 'tei'
         """
         url_lower = base_url.lower().rstrip('/')
 
@@ -107,12 +114,19 @@ class ModelChecker:
         if '/v1/models' in url_lower or '/v1/embeddings' in url_lower:
             return 'openai_compatible'
 
-        # Check for common OpenAI-compatible ports (vLLM 8000, LM Studio 1234, etc.)
-        # without explicit path
-        OPENAI_COMPATIBLE_PORTS = {8000, 1234, 8080, 5000, 5001}
+        # Check for explicit native TEI path (POST /embed)
+        if url_lower.endswith('/embed'):
+            return 'tei'
+
+        # Port-based detection when no explicit path disambiguates the endpoint.
+        # Native TEI defaults to 8080; other common OpenAI-compatible servers
+        # (vLLM 8000, LM Studio 1234, etc.) use the ports below.
+        OPENAI_COMPATIBLE_PORTS = {8000, 1234, 5000, 5001}
         try:
             from urllib.parse import urlparse
             parsed = urlparse(base_url)
+            if parsed.port == 8080 or parsed.netloc.endswith(':8080'):
+                return 'tei'
             if parsed.port in OPENAI_COMPATIBLE_PORTS or any(
                 parsed.netloc.endswith(f':{p}') for p in OPENAI_COMPATIBLE_PORTS
             ):
@@ -149,7 +163,9 @@ class ModelChecker:
         """
         provider_type = self._detect_provider_type(base_url)
 
-        if provider_type == 'openai_compatible':
+        if provider_type == 'tei':
+            return await self._check_tei_model(client, base_url, model_name)
+        elif provider_type == 'openai_compatible':
             return await self._check_openai_compatible_model(client, base_url, model_name)
         else:
             return await self._check_ollama_model(client, base_url, model_name)
@@ -190,6 +206,74 @@ class ModelChecker:
             return {
                 'available': False,
                 'error': f"Model '{model_name}' not found. Available models: {', '.join(available_model_names) or 'none'}"
+            }
+
+        except httpx.TimeoutException:
+            return {
+                'available': False,
+                'error': f"Request timed out after {self.timeout}s"
+            }
+        except httpx.HTTPStatusError as e:
+            return {
+                'available': False,
+                'error': f"HTTP error {e.response.status_code}: {e.response.text}"
+            }
+        except httpx.RequestError as e:
+            return {
+                'available': False,
+                'error': f"Request failed: {str(e)}"
+            }
+        except (ValueError, TypeError, RuntimeError) as e:
+            return {
+                'available': False,
+                'error': f"Unexpected error: {str(e)}"
+            }
+
+    async def _check_tei_model(
+        self,
+        client: httpx.AsyncClient,
+        base_url: str,
+        model_name: str
+    ) -> Dict[str, Any]:
+        """
+        Check model availability using native TEI's /info endpoint.
+
+        Native HuggingFace TEI serves a single model and exposes its identity at
+        ``<root>/info`` as ``{"model_id": "...", ...}``. The /info route lives at
+        the server root, not under the /embed route, so any trailing /embed is
+        stripped before probing.
+        """
+        root = base_url.rstrip('/')
+        if root.endswith('/embed'):
+            root = root[: -len('/embed')]
+        url = f"{root.rstrip('/')}/info"
+
+        try:
+            response = await client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+            live_model_id = data.get('model_id', '') if isinstance(data, dict) else ''
+            if not live_model_id:
+                return {
+                    'available': False,
+                    'error': "TEI /info response missing 'model_id'"
+                }
+
+            # TEI serves one model; compare leniently by the last path segment
+            # (e.g. "microsoft/harrier-oss-v1-0.6b" vs "harrier-oss-v1-0.6b").
+            if (
+                live_model_id == model_name
+                or live_model_id.split('/')[-1] == model_name.split('/')[-1]
+            ):
+                return {'available': True, 'error': None}
+
+            return {
+                'available': False,
+                'error': (
+                    f"Model '{model_name}' not found. "
+                    f"Live TEI model: '{live_model_id}'"
+                )
             }
 
         except httpx.TimeoutException:

--- a/backend/tests/test_embeddings_tei.py
+++ b/backend/tests/test_embeddings_tei.py
@@ -28,8 +28,10 @@ except ImportError:
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
+from app.services.circuit_breaker import CircuitBreakerError
 from app.services.embeddings import EmbeddingError, EmbeddingService
 
 
@@ -172,3 +174,87 @@ class TestTeiRoundTrip:
 
         with pytest.raises(EmbeddingError):
             await service.embed_single("x")
+
+    async def test_embed_passage_applies_doc_prefix_in_tei_mode(self, mock_tei_settings):
+        # LC5-07: the document prefix must be prepended to the TEI inputs payload.
+        mock_tei_settings.embedding_doc_prefix = "PASSAGE: "
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(
+            return_value=_mock_response(200, [[0.5, 0.6]])
+        )
+
+        vec = await service.embed_passage("hello")
+
+        assert vec == [0.5, 0.6]
+        assert service._client.post.call_args.kwargs["json"] == {
+            "inputs": "PASSAGE: hello"
+        }
+
+    async def test_embed_batch_rejects_non_list_response(self, mock_tei_settings):
+        # LC5-03: TEI batch guard — a non-list (e.g. error object) must raise.
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(
+            return_value=_mock_response(200, {"error": "boom"})
+        )
+
+        with pytest.raises(EmbeddingError):
+            await service.embed_batch(["a", "b"], batch_size=10)
+
+    async def test_embed_batch_non_200_raises(self, mock_tei_settings):
+        # LC5-01: a non-200 from a TEI batch call surfaces as EmbeddingError.
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(return_value=_mock_response(503, []))
+
+        with pytest.raises(EmbeddingError):
+            await service.embed_batch(["a"], batch_size=10)
+
+    async def test_embed_single_timeout_wrapped(self, mock_tei_settings):
+        # LC5-02: httpx.TimeoutException -> EmbeddingError (passthrough breaker).
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(side_effect=httpx.TimeoutException("t"))
+
+        with patch("app.services.embeddings.embeddings_cb", lambda fn: fn):
+            with pytest.raises(EmbeddingError):
+                await service.embed_single("x")
+
+    async def test_embed_single_http_error_wrapped(self, mock_tei_settings):
+        # LC5-02: httpx.HTTPError -> EmbeddingError.
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(side_effect=httpx.HTTPError("boom"))
+
+        with patch("app.services.embeddings.embeddings_cb", lambda fn: fn):
+            with pytest.raises(EmbeddingError):
+                await service.embed_single("x")
+
+    async def test_embed_single_circuit_breaker_open_wrapped(self, mock_tei_settings):
+        # F-C10 regression: an open circuit breaker must surface as EmbeddingError
+        # from the single-embed path (parity with the batch path), not as a raw
+        # CircuitBreakerError.
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(return_value=_mock_response(200, [[0.1]]))
+
+        def open_breaker(_fn):
+            async def _raise(*args, **kwargs):
+                raise CircuitBreakerError("circuit open")
+            return _raise
+
+        with patch("app.services.embeddings.embeddings_cb", open_breaker):
+            with pytest.raises(EmbeddingError) as exc:
+                await service.embed_single("x")
+        assert "circuit breaker" in str(exc.value).lower()
+
+
+class TestTeiHttpsDetection:
+    """LC5-08: HTTPS native-TEI URLs resolve to the tei mode and /embed route."""
+
+    def test_https_bare_8080_resolves_to_native_embed(self, mock_tei_settings):
+        mock_tei_settings.ollama_embedding_url = "https://localhost:8080"
+        service = EmbeddingService()
+        assert service.provider_mode == "tei"
+        assert service.embeddings_url == "https://localhost:8080/embed"

--- a/backend/tests/test_embeddings_tei.py
+++ b/backend/tests/test_embeddings_tei.py
@@ -1,0 +1,174 @@
+"""
+Tests for native TEI (HuggingFace Text Embeddings Inference) provider mode.
+
+Native TEI servers always expose ``POST /embed`` with an ``{"inputs": ...}``
+payload and return a raw JSON array of embedding arrays. Only some TEI builds
+additionally expose the OpenAI-compatible ``/v1/embeddings`` route, so a bare
+``host:8080`` URL must resolve to the native ``/embed`` route rather than the
+OpenAI path (which would 404 against a native-only deployment).
+"""
+import os
+import sys
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Stub missing optional dependencies (mirrors sibling embedding test modules)
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+    sys.modules['lancedb'] = types.ModuleType('lancedb')
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+    sys.modules['pyarrow'] = types.ModuleType('pyarrow')
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.embeddings import EmbeddingError, EmbeddingService
+
+
+@pytest.fixture
+def mock_tei_settings():
+    """Patch embedding settings with a native-TEI-style configuration.
+
+    The SSRF guard in ``EmbeddingService.__init__`` resolves the host and
+    rejects loopback addresses unless ``ALLOW_LOCAL_SERVICES=1``; we use a
+    ``localhost`` URL (which always resolves) with that opt-in so detection
+    can be exercised deterministically and offline.
+    """
+    prev = os.environ.get("ALLOW_LOCAL_SERVICES")
+    os.environ["ALLOW_LOCAL_SERVICES"] = "1"
+    try:
+        with patch("app.services.embeddings.settings") as mock:
+            mock.ollama_embedding_url = "http://localhost:8080"
+            mock.embedding_model = "BAAI/bge-m3"
+            mock.embedding_doc_prefix = ""
+            mock.embedding_query_prefix = ""
+            mock.embedding_batch_size = 512
+            mock.embedding_batch_max_retries = 3
+            mock.embedding_batch_min_sub_size = 1
+            mock.embedding_concurrent_batches = 4
+            mock.chunk_size_chars = 1200
+            mock.chunk_overlap_chars = 120
+            yield mock
+    finally:
+        if prev is None:
+            os.environ.pop("ALLOW_LOCAL_SERVICES", None)
+        else:
+            os.environ["ALLOW_LOCAL_SERVICES"] = prev
+
+
+def _mock_response(status_code, json_value):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_value
+    resp.text = str(json_value)
+    return resp
+
+
+class TestTeiProviderDetection:
+    """URL -> (provider_mode, embeddings_url) resolution for native TEI."""
+
+    def test_bare_8080_resolves_to_native_embed(self, mock_tei_settings):
+        mock_tei_settings.ollama_embedding_url = "http://localhost:8080"
+        service = EmbeddingService()
+        assert service.provider_mode == "tei"
+        assert service.embeddings_url == "http://localhost:8080/embed"
+
+    def test_bare_8080_trailing_slash_resolves_to_native_embed(self, mock_tei_settings):
+        mock_tei_settings.ollama_embedding_url = "http://localhost:8080/"
+        service = EmbeddingService()
+        assert service.provider_mode == "tei"
+        assert service.embeddings_url == "http://localhost:8080/embed"
+
+    def test_explicit_embed_path_is_tei(self, mock_tei_settings):
+        # An explicit /embed path on a non-default port must still select TEI.
+        mock_tei_settings.ollama_embedding_url = "http://localhost:9000/embed"
+        service = EmbeddingService()
+        assert service.provider_mode == "tei"
+        assert service.embeddings_url == "http://localhost:9000/embed"
+
+    def test_explicit_v1_embeddings_on_8080_stays_openai(self, mock_tei_settings):
+        # Regression guard: an explicit OpenAI path must NOT be hijacked by TEI
+        # detection, even on the TEI default port.
+        mock_tei_settings.ollama_embedding_url = "http://localhost:8080/v1/embeddings"
+        service = EmbeddingService()
+        assert service.provider_mode == "openai"
+        assert service.embeddings_url == "http://localhost:8080/v1/embeddings"
+
+    def test_port_1234_stays_openai(self, mock_tei_settings):
+        mock_tei_settings.ollama_embedding_url = "http://localhost:1234"
+        service = EmbeddingService()
+        assert service.provider_mode == "openai"
+        assert service.embeddings_url == "http://localhost:1234/v1/embeddings"
+
+    def test_default_port_stays_ollama(self, mock_tei_settings):
+        mock_tei_settings.ollama_embedding_url = "http://localhost:11434"
+        service = EmbeddingService()
+        assert service.provider_mode == "ollama"
+        assert service.embeddings_url == "http://localhost:11434/api/embeddings"
+
+
+class TestTeiPayloadShape:
+    """Native TEI payloads use {"inputs": ...} with no model field."""
+
+    def test_single_payload_uses_inputs(self, mock_tei_settings):
+        service = EmbeddingService()
+        assert service._build_payload("hello") == {"inputs": "hello"}
+
+
+@pytest.mark.asyncio
+class TestTeiRoundTrip:
+    """End-to-end embed calls against a mocked native-TEI HTTP response."""
+
+    async def test_embed_single_parses_array_response(self, mock_tei_settings):
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(
+            return_value=_mock_response(200, [[0.1, 0.2, 0.3]])
+        )
+
+        vec = await service.embed_single("query text")
+
+        assert vec == [0.1, 0.2, 0.3]
+        args, kwargs = service._client.post.call_args
+        assert args[0] == "http://localhost:8080/embed"
+        assert kwargs["json"] == {"inputs": "query text"}
+
+    async def test_embed_batch_parses_array_response(self, mock_tei_settings):
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(
+            return_value=_mock_response(200, [[0.1, 0.2], [0.3, 0.4]])
+        )
+
+        out = await service.embed_batch(["a", "b"], batch_size=10)
+
+        assert out == [[0.1, 0.2], [0.3, 0.4]]
+        args, kwargs = service._client.post.call_args
+        assert args[0] == "http://localhost:8080/embed"
+        assert kwargs["json"] == {"inputs": ["a", "b"]}
+
+    async def test_embed_single_rejects_empty_array(self, mock_tei_settings):
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(return_value=_mock_response(200, []))
+
+        with pytest.raises(EmbeddingError):
+            await service.embed_single("x")
+
+    async def test_embed_single_rejects_non_array_response(self, mock_tei_settings):
+        service = EmbeddingService()
+        service._client = MagicMock()
+        service._client.post = AsyncMock(
+            return_value=_mock_response(200, {"data": [{"embedding": [0.1]}]})
+        )
+
+        with pytest.raises(EmbeddingError):
+            await service.embed_single("x")

--- a/backend/tests/test_lifespan_tei.py
+++ b/backend/tests/test_lifespan_tei.py
@@ -1,0 +1,134 @@
+"""
+Runtime tests for the TEI startup model-validation helper in lifespan.py
+(`_validate_tei_embedding_model`).
+
+The helper probes the embedding server's /info endpoint (at the host root) and
+raises RuntimeError on a genuine model-id mismatch, while treating network
+failures, SSRF blocks, and non-200 responses as non-fatal "skip validation".
+"""
+import os
+import sys
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Stub missing optional dependencies (mirrors sibling test modules)
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+    sys.modules['lancedb'] = types.ModuleType('lancedb')
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+    sys.modules['pyarrow'] = types.ModuleType('pyarrow')
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.lifespan as lifespan_mod
+from app.services.ssrf import URLBlocked
+
+
+def _svc(url):
+    svc = MagicMock()
+    svc.embeddings_url = url
+    return svc
+
+
+def _resp(status_code, json_value=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_value if json_value is not None else {}
+    return r
+
+
+def _client_patch(response=None, get_side_effect=None):
+    """Patch httpx.AsyncClient with an async-context-manager mock.
+
+    Returns (patcher, client) where client.get is an AsyncMock.
+    """
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response, side_effect=get_side_effect)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return patch("httpx.AsyncClient", return_value=cm), client
+
+
+@pytest.mark.asyncio
+async def test_tei_model_match_passes_and_probes_root_info():
+    p_client, client = _client_patch(
+        _resp(200, {"model_id": "microsoft/harrier-oss-v1-0.6b"})
+    )
+    with patch.object(lifespan_mod, "settings") as s, patch.object(
+        lifespan_mod, "assert_url_safe"
+    ), p_client:
+        s.embedding_model = "microsoft/harrier-oss-v1-0.6b"
+        # Native /embed URL — /info must be derived at the server root.
+        await lifespan_mod._validate_tei_embedding_model(
+            _svc("http://tei.local:8080/embed")
+        )
+
+    client.get.assert_awaited_once()
+    assert client.get.call_args[0][0] == "http://tei.local:8080/info"
+
+
+@pytest.mark.asyncio
+async def test_tei_lenient_last_segment_match_passes():
+    p_client, client = _client_patch(
+        _resp(200, {"model_id": "microsoft/harrier-oss-v1-0.6b"})
+    )
+    with patch.object(lifespan_mod, "settings") as s, patch.object(
+        lifespan_mod, "assert_url_safe"
+    ), p_client:
+        s.embedding_model = "harrier-oss-v1-0.6b"  # bare leaf, no org prefix
+        await lifespan_mod._validate_tei_embedding_model(
+            _svc("http://tei.local:8080")
+        )
+
+    assert client.get.call_args[0][0] == "http://tei.local:8080/info"
+
+
+@pytest.mark.asyncio
+async def test_tei_model_mismatch_raises_runtime_error():
+    p_client, _ = _client_patch(_resp(200, {"model_id": "BAAI/bge-m3"}))
+    with patch.object(lifespan_mod, "settings") as s, patch.object(
+        lifespan_mod, "assert_url_safe"
+    ), p_client:
+        s.embedding_model = "nomic-embed-text"
+        with pytest.raises(RuntimeError):
+            await lifespan_mod._validate_tei_embedding_model(
+                _svc("http://tei.local:8080")
+            )
+
+
+@pytest.mark.asyncio
+async def test_tei_non_200_skips_without_raise():
+    p_client, _ = _client_patch(_resp(404))
+    with patch.object(lifespan_mod, "settings") as s, patch.object(
+        lifespan_mod, "assert_url_safe"
+    ), p_client:
+        s.embedding_model = "anything"
+        # 404 on /info -> skip validation, must not raise.
+        await lifespan_mod._validate_tei_embedding_model(
+            _svc("http://tei.local:8080")
+        )
+
+
+@pytest.mark.asyncio
+async def test_tei_urlblocked_skips_without_probing():
+    p_client, client = _client_patch(_resp(200, {"model_id": "x"}))
+    with patch.object(lifespan_mod, "settings") as s, patch.object(
+        lifespan_mod, "assert_url_safe", side_effect=URLBlocked("blocked")
+    ), p_client:
+        s.embedding_model = "anything"
+        # SSRF guard blocks the host -> skip validation, no GET, no raise.
+        await lifespan_mod._validate_tei_embedding_model(
+            _svc("http://tei.local:8080")
+        )
+
+    client.get.assert_not_called()

--- a/backend/tests/test_llm_integration.py
+++ b/backend/tests/test_llm_integration.py
@@ -210,6 +210,129 @@ class TestModelChecker(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_detect_provider_type_native_tei(self):
+        """Bare port 8080 and explicit /embed paths resolve to native TEI."""
+        checker = ModelChecker()
+        # Bare TEI default port -> native TEI
+        self.assertEqual(checker._detect_provider_type("http://localhost:8080"), "tei")
+        self.assertEqual(checker._detect_provider_type("http://localhost:8080/"), "tei")
+        # Explicit native /embed path -> native TEI (any port)
+        self.assertEqual(
+            checker._detect_provider_type("http://localhost:9000/embed"), "tei"
+        )
+        # Explicit OpenAI path must NOT be hijacked by TEI detection
+        self.assertEqual(
+            checker._detect_provider_type("http://localhost:8080/v1/embeddings"),
+            "openai_compatible",
+        )
+        # LM Studio default port stays OpenAI-compatible
+        self.assertEqual(
+            checker._detect_provider_type("http://localhost:1234"), "openai_compatible"
+        )
+        # Ollama default port stays Ollama
+        self.assertEqual(
+            checker._detect_provider_type("http://localhost:11434"), "ollama"
+        )
+
+    def test_check_model_availability_tei_uses_info_endpoint(self):
+        """Native TEI availability probes <root>/info and matches model_id."""
+        async def run_test():
+            checker = ModelChecker()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {
+                "model_id": "microsoft/harrier-oss-v1-0.6b",
+                "max_input_length": 8192,
+            }
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+
+            result = await checker._check_model_availability(
+                mock_client,
+                "http://localhost:8080",
+                "microsoft/harrier-oss-v1-0.6b",
+            )
+
+            self.assertTrue(result["available"])
+            self.assertIsNone(result["error"])
+            mock_client.get.assert_called_once()
+            self.assertEqual(
+                mock_client.get.call_args[0][0], "http://localhost:8080/info"
+            )
+
+        asyncio.run(run_test())
+
+    def test_check_model_availability_tei_strips_embed_suffix(self):
+        """An explicit /embed URL still probes the server-root /info."""
+        async def run_test():
+            checker = ModelChecker()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            # Lenient last-segment match: config has the bare name, live is qualified.
+            mock_response.json.return_value = {"model_id": "BAAI/bge-m3"}
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+
+            result = await checker._check_model_availability(
+                mock_client,
+                "http://localhost:8080/embed",
+                "bge-m3",
+            )
+
+            self.assertTrue(result["available"])
+            self.assertEqual(
+                mock_client.get.call_args[0][0], "http://localhost:8080/info"
+            )
+
+        asyncio.run(run_test())
+
+    def test_check_model_availability_tei_mismatch(self):
+        """A mismatched live TEI model_id reports unavailable with detail."""
+        async def run_test():
+            checker = ModelChecker()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {"model_id": "BAAI/bge-m3"}
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+
+            result = await checker._check_model_availability(
+                mock_client,
+                "http://localhost:8080",
+                "nomic-embed-text",
+            )
+
+            self.assertFalse(result["available"])
+            self.assertIn("not found", result["error"])
+            self.assertIn("BAAI/bge-m3", result["error"])
+
+        asyncio.run(run_test())
+
+    def test_check_model_availability_tei_non_dict_info(self):
+        """A non-dict /info body reports unavailable without raising (LC5-12)."""
+        async def run_test():
+            checker = ModelChecker()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = ["unexpected", "list", "body"]
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+
+            result = await checker._check_model_availability(
+                mock_client,
+                "http://localhost:8080",
+                "BAAI/bge-m3",
+            )
+
+            self.assertFalse(result["available"])
+            self.assertIn("model_id", result["error"])
+
+        asyncio.run(run_test())
+
 
 class TestLLMClient(unittest.TestCase):
     """Test cases for LLMClient."""

--- a/backend/tests/test_settings_ssrf.py
+++ b/backend/tests/test_settings_ssrf.py
@@ -259,15 +259,17 @@ class TestLifespanSSRFGuard(unittest.TestCase):
         with open(lifespan_path, "r") as f:
             source = f.read()
 
-        # Find the strict_embedding_model_check block (TEI validation section)
-        tei_start = source.find("strict_embedding_model_check")
+        # The TEI /info validation lives in the _validate_tei_embedding_model
+        # helper; bound the block to that function definition.
+        tei_start = source.find("async def _validate_tei_embedding_model")
         self.assertGreater(
             tei_start,
             0,
-            "lifespan.py should have strict_embedding_model_check block",
+            "lifespan.py should define _validate_tei_embedding_model",
         )
-        # Find the next app.state.vector_store to bound the TEI block
-        tei_end = source.find("app.state.vector_store", tei_start)
+        # The helper is defined immediately before the @asynccontextmanager
+        # lifespan; use that to bound the block.
+        tei_end = source.find("@asynccontextmanager", tei_start)
         tei_block = source[tei_start:tei_end]
 
         # Within that block, info_url is defined first, then assert_url_safe is called
@@ -342,9 +344,9 @@ class TestLifespanSSRFGuard(unittest.TestCase):
         with open(lifespan_path, "r") as f:
             source = f.read()
 
-        # Find the TEI validation block
-        tei_block_start = source.find("strict_embedding_model_check")
-        tei_block_end = source.find("app.state.vector_store", tei_block_start)
+        # Find the TEI validation block (the _validate_tei_embedding_model helper)
+        tei_block_start = source.find("async def _validate_tei_embedding_model")
+        tei_block_end = source.find("@asynccontextmanager", tei_block_start)
         tei_block = source[tei_block_start:tei_block_end]
 
         # URLBlocked should be caught separately, not re-raised

--- a/frontend/src/components/settings/ModelConnectionSettings.tsx
+++ b/frontend/src/components/settings/ModelConnectionSettings.tsx
@@ -46,7 +46,8 @@ export function ModelConnectionSettings({
             )}
             <p id="ollama_embedding_url-desc" className="text-xs text-muted-foreground">
               URL for the embedding model service (e.g., HuggingFace TEI, Ollama, OpenAI-compatible).
-              Examples: http://harrier-embed:8080/v1/embeddings (TEI) or http://localhost:11434 (Ollama)
+              Examples: http://harrier-embed:8080 (native TEI /embed), http://harrier-embed:8080/v1/embeddings
+              (TEI OpenAI-compatible), or http://localhost:11434 (Ollama)
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Remote HuggingFace Text Embeddings Inference (TEI) servers expose the native `POST /embed` route (`{"inputs": ...}`, response = raw array-of-arrays) but not always the OpenAI-compatible `/v1/embeddings` route. The app previously mapped a bare `host:8080` URL to OpenAI mode and appended `/v1/embeddings`, which 404s against native-only TEI deployments (e.g. `172.16.50.40:8080`). This adds a third `"tei"` provider mode and wires it end-to-end.
- **`embeddings.py`**: an explicit `/embed` path or a bare port-8080 URL resolves to native TEI and posts `{"inputs": text|texts}` (no model field), parsing the raw JSON array-of-arrays for both single and batch. Explicit `/v1/embeddings` still selects OpenAI mode, so existing default deployments are untouched.
- **`model_checker.py`**: native-TEI model availability now probes `/info` and matches `model_id` (instead of `/v1/models`, which native TEI lacks). `8080` removed from the OpenAI-compatible port set; detection kept consistent with `EmbeddingService`.
- **`lifespan.py`**: the startup `strict_embedding_model_check` now derives `/info` at the server root (stripping the embeddings-route suffix) so it actually validates native TEI instead of silently 404ing.
- **`ModelConnectionSettings.tsx`**: help text documents the native-TEI URL form.

## Test plan
- [x] `pytest tests/test_embeddings_tei.py tests/test_lifespan_tei.py tests/test_llm_integration.py::TestModelChecker` (ALLOW_LOCAL_SERVICES=1) — 31 passed
- [x] `pytest tests/test_settings_ssrf.py tests/test_lifespan_model_assertion.py` — 16 passed (lifespan source-introspection invariants intact after helper extraction)
- [x] `pytest tests/test_ssrf_services.py::TestModelCheckerSSRF` — 5 passed (no detection regression)
- [x] CI-gated backend files (`test_path_prefix`, `test_auth_routes`, `test_main_catchall`) — 66 passed
- [x] `ruff check .` — clean; `py_compile` touched files — OK
- [x] `python scripts/check_config_contract.py` — passed
- [x] frontend `npm run typecheck` + `npm run lint` — clean
- [x] Regression: `test_embeddings.py` shows 6 pre-existing failures (process-global circuit-breaker pollution when overflow tests run in isolation) — **identical on the clean tree**, unrelated to this PR and not in the CI-gated set

## Review follow-up

**F-C10 — ACCEPTED** (CircuitBreakerError not caught in single-embed path)
`_embed_with_prefix` caught `httpx.TimeoutException`/`httpx.HTTPError` but not `CircuitBreakerError`, so an open breaker surfaced raw from `embed_single` while the batch path wrapped it. Added `except CircuitBreakerError -> EmbeddingError`. Regression test: `test_embed_single_circuit_breaker_open_wrapped`.

**F-SEC-001 — ACCEPTED** (explicit `follow_redirects=False`)
Added `follow_redirects=False` to the embedding client, the ModelChecker client, and the startup `/info` client, matching the `ssrf.py` convention. (httpx already defaults to not following redirects, so this is defense-in-depth/convention compliance rather than an active exploit fix.)

**F-LC5-06 / LC5-06 — ACCEPTED** (lifespan startup validation untested)
Extracted the inline TEI `/info` validation into a testable `_validate_tei_embedding_model` helper. Runtime tests in `test_lifespan_tei.py`: model match, lenient last-segment match, mismatch→`RuntimeError`, non-200 skip, and `URLBlocked` skip. The two source-introspection guard tests in `test_settings_ssrf.py` were repointed at the helper (security intent — `assert_url_safe` before the GET, `URLBlocked` not re-raised, `RuntimeError` re-raised — preserved).

**LC5-01/02/03/07/08, LC5-12 — ACCEPTED** (coverage gaps)
Added tests for: TEI batch non-list guard, TEI batch non-200, `embed_single` timeout/HTTP-error wrapping, TEI doc-prefix application, HTTPS native-TEI detection, and ModelChecker non-dict `/info` response.

**F-LC005 — ACCEPTED (with corrected evidence)** (bare `:8080` behavioral change)
The finding's premise was inaccurate: pre-PR, a bare `:8080` URL resolved to **OpenAI mode** (`/v1/embeddings`), not Ollama. The real change is openai→tei. Documented in CHANGELOG (`Added` + `Changed`), including the escape hatch: set an explicit `/v1/embeddings` path to keep OpenAI mode. Default deployments use that explicit path and are unaffected.

**F-C16 — REJECTED** (`/embed` endswith too loose)
`endswith('/embed')` is intentional: it supports subpath-proxied TEI (e.g. `https://host/tei/embed`). Requiring an exact `/embed` path would regress reverse-proxy deployments. The contrived `/api/embed` / `/v2/embed` cases are reasonably treated as native TEI.

**F-LC-11 — DEFERRED** (port-set divergence for 8000/5000/5001)
Pre-existing before this PR (`EmbeddingService` → Ollama, `ModelChecker` → OpenAI-compatible for those ports). This PR aligns the two files for 8080 (tei) and 1234 (openai). Reconciling 8000/5000/5001 changes behavior for non-TEI deployments and is out of scope for native-TEI support.

**LC-07 — PARTIALLY ADDRESSED** (lifespan duplicates ModelChecker `/info` logic)
The extraction centralizes lifespan's probe in one helper. Full cross-module dedup is deferred: `ModelChecker._check_tei_model` returns a status dict while the startup check must `raise RuntimeError` on mismatch — different contracts.

**C-001 / C-004 — PRE-EXISTING** (module-level `sys.modules` stubs; `asyncio.run()` in `unittest.TestCase`) — established patterns in sibling test modules; not introduced here.

### Notes
- Two independent skeptical reviews (one per change set) returned APPROVED / RISK: LOW with no blocking findings.
- A genuine model mismatch under `ALLOW_LOCAL_SERVICES=1` will now correctly fail startup — the documented intent of `strict_embedding_model_check`, disablable via `STRICT_EMBEDDING_MODEL_CHECK=false`.

https://claude.ai/code/session_013PU4hrmdE8nbcL1JxL4Pcd