### PR TITLE
fix(wiki): surface SSE publish failures at WARNING, not DEBUG (#106)

### DIFF
--- a/backend/app/services/wiki_compile_processor.py
+++ b/backend/app/services/wiki_compile_processor.py
@@ -176,7 +176,18 @@ class WikiCompileProcessor:
                 payload["error"] = error
             get_wiki_event_bus().publish(job.vault_id, payload)
         except Exception as exc:  # noqa: BLE001 — fan-out must never fail the loop
-            logger.debug("WikiCompileProcessor: event publish failed: %s", exc)
+            # WARNING (not DEBUG): these are terminal-state events (job
+            # completed/failed) that subscribers expect in real time. A dropped
+            # notification is operationally significant — surface it so the
+            # event is visible to operators, not only at debug verbosity.
+            logger.warning(
+                "WikiCompileProcessor: event publish failed (job_id=%s vault_id=%s event=%s): %s",
+                job.id,
+                job.vault_id,
+                event_type,
+                exc,
+                exc_info=True,
+            )
 
     def _dispatch(self, job) -> dict:
         """Dispatch a job to the appropriate handler. Runs in a thread."""

--- a/backend/tests/test_wiki_compile_processor.py
+++ b/backend/tests/test_wiki_compile_processor.py
@@ -1,10 +1,13 @@
 """Tests for WikiCompileProcessor and the new WikiCompiler job methods."""
 
 import asyncio
+import logging
 import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 
 def _make_env():
@@ -567,6 +570,99 @@ class TestWikiCompileProcessorLifecycle(unittest.IsolatedAsyncioTestCase):
             row = conn.execute("SELECT status FROM wiki_compile_jobs").fetchone()
         # After start+stop, the orphan should have been reset to pending (then possibly processed)
         self.assertNotEqual(dict(row)["status"], "running")
+
+
+# ---------------------------------------------------------------------------
+# Regression for issue #106: SSE _publish_event must log at WARNING (not DEBUG)
+# when event delivery fails. Terminal-state notifications are operationally
+# significant and must not be silently dropped.
+# ---------------------------------------------------------------------------
+
+class TestPublishEventFailureLogging(unittest.TestCase):
+    """Ensure _publish_event surfaces failures at WARNING level (issue #106)."""
+
+    LOGGER_NAME = "app.services.wiki_compile_processor"
+
+    def _make_job(self):
+        return SimpleNamespace(id=42, vault_id=1, trigger_type="manual")
+
+    def _make_proc(self):
+        from unittest.mock import MagicMock
+
+        from app.services.wiki_compile_processor import WikiCompileProcessor
+
+        # _publish_event never touches self._pool, so a sentinel is fine.
+        return WikiCompileProcessor(pool=MagicMock())  # type: ignore[arg-type]
+
+    def test_publish_failure_emits_warning_with_traceback(self):
+        proc = self._make_proc()
+        with patch(
+            "app.services.wiki_events.get_wiki_event_bus",
+            side_effect=RuntimeError("simulated SSE bus failure"),
+        ):
+            with self.assertLogs(self.LOGGER_NAME, level=logging.DEBUG) as cap:
+                proc._publish_event(
+                    self._make_job(),
+                    "job_completed",
+                    result={"page": None, "claims": [], "entities": [], "skipped": False},
+                )
+
+        warnings = [r for r in cap.records if r.levelno >= logging.WARNING]
+        self.assertTrue(
+            warnings,
+            "Expected a WARNING-level log on SSE publish failure, got "
+            f"{[r.levelname for r in cap.records]}",
+        )
+        # Operators need the traceback to diagnose the failure.
+        self.assertTrue(
+            any(r.exc_info for r in warnings),
+            "Expected exc_info on the WARNING record so operators can see the cause",
+        )
+        # Message must include the context that helps an on-call engineer
+        # pinpoint the dropped terminal-state event.
+        msg = warnings[0].getMessage()
+        self.assertIn("event publish failed", msg)
+        self.assertIn("job_id=42", msg)
+        self.assertIn("vault_id=1", msg)
+        self.assertIn("event=job_completed", msg)
+
+    def test_publish_success_does_not_warn(self):
+        from app.services.wiki_events import WikiEventBus
+
+        class _StubBus(WikiEventBus):
+            def publish(self, vault_id, event):  # noqa: D401
+                return None
+
+        proc = self._make_proc()
+        records = []
+
+        class _CapturingHandler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        logger = logging.getLogger(self.LOGGER_NAME)
+        handler = _CapturingHandler(level=logging.WARNING)
+        prev_level = logger.level
+        logger.addHandler(handler)
+        logger.setLevel(logging.WARNING)
+        try:
+            with patch(
+                "app.services.wiki_events.get_wiki_event_bus", return_value=_StubBus()
+            ):
+                proc._publish_event(
+                    self._make_job(),
+                    "job_completed",
+                    result={"page": None, "claims": [], "entities": [], "skipped": False},
+                )
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(prev_level)
+        self.assertEqual(
+            [r for r in records if r.levelno >= logging.WARNING],
+            [],
+            "Expected no WARNING logs on successful publish, got: "
+            f"{[r.getMessage() for r in records]}",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Upgrade `WikiCompileProcessor._publish_event` exception log from `logger.debug` to `logger.warning` with `exc_info=True` so dropped SSE terminal-state events (job_completed / job_failed) are visible to operators at the default INFO level instead of being silently dropped.
- Include `job_id`, `vault_id`, and `event_type` in the log message so on-call engineers can correlate the dropped event with the job row.
- Add `TestPublishEventFailureLogging` regression coverage: one test asserts a WARNING (with `exc_info`) is emitted when the event bus raises (fails on master), and a companion test asserts the happy path stays quiet so the upgrade does not spam logs in normal operation.

Closes #106

## Test plan
- [x] `cd backend && PYTHONPATH=. python3 -m pytest tests/test_wiki_compile_processor.py` — all 69 tests pass (including 2 new `TestPublishEventFailureLogging` cases)
- [x] `cd backend && python3 -m ruff check app/services/wiki_compile_processor.py tests/test_wiki_compile_processor.py` — All checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface SSE publish failures at WARNING with traceback in WikiCompileProcessor._publish_event so dropped terminal events aren’t silent at INFO. The log now includes job_id, vault_id, and event type for quick correlation.

- **Bug Fixes**
  - Added regression tests that assert a WARNING with traceback on publish failure and no warnings on success.

<sup>Written for commit 73babfcf3c34aed361d7624b2f4c093548a55e25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

