### PR TITLE
test(chat): add SourceCitation snippet tooltip boundary tests (issue #43)

### DIFF
--- a/frontend/src/components/chat/SourceCitation.test.tsx
+++ b/frontend/src/components/chat/SourceCitation.test.tsx
@@ -1,0 +1,175 @@
+// frontend/src/components/chat/SourceCitation.test.tsx
+// Regression tests for the snippet tooltip on SourceCitation (issue #43).
+// Covers:
+//   - absence of snippet (undefined, null, empty string) → no tooltip text rendered
+//   - boundary length: exactly 100 chars → no ellipsis
+//   - overflow length: 101+ chars → first 100 chars + Unicode ellipsis
+//   - escaping: HTML-like snippet text renders as literal text, not DOM
+//
+// The Radix-based Tooltip is mocked as a transparent passthrough (matches the
+// pattern in MessageContent.memoization.test.tsx) so the snippet text becomes
+// directly queryable in the rendered DOM, which is what we actually want to
+// assert: did the truncation + conditional render logic do the right thing?
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SourceCitation } from "./SourceCitation";
+import type { Source } from "@/lib/api";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children, asChild: _asChild }: { children: React.ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
+}));
+
+const noop = () => {};
+
+const ELLIPSIS = "\u2026"; // the single-character ellipsis used in SourceCitation.tsx
+
+function makeSource(overrides: Partial<Source> = {}): Source {
+  return {
+    id: "src-1",
+    filename: "report.pdf",
+    ...overrides,
+  };
+}
+
+describe("SourceCitation snippet tooltip (issue #43)", () => {
+  it("does not render any snippet text when source.snippet is undefined", () => {
+    const source = makeSource();
+    expect(source.snippet).toBeUndefined();
+
+    const { container } = render(
+      <SourceCitation source={source} index={0} onClick={noop} />
+    );
+
+    // The trigger button still renders, but no <p> with snippet text.
+    expect(screen.getByRole("button", { name: /Source S1: report\.pdf/ })).toBeInTheDocument();
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("does not render any snippet text when source.snippet is explicitly null", () => {
+    // Cast through unknown to construct a Source with a null snippet on purpose.
+    const source = makeSource({ snippet: null as unknown as string });
+
+    const { container } = render(
+      <SourceCitation source={source} index={0} onClick={noop} />
+    );
+
+    expect(screen.getByRole("button", { name: /Source S1: report\.pdf/ })).toBeInTheDocument();
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("does not render any snippet text when source.snippet is the empty string", () => {
+    // The conditional render uses `source.snippet && ...`, so "" must short-circuit.
+    const source = makeSource({ snippet: "" });
+
+    const { container } = render(
+      <SourceCitation source={source} index={0} onClick={noop} />
+    );
+
+    expect(screen.getByRole("button", { name: /Source S1: report\.pdf/ })).toBeInTheDocument();
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("renders the snippet in full with no ellipsis when it is exactly 100 characters", () => {
+    const exact = "a".repeat(100);
+    const source = makeSource({ snippet: exact });
+
+    render(<SourceCitation source={source} index={0} onClick={noop} />);
+
+    // Full 100-char string is present, no ellipsis appended.
+    const para = screen.getByText(exact);
+    expect(para.tagName.toLowerCase()).toBe("p");
+    expect(para.textContent).toBe(exact);
+    expect(para.textContent).not.toContain(ELLIPSIS);
+  });
+
+  it("renders the snippet in full with no ellipsis when it is exactly 1 character", () => {
+    // Sanity-check the lower boundary, complements the 100-char boundary.
+    const source = makeSource({ snippet: "x" });
+
+    render(<SourceCitation source={source} index={0} onClick={noop} />);
+
+    // The aria-label "Source S1: report.pdf" contains "S1" which is not "x",
+    // so getByText("x", { exact: true }) is unambiguous here.
+    const para = screen.getByText("x");
+    expect(para.tagName.toLowerCase()).toBe("p");
+    expect(para.textContent).toBe("x");
+    expect(para.textContent).not.toContain(ELLIPSIS);
+  });
+
+  it("truncates to the first 100 characters and appends an ellipsis at 101 characters", () => {
+    const exact = "a".repeat(100);
+    const overflow = exact + "Z"; // 101 chars total
+    const source = makeSource({ snippet: overflow });
+
+    render(<SourceCitation source={source} index={0} onClick={noop} />);
+
+    const expected = exact + ELLIPSIS;
+    const para = screen.getByText(expected);
+    expect(para.tagName.toLowerCase()).toBe("p");
+    // The trailing "Z" must NOT appear — only the truncated prefix + ellipsis.
+    expect(para.textContent).toBe(expected);
+    expect(para.textContent?.endsWith("Z")).toBe(false);
+  });
+
+  it("truncates to the first 100 characters and appends an ellipsis for much longer snippets", () => {
+    const overflow = "lorem ipsum ".repeat(200); // ~2400 chars
+    const source = makeSource({ snippet: overflow });
+
+    render(<SourceCitation source={source} index={0} onClick={noop} />);
+
+    const expected = overflow.slice(0, 100) + ELLIPSIS;
+    const para = screen.getByText(expected);
+    expect(para.tagName.toLowerCase()).toBe("p");
+    expect(para.textContent).toBe(expected);
+    // The 101st character ("d" from the second "lorem") must not be present.
+    expect(para.textContent).not.toContain("dolor");
+  });
+
+  it("renders HTML-like snippet text as literal text (escaped), not as a DOM element", () => {
+    // The snippet is rendered as a child of <p>, not via dangerouslySetInnerHTML,
+    // so React's text-node escaping must keep the angle brackets as text.
+    const evil = "<script>alert('xss')</script> & \"quotes\" 'apos'";
+    const source = makeSource({ snippet: evil });
+
+    const { container } = render(
+      <SourceCitation source={source} index={0} onClick={noop} />
+    );
+
+    // The literal string is present as text in the <p>.
+    const para = screen.getByText(evil);
+    expect(para.tagName.toLowerCase()).toBe("p");
+    // No <script> element was ever created from the snippet.
+    expect(container.querySelector("script")).toBeNull();
+    // The angle brackets are encoded as entities in the rendered HTML — proves
+    // the text was escaped rather than parsed as markup. (The exact entity
+    // encoding for ' varies between text nodes and attribute values; we only
+    // care that the dangerous characters were escaped at all.)
+    expect(para.innerHTML).toContain("&lt;script&gt;");
+    expect(para.innerHTML).toContain("&lt;/script&gt;");
+    expect(para.innerHTML).toContain("&amp;");
+  });
+
+  it("the inline variant never renders the snippet (only filename) — guard against future drift", () => {
+    // The inline variant intentionally shows the filename in the tooltip, not
+    // the snippet. We assert that explicitly so a future refactor cannot quietly
+    // start leaking the snippet into the inline tooltip. Note: the inline
+    // variant DOES render a <p> (with the filename), so we can't use absence of
+    // <p> as the signal — we have to look at its text content.
+    const source = makeSource({ snippet: "should-not-appear" });
+
+    render(
+      <SourceCitation source={source} index={0} onClick={noop} variant="inline" />
+    );
+
+    // The snippet text must not appear anywhere in the rendered output.
+    expect(screen.queryByText("should-not-appear")).not.toBeInTheDocument();
+    // The filename does appear (this is what the inline tooltip is for).
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused Vitest coverage for `SourceCitation` snippet tooltip boundary behavior (the last PR #42 review follow-up in #43 still missing a test) — 9/9 tests pass.
- The `strip` variant truncates `source.snippet` to 100 characters and conditionally renders the snippet in a tooltip; tests assert the truncation edge (exactly 100 vs 101+), the no-snippet cases (undefined / null / empty string), escaped-text rendering of HTML-like snippet content, and that the `inline` variant intentionally omits the snippet.
- Uses the established `MessageContent.memoization.test.tsx` pattern of mocking `@/components/ui/tooltip` as a transparent passthrough so the truncation + conditional-render logic is directly assertable in the rendered DOM.

Closes #43

## Test plan
- [x] `git diff --check origin/master..HEAD` -- clean
- [x] `npx vitest run src/components/chat/SourceCitation.test.tsx` (from `frontend/`) -- 1 file, 9/9 tests passed (2.68s)

## Out of scope
- The issue's second item (SourcesPanel duplicate max-width cleanup) was OBE per the repo owner: `SourcesPanel.tsx` no longer exists in the tree, and `SourceCards.tsx` has no duplicate `max-w-*` classes. Confirmed via repo search; no code change warranted.

## Review follow-up
- Addresses the remaining PR #42 review follow-up from #43 by adding the missing `SourceCitation` snippet/tooltip test coverage. No source code changes; test-only diff (+175 lines in 1 file).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Vitest tests for SourceCitation snippet tooltip boundaries to complete issue #43, covering 100-char truncation with ellipsis at 101+, no-snippet cases, HTML escaping, and that the inline variant omits the snippet. Tests mock `@/components/ui/tooltip` as a passthrough for direct DOM assertions; no source changes, tests only.

<sup>Written for commit 1b714d79f1797c07f12452e7f30d8a253bc7db44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

