### PR TITLE
fix(chat): guard transcript load against empty fork responses (issue #83)

### DIFF
--- a/frontend/src/components/chat/TranscriptPane.test.tsx
+++ b/frontend/src/components/chat/TranscriptPane.test.tsx
@@ -92,6 +92,14 @@ vi.mock("@/lib/api", () => ({
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate,
 }));
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
 vi.mock("./MessageBubble", () => ({
   MessageBubble: ({ message, onFork, userInitial }: { message: { id: string; role: string; content: string }; onFork?: () => void; userInitial?: string }) => (
     <div data-testid="message-bubble" data-message-id={message.id} data-user-initial={userInitial}>
@@ -146,6 +154,7 @@ vi.mock("@tanstack/react-virtual", () => ({
 import { useSendMessage, MAX_INPUT_LENGTH } from "@/hooks/useSendMessage";
 import { useChatHistory } from "@/hooks/useChatHistory";
 import { forkChatSession } from "@/lib/api";
+import { toast } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 // Helper to render Composer with required providers
@@ -327,6 +336,39 @@ describe("TranscriptPane", () => {
       );
       expect(mockRefreshHistory).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/chat/20");
+    });
+
+    it("does not load the transcript when the fork response has no messages (issue #83)", async () => {
+      vi.mocked(forkChatSession).mockResolvedValue({
+        id: 99,
+        vault_id: 1,
+        title: "Empty Branch",
+        created_at: "2026-05-15T00:00:00Z",
+        updated_at: "2026-05-15T00:00:00Z",
+        forked_from_session_id: 10,
+        fork_message_index: 1,
+        messages: [],
+      });
+      mockChatState.activeChatId = "10";
+      _mockMessageCount = 2;
+      setMockMessages([
+        { id: "m1", role: "user", content: "Question" },
+        { id: "m2", role: "assistant", content: "Answer" },
+      ]);
+
+      render(<TranscriptPane />);
+
+      await userEvent.click(screen.getByLabelText("Fork m2"));
+
+      await waitFor(() => expect(forkChatSession).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(toast.warning).toHaveBeenCalledWith(
+          expect.stringMatching(/no messages/i)
+        )
+      );
+      expect(mockChatState.loadChat).not.toHaveBeenCalled();
+      expect(mockRefreshHistory).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/chat/TranscriptPane.tsx
+++ b/frontend/src/components/chat/TranscriptPane.tsx
@@ -408,6 +408,10 @@ export function TranscriptPane({ className }: TranscriptPaneProps) {
     setIsForking(true);
     try {
       const forked = await forkChatSession(parseInt(activeChatId), msgIndex);
+      if (!forked.messages?.length) {
+        toast.warning("Fork returned no messages — staying on the current session.");
+        return;
+      }
       const forkMessages = forked.messages.map((m) => ({
         id: m.id.toString(),
         role: m.role as "user" | "assistant",


### PR DESCRIPTION
## Summary
- Add a defensive guard in `TranscriptPane.handleFork` for empty `messages` arrays returned by `forkChatSession`. Per the API type, an empty array is a valid response, and previously the user would silently land on an empty conversation.
- On an empty fork response, surface a warning toast and short-circuit: do not call `loadChat`, do not refresh history, and do not navigate.
- Add a focused test that mocks `forkChatSession` to resolve with `{ id: 99, messages: [] }` and asserts none of the downstream side effects fire and the toast warning is shown.

Closes #83

## Test plan
- [x] `cd frontend && npx vitest run src/components/chat/TranscriptPane.test.tsx` -- 54/54 tests passed (including the new empty-fork guard)
- [x] `cd frontend && npx tsc --noEmit` -- clean (no type errors)
- [x] `cd frontend && npx eslint --max-warnings 0 src/components/chat/TranscriptPane.tsx src/components/chat/TranscriptPane.test.tsx` -- clean (no warnings)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defensively handle empty fork responses in `TranscriptPane`: if `forkChatSession` returns no messages, show a warning toast and stay on the current session. Adds a test that mocks an empty fork to verify no load, no history refresh, and no navigation (closes #83).

<sup>Written for commit be2132c66aa354e360d35b021251d83f4634f74e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

