### PR TITLE
fix(wiki): retry _reset_job_to_pending on transient DB errors

### DIFF
--- a/backend/app/services/wiki_compile_processor.py
+++ b/backend/app/services/wiki_compile_processor.py
@@ -16,8 +16,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-POLL_INTERVAL = 5  # seconds between polls when queue is empty
-MAX_RETRIES = 3    # max automatic retries before a job is permanently failed
+POLL_INTERVAL = 5        # seconds between polls when queue is empty
+MAX_RETRIES = 3           # max automatic retries before a job is permanently failed
+RESET_RETRY_ATTEMPTS = 3  # attempts to recover a job from 'failed' → 'pending' after a transient DB error
+RESET_RETRY_BASE_DELAY = 0.5  # seconds; doubled per attempt (0.5, 1.0, 2.0)
 
 
 class WikiCompileProcessor:
@@ -102,7 +104,7 @@ class WikiCompileProcessor:
                                 job.id, new_retry_count, MAX_RETRIES, backoff,
                             )
                             await asyncio.sleep(backoff)
-                            await asyncio.to_thread(self._reset_job_to_pending, job.id)
+                            await self._reset_job_to_pending_with_retry(job.id)
                         else:
                             logger.error(
                                 "WikiCompileProcessor: job id=%d permanently failed after %d retries",
@@ -148,6 +150,37 @@ class WikiCompileProcessor:
 
         with self._pool.connection() as conn:
             WikiStore(conn).reset_job_to_pending(job_id)
+
+    async def _reset_job_to_pending_with_retry(self, job_id: int) -> None:
+        """Reset a 'failed' job to 'pending' with bounded retry on transient DB errors.
+
+        A single transient failure (e.g. SQLite 'database is locked') on the original
+        one-shot call would leave the job stuck in 'failed' until manual API retry.
+        This helper retries the reset a few times with short exponential backoff so
+        the auto-retry pipeline self-heals. Non-recoverable failures propagate to the
+        outer poll-loop guard, which logs and continues with the next job.
+        """
+        last_exc: Optional[BaseException] = None
+        for attempt in range(1, RESET_RETRY_ATTEMPTS + 1):
+            try:
+                await asyncio.to_thread(self._reset_job_to_pending, job_id)
+                if attempt > 1:
+                    logger.warning(
+                        "WikiCompileProcessor: job id=%d reset recovered on attempt %d/%d",
+                        job_id, attempt, RESET_RETRY_ATTEMPTS,
+                    )
+                return
+            except Exception as exc:  # noqa: BLE001 — propagate only after final attempt
+                last_exc = exc
+                if attempt < RESET_RETRY_ATTEMPTS:
+                    delay = RESET_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                    logger.warning(
+                        "WikiCompileProcessor: job id=%d reset attempt %d/%d failed: %s; retrying in %.1fs",
+                        job_id, attempt, RESET_RETRY_ATTEMPTS, exc, delay,
+                    )
+                    await asyncio.sleep(delay)
+        assert last_exc is not None
+        raise last_exc
 
     def _publish_event(self, job, event_type: str, *, result: Optional[dict] = None, error: Optional[str] = None) -> None:
         """Fan out a terminal-state event to SSE subscribers for the vault.

--- a/backend/tests/test_wiki_compile_processor.py
+++ b/backend/tests/test_wiki_compile_processor.py
@@ -650,6 +650,143 @@ class TestRetryCountAndCancellation(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Issue 104: _reset_job_to_pending must retry on transient DB errors
+# ---------------------------------------------------------------------------
+
+class TestResetJobToPendingRetry(unittest.IsolatedAsyncioTestCase):
+    """Regression for issue #104: bounded retry on the auto-retry reset path.
+
+    A transient DB error (e.g. SQLite 'database is locked') on the original
+    one-shot reset left the job stranded in 'failed' state until manual API
+    retry. The processor now wraps the reset in a bounded retry with short
+    exponential backoff so the auto-retry pipeline self-heals.
+    """
+
+    async def asyncSetUp(self):
+        from app.models.database import SQLiteConnectionPool, run_migrations
+
+        td = tempfile.mkdtemp()
+        db_path = str(Path(td) / "test.db")
+        run_migrations(db_path)
+        self.pool = SQLiteConnectionPool(db_path, max_size=2)
+        with self.pool.connection() as conn:
+            conn.execute("INSERT OR IGNORE INTO vaults (id, name) VALUES (1, 'T')")
+            conn.commit()
+            from app.services.wiki_store import WikiStore
+            self.store = WikiStore(conn)
+            # Plant a job in the exact state the retry-handler expects: failed,
+            # retry_count < MAX_RETRIES, so the next claim is an auto-retry.
+            self.job = self.store.create_job(vault_id=1, trigger_type="manual")
+            self.store.claim_next_pending_job()
+            self.store.fail_job(self.job.id, "handler exploded")
+
+    async def asyncTearDown(self):
+        self.pool.close_all()
+
+    async def test_transient_failure_is_retried_and_recovers(self):
+        """A single transient error must NOT leave the job stuck in 'failed'."""
+        from app.services.wiki_compile_processor import WikiCompileProcessor
+
+        proc = WikiCompileProcessor(self.pool)
+        real = proc._reset_job_to_pending
+        calls = {"n": 0}
+
+        def flaky(job_id):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return real(job_id)
+
+        proc._reset_job_to_pending = flaky
+        # The helper should retry and ultimately succeed.
+        await proc._reset_job_to_pending_with_retry(self.job.id)
+
+        self.assertEqual(calls["n"], 2, "Reset should have been attempted twice")
+        with self.pool.connection() as conn:
+            row = conn.execute(
+                "SELECT status FROM wiki_compile_jobs WHERE id = ?", (self.job.id,)
+            ).fetchone()
+        self.assertEqual(dict(row)["status"], "pending")
+
+    async def test_two_transient_failures_still_recover(self):
+        """A second transient error is also recovered (succeeds on the 3rd attempt)."""
+        from app.services.wiki_compile_processor import WikiCompileProcessor
+
+        proc = WikiCompileProcessor(self.pool)
+        real = proc._reset_job_to_pending
+        calls = {"n": 0}
+
+        def flaky(job_id):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return real(job_id)
+
+        proc._reset_job_to_pending = flaky
+        await proc._reset_job_to_pending_with_retry(self.job.id)
+
+        self.assertEqual(calls["n"], 3, "Reset should have been attempted three times")
+        with self.pool.connection() as conn:
+            row = conn.execute(
+                "SELECT status FROM wiki_compile_jobs WHERE id = ?", (self.job.id,)
+            ).fetchone()
+        self.assertEqual(dict(row)["status"], "pending")
+
+    async def test_persistent_failure_propagates_after_bounded_attempts(self):
+        """When every attempt fails, the helper must surface the last error.
+
+        The outer poll-loop guard catches and logs it; the job remains in
+        'failed' (which is the correct observable state when the DB is
+        genuinely unreachable).
+        """
+        from app.services.wiki_compile_processor import (
+            RESET_RETRY_ATTEMPTS,
+            WikiCompileProcessor,
+        )
+
+        proc = WikiCompileProcessor(self.pool)
+        calls = {"n": 0}
+
+        def always_fail(job_id):
+            calls["n"] += 1
+            raise sqlite3.OperationalError("database is locked")
+
+        proc._reset_job_to_pending = always_fail
+        with self.assertRaises(sqlite3.OperationalError):
+            await proc._reset_job_to_pending_with_retry(self.job.id)
+
+        self.assertEqual(calls["n"], RESET_RETRY_ATTEMPTS)
+        with self.pool.connection() as conn:
+            row = conn.execute(
+                "SELECT status FROM wiki_compile_jobs WHERE id = ?", (self.job.id,)
+            ).fetchone()
+        # Persistent failure → job stays in 'failed' (same as pre-fix behavior).
+        self.assertEqual(dict(row)["status"], "failed")
+
+    async def test_immediate_success_does_not_retry(self):
+        """Happy path: the first attempt must be enough — no extra calls."""
+        from app.services.wiki_compile_processor import WikiCompileProcessor
+
+        proc = WikiCompileProcessor(self.pool)
+        calls = {"n": 0}
+        real = proc._reset_job_to_pending
+
+        def counting(job_id):
+            calls["n"] += 1
+            return real(job_id)
+
+        proc._reset_job_to_pending = counting
+        await proc._reset_job_to_pending_with_retry(self.job.id)
+
+        self.assertEqual(calls["n"], 1, "Happy path must not trigger retries")
+        with self.pool.connection() as conn:
+            row = conn.execute(
+                "SELECT status FROM wiki_compile_jobs WHERE id = ?", (self.job.id,)
+            ).fetchone()
+        self.assertEqual(dict(row)["status"], "pending")
+
+
+# ---------------------------------------------------------------------------
 # Per-claim citation precision
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Wrap `_reset_job_to_pending` in a bounded retry (3 attempts, 0.5/1.0/2.0s backoff) so the WikiCompileProcessor auto-retry loop self-heals on transient DB contention (e.g. SQLite `database is locked`) instead of leaving the job stuck in `failed` until manual API retry.
- After exhausting attempts the helper re-raises so the outer poll-loop guard logs and continues, preserving pre-fix behavior for genuinely persistent failures.
- Add `TestResetJobToPendingRetry` covering: single transient recovery, two transient recoveries, persistent-failure propagation, and happy-path no-extra-calls.

Closes #104

## Test plan
- [x] `cd backend && python -m pytest tests/test_wiki_compile_processor.py::TestResetJobToPendingRetry -v` -- all new retry cases pass
- [x] `cd backend && python -m pytest tests/test_wiki_compile_processor.py -v` -- full module green, no regressions in pre-existing tests
- [x] `cd backend && python -m py_compile app/services/wiki_compile_processor.py tests/test_wiki_compile_processor.py` -- clean compile
- [x] `cd backend && ruff check app/services/wiki_compile_processor.py tests/test_wiki_compile_processor.py` -- no lint findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the wiki compile auto-retry loop resilient to transient DB errors by retrying job reset to pending, so jobs don’t get stuck in failed on SQLite “database is locked”. Preserves existing behavior for persistent failures. Fixes #104.

- Bug Fixes
  - Wrap `_reset_job_to_pending` with bounded retry (3 attempts, 0.5/1.0/2.0s backoff) and use it in the `WikiCompileProcessor` poll loop.
  - Re-raise after final attempt so the outer guard logs and moves on.
  - Tests cover single/two transient recoveries, persistent failure propagation, and no extra retries on success.

<sup>Written for commit 1e01a4a5c3dde4557feddad4ee79473c01f00901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

