### PR TITLE
fix(frontend): add test coverage for useSendMessage error paths and rejected-files dismiss (issue #55)

### DIFF
--- a/frontend/src/hooks/useSendMessage.test.ts
+++ b/frontend/src/hooks/useSendMessage.test.ts
@@ -190,4 +190,223 @@ describe("useSendMessage", () => {
       });
     });
   });
+
+  describe("error-path coverage (issue #55)", () => {
+    type StreamHandlers = {
+      onMessage: (chunk: string) => void;
+      onSources: (sources: unknown[]) => void;
+      onMemories: (memories: unknown[]) => void;
+      onWiki: (wikiRefs: unknown[]) => void;
+      onKMS: (kmsRefs: unknown[]) => void;
+      onMode: (mode: string) => void;
+      onError: (error: Error) => void;
+      onComplete: () => Promise<void> | void;
+    };
+
+    // Install a chatStream mock that captures the handlers so each test can
+    // fire them at will. The captured handler is read from a mutable cell
+    // so subsequent mock invocations (e.g. retries) update the reference
+    // and trigger calls operate on the latest invocation.
+    function installCapturingStreamMock(): { trigger: { error: (e: Error) => void; complete: () => void } } {
+      const cell: { current: StreamHandlers | null } = { current: null };
+      apiMocks.chatStream.mockImplementation((_messages: unknown, handlers: StreamHandlers) => {
+        cell.current = handlers;
+        return vi.fn(); // abort function
+      });
+      return {
+        trigger: {
+          error: (e: Error) => {
+            if (!cell.current) throw new Error("chatStream was not invoked yet");
+            cell.current.onError(e);
+          },
+          complete: () => {
+            if (!cell.current) throw new Error("chatStream was not invoked yet");
+            void cell.current.onComplete();
+          },
+        },
+      };
+    }
+
+    it("flips isStreaming to true synchronously when send begins", async () => {
+      // Arrange: a stream that never completes, so we can observe the
+      // mid-flight isStreaming value.
+      apiMocks.chatStream.mockImplementation((_messages: unknown, _handlers: StreamHandlers) => {
+        return vi.fn();
+      });
+      const refreshHistory = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ activeChatId: "42", input: "Stream start" });
+
+      const { result } = renderHook(() => useSendMessage(7, refreshHistory));
+
+      // Don't await — observe store state immediately after kicking off the send.
+      act(() => {
+        void result.current.handleSend();
+      });
+
+      // isStreaming must be true right after the send call returns, before any
+      // stream events have fired. This guards the immediate flip behavior.
+      expect(useChatStore.getState().isStreaming).toBe(true);
+    });
+
+    it("handles AbortError: clears isStreaming, abortFn, streamingMessageId, sendingRef — without stamping an error on the message", async () => {
+      const capture = installCapturingStreamMock();
+      const refreshHistory = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ activeChatId: "42", input: "Will be aborted" });
+
+      const { result } = renderHook(() => useSendMessage(7, refreshHistory));
+
+      await act(async () => {
+        await result.current.handleSend();
+      });
+
+      // The send should have created the assistant message and marked it as
+      // streaming. Capture the streamingMessageId so we can inspect the
+      // message after abort.
+      const streamingId = useChatStore.getState().streamingMessageId;
+      expect(streamingId).toBeTruthy();
+      expect(useChatStore.getState().isStreaming).toBe(true);
+
+      // Simulate the AbortError bubbling up through the SSE stream.
+      await act(async () => {
+        capture.trigger.error(new DOMException("aborted", "AbortError"));
+      });
+
+      await waitFor(() => {
+        expect(useChatStore.getState().isStreaming).toBe(false);
+      });
+      expect(useChatStore.getState().abortFn).toBeNull();
+      expect(useChatStore.getState().streamingMessageId).toBeNull();
+
+      // Aborts must NOT mark the assistant message with an error field —
+      // they're a normal user action, not a failure.
+      const assistant = useChatStore.getState().messagesById[streamingId!];
+      expect(assistant).toBeDefined();
+      expect(assistant?.error).toBeUndefined();
+
+      // refreshHistory must NOT be called for an aborted send (no onComplete fired).
+      expect(refreshHistory).not.toHaveBeenCalled();
+
+      // sendingRef must have been cleared: a subsequent send must not be silently dropped.
+      useChatStore.setState({ input: "second send" });
+      await act(async () => {
+        await result.current.handleSend();
+      });
+      // chatStream called twice total — once for the aborted send, once for the follow-up.
+      expect(apiMocks.chatStream).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles AbortError when error.message mentions 'abort' but name is not 'AbortError'", async () => {
+      // The code also matches /aborted|abort/i on message — exercise that branch.
+      const capture = installCapturingStreamMock();
+      const refreshHistory = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ activeChatId: "42", input: "Will be aborted via message" });
+
+      const { result } = renderHook(() => useSendMessage(7, refreshHistory));
+
+      await act(async () => {
+        await result.current.handleSend();
+      });
+
+      const streamingId = useChatStore.getState().streamingMessageId;
+      expect(streamingId).toBeTruthy();
+
+      await act(async () => {
+        // Plain Error (not DOMException) — only the message regex will catch this.
+        capture.trigger.error(new Error("Request was aborted by client"));
+      });
+
+      await waitFor(() => {
+        expect(useChatStore.getState().isStreaming).toBe(false);
+      });
+      expect(useChatStore.getState().abortFn).toBeNull();
+      expect(useChatStore.getState().streamingMessageId).toBeNull();
+      const assistant = useChatStore.getState().messagesById[streamingId!];
+      expect(assistant?.error).toBeUndefined();
+    });
+
+    it("network error: stamps a friendly 'Connection lost' message and rolls back streaming state", async () => {
+      const capture = installCapturingStreamMock();
+      const refreshHistory = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ activeChatId: "42", input: "Will fail with network error" });
+
+      const { result } = renderHook(() => useSendMessage(7, refreshHistory));
+
+      await act(async () => {
+        await result.current.handleSend();
+      });
+
+      const streamingId = useChatStore.getState().streamingMessageId;
+      expect(streamingId).toBeTruthy();
+      expect(useChatStore.getState().isStreaming).toBe(true);
+
+      await act(async () => {
+        capture.trigger.error(new TypeError("Failed to fetch"));
+      });
+
+      await waitFor(() => {
+        expect(useChatStore.getState().isStreaming).toBe(false);
+      });
+      expect(useChatStore.getState().abortFn).toBeNull();
+      expect(useChatStore.getState().streamingMessageId).toBeNull();
+
+      const assistant = useChatStore.getState().messagesById[streamingId!];
+      expect(assistant?.error).toBe(
+        "Connection lost. Check your network and try again."
+      );
+      // refreshHistory is only called from onComplete, which never fired.
+      expect(refreshHistory).not.toHaveBeenCalled();
+    });
+
+    it("non-network, non-abort error: stamps the raw error.message on the assistant message", async () => {
+      const capture = installCapturingStreamMock();
+      const refreshHistory = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ activeChatId: "42", input: "Will fail with server error" });
+
+      const { result } = renderHook(() => useSendMessage(7, refreshHistory));
+
+      await act(async () => {
+        await result.current.handleSend();
+      });
+
+      const streamingId = useChatStore.getState().streamingMessageId;
+
+      await act(async () => {
+        capture.trigger.error(new Error("upstream LLM returned 500"));
+      });
+
+      await waitFor(() => {
+        expect(useChatStore.getState().isStreaming).toBe(false);
+      });
+      const assistant = useChatStore.getState().messagesById[streamingId!];
+      expect(assistant?.error).toBe("upstream LLM returned 500");
+    });
+
+    it("failure rollback: after a non-abort error, sendingRef is reset so a follow-up send is not silently dropped", async () => {
+      const capture = installCapturingStreamMock();
+      const refreshHistory = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ activeChatId: "42", input: "First send will fail" });
+
+      const { result } = renderHook(() => useSendMessage(7, refreshHistory));
+
+      await act(async () => {
+        await result.current.handleSend();
+      });
+      expect(apiMocks.chatStream).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        capture.trigger.error(new Error("boom"));
+      });
+
+      await waitFor(() => {
+        expect(useChatStore.getState().isStreaming).toBe(false);
+      });
+
+      // Now retry — must not be blocked by the previous send's sendingRef.
+      useChatStore.setState({ input: "Second send" });
+      await act(async () => {
+        await result.current.handleSend();
+      });
+      expect(apiMocks.chatStream).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -169,6 +169,85 @@ vi.mock('@/lib/formatters', () => ({
   formatDate: (date: string) => date,
 }));
 
+// Test control for the UploadDropzone mock: the factory installs a global
+// handle so tests can drive the onRejected / onFiles callbacks that the page
+// passes to the dropzone. The mock renders a tiny "test bench" so we can
+// assert whether the real component (and the page-level wiring) is connected.
+const dropzoneTestHandle: {
+  current: {
+    onFiles: ((files: File[]) => void) | null;
+    onRejected: ((names: string[]) => void) | null;
+  };
+} = {
+  current: { onFiles: null, onRejected: null },
+};
+vi.mock('@/components/documents/UploadDropzone', () => ({
+  UploadDropzone: (props: {
+    onFiles: (files: File[]) => void;
+    onRejected: (names: string[]) => void;
+  }) => {
+    dropzoneTestHandle.current.onFiles = props.onFiles;
+    dropzoneTestHandle.current.onRejected = props.onRejected;
+    return (
+      <div data-testid="upload-dropzone-stub">
+        <button
+          type="button"
+          data-testid="dropzone-trigger-rejected"
+          onClick={() =>
+            dropzoneTestHandle.current.onRejected?.(['a.exe (too large)', 'b.xyz (unsupported)'])
+          }
+        >
+          trigger rejected
+        </button>
+        <button
+          type="button"
+          data-testid="dropzone-trigger-rejected-empty"
+          onClick={() => dropzoneTestHandle.current.onRejected?.([])}
+        >
+          trigger rejected empty
+        </button>
+        <button
+          type="button"
+          data-testid="dropzone-trigger-rejected-new"
+          onClick={() => dropzoneTestHandle.current.onRejected?.(['c.txt (too large)'])}
+        >
+          trigger rejected new
+        </button>
+        <button
+          type="button"
+          data-testid="dropzone-trigger-files"
+          onClick={() => dropzoneTestHandle.current.onFiles?.([])}
+        >
+          trigger files
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock('@/components/documents/RejectedFilesBanner', () => ({
+  RejectedFilesBanner: ({ files, onDismiss }: { files: string[]; onDismiss: () => void }) => {
+    if (files.length === 0) return null;
+    return (
+      <div data-testid="rejected-files-banner" role="status" aria-live="polite">
+        <span data-testid="rejected-files-count">
+          {files.length === 1 ? '1 file was rejected' : `${files.length} files were rejected`}
+        </span>
+        <ul data-testid="rejected-files-list">
+          {files.map((file, index) => (
+            <li key={index} data-testid="rejected-files-item">
+              {file}
+            </li>
+          ))}
+        </ul>
+        <button type="button" aria-label="Dismiss rejected files list" onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
+    );
+  },
+}));
+
 // Import component after mocks
 import DocumentsPage from '@/pages/DocumentsPage';
 import { useVaultStore } from '@/stores/useVaultStore';
@@ -856,6 +935,126 @@ describe('DocumentsPage - Drag to Resize Filename Column', () => {
       });
 
       expect(container).toBeTruthy();
+    });
+  });
+
+  describe('Rejected files banner (issue #55)', () => {
+    // Reset the per-component handle so a stale callback from a prior render
+    // can't bleed into the next test.
+    beforeEach(() => {
+      dropzoneTestHandle.current.onFiles = null;
+      dropzoneTestHandle.current.onRejected = null;
+    });
+
+    it('does not render the rejected-files banner when no rejection has occurred', async () => {
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('upload-dropzone-stub')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('rejected-files-banner')).not.toBeInTheDocument();
+    });
+
+    it('renders the rejected-files banner with the rejected file list when the dropzone reports rejections', async () => {
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('upload-dropzone-stub')).toBeInTheDocument();
+      });
+      // The page must have wired up onRejected for the test stub to be functional.
+      expect(dropzoneTestHandle.current.onRejected).toBeTypeOf('function');
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('dropzone-trigger-rejected'));
+      });
+
+      const banner = await screen.findByTestId('rejected-files-banner');
+      expect(banner).toBeInTheDocument();
+      expect(screen.getByTestId('rejected-files-count').textContent).toBe(
+        '2 files were rejected'
+      );
+      const items = screen.getAllByTestId('rejected-files-item');
+      expect(items).toHaveLength(2);
+      expect(items[0]).toHaveTextContent('a.exe (too large)');
+      expect(items[1]).toHaveTextContent('b.xyz (unsupported)');
+    });
+
+    it('clears the rejected-files banner when the dismiss button is clicked', async () => {
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('upload-dropzone-stub')).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('dropzone-trigger-rejected'));
+      });
+      expect(await screen.findByTestId('rejected-files-banner')).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Dismiss rejected files list'));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('rejected-files-banner')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not re-render the rejected-files banner after dismiss unless a new rejection arrives', async () => {
+      await act(async () => {
+        const result = render(<DocumentsPage />);
+        container = result.container;
+        unmount = result.unmount;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('upload-dropzone-stub')).toBeInTheDocument();
+      });
+
+      // 1) Reject two files, banner appears.
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('dropzone-trigger-rejected'));
+      });
+      expect(await screen.findByTestId('rejected-files-banner')).toBeInTheDocument();
+
+      // 2) Dismiss — banner disappears.
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Dismiss rejected files list'));
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('rejected-files-banner')).not.toBeInTheDocument();
+      });
+
+      // 3) Firing onRejected with an empty list must NOT bring the banner back.
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('dropzone-trigger-rejected-empty'));
+      });
+      expect(screen.queryByTestId('rejected-files-banner')).not.toBeInTheDocument();
+
+      // 4) Sanity: a fresh non-empty rejection does re-show the banner with the
+      //    new file list — this proves the dismiss doesn't permanently break
+      //    the wiring.
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('dropzone-trigger-rejected-new'));
+      });
+      const banner = await screen.findByTestId('rejected-files-banner');
+      expect(banner).toBeInTheDocument();
+      expect(screen.getByTestId('rejected-files-count').textContent).toBe(
+        '1 file was rejected'
+      );
+      expect(screen.getByTestId('rejected-files-item')).toHaveTextContent('c.txt (too large)');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds focused error-path coverage for `useSendMessage` (issue #55 remaining work item 1): AbortError clears streaming state without stamping an assistant-message error, network errors stamp the friendly "Connection lost" message, other errors stamp raw `error.message`, `isStreaming` flips to `true` synchronously on send start, and `sendingRef` is rolled back after a failure so retries aren't silently dropped.
- Adds rejected-files dismiss coverage in `DocumentsPage` (issue #55 remaining work item 2): drives the `UploadDropzone` `onRejected` callback, asserts the `RejectedFilesBanner` renders the file list, the dismiss button clears the banner, and the banner does not reappear without a new rejection. `UploadDropzone` and `RejectedFilesBanner` are mocked with thin test stubs that expose the page-level wiring.
- Test-only additions; no production behavior changes.

Closes #55

## Test plan
- [x] `npx vitest run src/hooks/useSendMessage.test.ts src/pages/DocumentsPage.test.tsx` (from `frontend/`) -- 41/41 tests passed (14 in `useSendMessage.test.ts`, 27 in `DocumentsPage.test.tsx`).
- [x] `git diff --check` clean.
- [x] `git status -sb` clean, branch 1 commit ahead of `origin/master`.
- [ ] Broader frontend `npm run typecheck`, `npm run lint -- --max-warnings 0`, full `npm test`, and `npm run build` not run locally in this cron-driven pass; CI will gate these. Scope is test-only additions in two files, but reviewers may re-run locally for full assurance.
- [ ] Backend gates not run -- no backend files touched.

## Review follow-up
- Addresses the two remaining test-coverage gaps explicitly listed in the "Remaining Work" section of issue #55 (round-4 UX deep dive follow-up). No production code changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds focused tests for useSendMessage error paths and the rejected-files dismiss flow on DocumentsPage, completing the remaining coverage in issue #55. Verifies AbortError rolls back streaming state without stamping an error, network errors show "Connection lost", other errors use error.message, isStreaming flips true on send start, sendingRef resets after failure, and the banner stays dismissed until a new rejection; no production code changed.

<sup>Written for commit b358695cc81175f6bb7896491289aaf8ceee6fb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

