### PR TITLE
fix(wiki): add UNIQUE(vault_id, claim_text) constraint to wiki_claims table

### DIFF
--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -403,7 +403,8 @@ CREATE TABLE IF NOT EXISTS wiki_claims (
     -- can still record the operator who promoted/reviewed it.
     created_by_kind TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(vault_id, claim_text)
 );
 
 CREATE TABLE IF NOT EXISTS wiki_claim_sources (
@@ -850,6 +851,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_wiki_page_hierarchy_and_versioning(sqlite_path)
     migrate_add_wiki_supporting_tables(sqlite_path)
     migrate_add_wiki_claims_normalized_text(sqlite_path)
+    migrate_add_wiki_claims_unique_claim_text(sqlite_path)
     migrate_assign_orphan_users_to_default_vault(sqlite_path)
 
     # Add partial unique index for duplicate hash detection (HIGH-10)
@@ -1392,7 +1394,8 @@ def migrate_add_wiki_tables(sqlite_path: str) -> None:
                 created_by INTEGER,
                 created_by_kind TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(vault_id, claim_text)
             );
 
             CREATE TABLE IF NOT EXISTS wiki_claim_sources (
@@ -2347,6 +2350,42 @@ def migrate_add_wiki_relations_unique(sqlite_path: str) -> None:
         conn.execute(
             "CREATE UNIQUE INDEX idx_wiki_relations_unique_triple "
             "ON wiki_relations(subject_entity_id, predicate, object_entity_id)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_wiki_claims_unique_claim_text(sqlite_path: str) -> None:
+    """Migration: add UNIQUE constraint on wiki_claims(vault_id, claim_text).
+
+    Deduplicates existing rows first (keeps highest id per vault+claim pair),
+    then creates a unique index.  Idempotent.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        tbl = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='wiki_claims'"
+        ).fetchone()
+        if not tbl:
+            return
+
+        idx = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_wiki_claims_unique_vault_claim'"
+        ).fetchone()
+        if idx:
+            return
+
+        # Remove duplicate rows (keep the latest / highest-id per vault+claim pair)
+        conn.execute(
+            """DELETE FROM wiki_claims WHERE id NOT IN (
+                SELECT MAX(id) FROM wiki_claims
+                GROUP BY vault_id, claim_text
+            )"""
+        )
+        conn.execute(
+            "CREATE UNIQUE INDEX idx_wiki_claims_unique_vault_claim "
+            "ON wiki_claims(vault_id, claim_text)"
         )
         conn.commit()
     finally:

--- a/backend/tests/test_wiki_store.py
+++ b/backend/tests/test_wiki_store.py
@@ -866,3 +866,127 @@ class TestWikiStoreSearchFacetsAndHierarchy(unittest.TestCase):
         self.assertEqual(self.store.get_page(child.id).parent_id, parent.id)
         # Root page has no parent.
         self.assertIsNone(parent.parent_id)
+
+
+class TestWikiClaimsUniqueConstraint(unittest.TestCase):
+    """Regression: wiki_claims UNIQUE(vault_id, claim_text) — issue #112."""
+
+    def setUp(self):
+        self.store, self.conn = _make_store()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_duplicate_claim_raises_integrity_error(self):
+        """Inserting a claim with the same (vault_id, claim_text) raises."""
+        import sqlite3
+
+        self.store.create_claim(
+            vault_id=1, claim_text="The sky is blue", source_type="manual"
+        )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.store.create_claim(
+                vault_id=1, claim_text="The sky is blue", source_type="manual"
+            )
+
+    def test_same_claim_text_different_vault_is_allowed(self):
+        """Same claim_text in different vaults is not a conflict."""
+        self.store.create_claim(
+            vault_id=1, claim_text="Shared fact", source_type="manual"
+        )
+        # vault 2 may not exist in FK terms but the UNIQUE index is on
+        # (vault_id, claim_text), so a different vault_id is fine.
+        self.conn.execute(
+            "INSERT OR IGNORE INTO vaults (id, name) VALUES (2, 'Vault 2')"
+        )
+        self.conn.commit()
+        claim2 = self.store.create_claim(
+            vault_id=2, claim_text="Shared fact", source_type="manual"
+        )
+        self.assertIsNotNone(claim2)
+
+    def test_unique_index_exists_after_migration(self):
+        """The unique index is present after run_migrations."""
+        from app.models.database import run_migrations
+
+        db_path = str(Path(tempfile.mkdtemp()) / "test_unique.db")
+        run_migrations(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        indexes = {
+            r["name"]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        conn.close()
+        self.assertIn("idx_wiki_claims_unique_vault_claim", indexes)
+
+    def test_migration_deduplicates_existing_rows(self):
+        """Migration removes duplicate rows and creates the unique index."""
+        from app.models.database import (
+            migrate_add_wiki_claims_unique_claim_text,
+        )
+
+        db_path = str(Path(tempfile.mkdtemp()) / "test_dedup.db")
+        # Build a minimal legacy schema WITHOUT the UNIQUE constraint to
+        # simulate a database created before this fix.
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            CREATE TABLE vaults (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL
+            );
+            CREATE TABLE wiki_pages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                page_type TEXT NOT NULL DEFAULT 'entity',
+                slug TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'draft',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE wiki_claims (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                vault_id INTEGER NOT NULL,
+                page_id INTEGER REFERENCES wiki_pages(id) ON DELETE SET NULL,
+                claim_text TEXT NOT NULL,
+                source_type TEXT NOT NULL DEFAULT 'manual',
+                status TEXT NOT NULL DEFAULT 'active',
+                confidence REAL DEFAULT 0.0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            INSERT OR IGNORE INTO vaults (id, name) VALUES (1, 'V');
+        """)
+        conn.commit()
+        # Insert duplicate rows (no unique constraint in this legacy schema).
+        conn.execute(
+            "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+            "VALUES (1, 'dup claim', 'manual', 'active')"
+        )
+        conn.execute(
+            "INSERT INTO wiki_claims (vault_id, claim_text, source_type, status) "
+            "VALUES (1, 'dup claim', 'manual', 'active')"
+        )
+        conn.commit()
+        count_before = conn.execute(
+            "SELECT COUNT(*) FROM wiki_claims WHERE claim_text = 'dup claim'"
+        ).fetchone()[0]
+        self.assertEqual(count_before, 2)
+        conn.close()
+
+        # Run the migration — should deduplicate and create the unique index.
+        migrate_add_wiki_claims_unique_claim_text(db_path)
+        conn = sqlite3.connect(db_path)
+        count_after = conn.execute(
+            "SELECT COUNT(*) FROM wiki_claims WHERE claim_text = 'dup claim'"
+        ).fetchone()[0]
+        self.assertEqual(count_after, 1)
+        idx = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name='idx_wiki_claims_unique_vault_claim'"
+        ).fetchone()
+        self.assertIsNotNone(idx)
+        conn.close()


### PR DESCRIPTION
## Summary
- Add `UNIQUE(vault_id, claim_text)` constraint to the `wiki_claims` table to prevent duplicate claims within the same vault.
- Create a migration (`migrate_add_wiki_claims_unique_claim_text`) that deduplicates existing rows (keeping highest-id per vault+claim pair) and creates a unique index (`idx_wiki_claims_unique_vault_claim`). Idempotent.
- Update the schema definition in `migrate_add_wiki_tables` and the `CREATE TABLE` statement to include the constraint for new databases.
- Add comprehensive tests covering: duplicate rejection, cross-vault allowance, index presence after migration, and migration deduplication of pre-existing duplicates.

Closes #112

## Test plan
- [x] `backend/tests/test_wiki_store.py` — 4 new tests in `TestWikiClaimsUniqueConstraint` all pass
- [x] Migration is idempotent (re-running is a no-op)
- [x] Cross-vault same claim_text is allowed
- [x] Deduplication keeps highest-id row

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate wiki claims per vault by enforcing a UNIQUE (vault_id, claim_text) constraint and adding a migration that deduplicates existing data. Schema is updated so new databases include the constraint; cross-vault duplicates remain allowed.

- **Migration**
  - Deduplicates existing rows (keeps highest id per vault+claim pair).
  - Creates unique index `idx_wiki_claims_unique_vault_claim`; idempotent.
  - Adds the constraint to table creation and runs in `run_migrations()`.

<sup>Written for commit 13015fbf53850074b1bec1bb1d0f40ceea1ff4e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

