### PR TITLE
fix(wiki): add test coverage for mark_claims_stale_by_memory

### DIFF
--- a/backend/tests/test_wiki_compile_processor.py
+++ b/backend/tests/test_wiki_compile_processor.py
@@ -398,6 +398,95 @@ class TestMarkClaimsStale(unittest.TestCase):
         ).fetchone()
         self.assertNotEqual(dict(row)["status"], "superseded")
 
+    # ------------------------------------------------------------------
+    # mark_claims_stale_by_memory — mirrors the file variant above.
+    # Sole-source memory → 'superseded' + 'stale' lint finding; multi-source
+    # (memory + file) → only 'weak_provenance' finding, claim stays active.
+    # ------------------------------------------------------------------
+
+    def _make_claim_with_memory_source(self, claim_id_label="test", memory_id=42):
+        claim = self.store.create_claim(
+            vault_id=1,
+            claim_text=f"Memory claim {claim_id_label}",
+            source_type="memory",
+        )
+        self.store.attach_source(
+            claim_id=claim.id,
+            source_kind="memory",
+            memory_id=memory_id,
+            source_label=f"memory:{memory_id}",
+            confidence=0.9,
+        )
+        self.conn.commit()
+        return claim
+
+    def test_sole_memory_source_claim_becomes_stale(self):
+        claim = self._make_claim_with_memory_source(memory_id=42)
+        result = self.store.mark_claims_stale_by_memory(memory_id=42, vault_id=1)
+        self.assertEqual(result["stale"], 1)
+        self.assertEqual(result["weak_provenance"], 0)
+        row = self.conn.execute(
+            "SELECT status FROM wiki_claims WHERE id = ?", (claim.id,)
+        ).fetchone()
+        self.assertEqual(dict(row)["status"], "superseded")
+        # Lint finding references the memory id, not a file id.
+        finding = self.conn.execute(
+            "SELECT finding_type, title, severity, related_claim_ids_json "
+            "FROM wiki_lint_findings WHERE vault_id = ? ORDER BY id DESC LIMIT 1",
+            (1,),
+        ).fetchone()
+        self.assertEqual(dict(finding)["finding_type"], "stale")
+        self.assertEqual(dict(finding)["severity"], "medium")
+        self.assertIn("memory_id=42", dict(finding)["title"])
+
+    def test_memory_source_with_other_source_not_stale(self):
+        claim = self._make_claim_with_memory_source(memory_id=42)
+        # Add a file source so the claim has a second provenance path.
+        self.store.attach_source(
+            claim_id=claim.id,
+            source_kind="document",
+            file_id=1,
+            source_label="file:1",
+            confidence=0.5,
+        )
+        self.conn.commit()
+        result = self.store.mark_claims_stale_by_memory(memory_id=42, vault_id=1)
+        self.assertEqual(result["stale"], 0)
+        self.assertEqual(result["weak_provenance"], 1)
+        row = self.conn.execute(
+            "SELECT status FROM wiki_claims WHERE id = ?", (claim.id,)
+        ).fetchone()
+        self.assertNotEqual(dict(row)["status"], "superseded")
+        finding = self.conn.execute(
+            "SELECT finding_type, title, severity FROM wiki_lint_findings "
+            "WHERE vault_id = ? ORDER BY id DESC LIMIT 1", (1,),
+        ).fetchone()
+        self.assertEqual(dict(finding)["finding_type"], "weak_provenance")
+        self.assertEqual(dict(finding)["severity"], "low")
+        self.assertIn("memory_id=42", dict(finding)["title"])
+
+    def test_memory_vault_scope_respected(self):
+        claim = self._make_claim_with_memory_source(memory_id=42)
+        result = self.store.mark_claims_stale_by_memory(memory_id=42, vault_id=999)
+        # Wrong vault — no claims should be stale or weak.
+        self.assertEqual(result["stale"], 0)
+        self.assertEqual(result["weak_provenance"], 0)
+        row = self.conn.execute(
+            "SELECT status FROM wiki_claims WHERE id = ?", (claim.id,)
+        ).fetchone()
+        self.assertNotEqual(dict(row)["status"], "superseded")
+        # And no lint finding should have been written either.
+        finding_count = self.conn.execute(
+            "SELECT COUNT(*) FROM wiki_lint_findings WHERE vault_id = ?", (999,)
+        ).fetchone()[0]
+        self.assertEqual(finding_count, 0)
+
+    def test_memory_unknown_id_is_noop(self):
+        # No claim has memory_id=7777; running the method should not raise
+        # and should report zero stale/weak findings.
+        result = self.store.mark_claims_stale_by_memory(memory_id=7777, vault_id=1)
+        self.assertEqual(result, {"stale": 0, "weak_provenance": 0})
+
 
 # ---------------------------------------------------------------------------
 # WikiCompileProcessor lifecycle


### PR DESCRIPTION
## Summary

- Add test coverage for `WikiCompiler.mark_claims_stale_by_memory` to close the
  zero-coverage gap reported in #110. Four new tests in `TestMarkClaimsStale`
  exercise the memory-source path, mirroring the existing file-source
  coverage and locking in the lint-finding title format
  (`memory_id=<id>`, not `file_id=<id>`).
- All four tests pass; the existing file-source tests continue to pass;
  `ruff check` and `python -m py_compile` are clean on the touched file.

## Test plan

- [x] `python3 -m py_compile backend/tests/test_wiki_compile_processor.py` -- OK
- [x] `ruff check backend/tests/test_wiki_compile_processor.py` -- All checks passed!
- [x] `python3 -m pytest backend/tests/test_wiki_compile_processor.py -k "TestMarkClaimsStale and memory" -v` -- 4 passed, 63 deselected
- [x] `python3 -m pytest backend/tests/test_wiki_compile_processor.py` -- 67 passed

Closes #110


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add four tests for WikiCompiler.mark_claims_stale_by_memory to close the zero-coverage gap in #110. They mirror the file-source cases and verify stale vs weak_provenance behavior, vault scoping, unknown-id no-op, and that lint titles use memory_id= (not file_id=).

<sup>Written for commit e1eed8d7084ec420d6be01ca2481910ad9ae87a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

