### PR TITLE
fix(wiki-retrieval): relax entity mismatch filter to check claim subject/object and entity aliases

### DIFF
--- a/backend/app/services/wiki_retrieval.py
+++ b/backend/app/services/wiki_retrieval.py
@@ -87,6 +87,10 @@ class WikiEvidence:
     matched_entity: Optional[str] = None
     matched_predicate: Optional[str] = None
     filtered_reason: Optional[str] = None
+    # Internal fields for entity mismatch filtering (issue #102).
+    # Populated by _fts_claim_search; not exposed in to_dict().
+    _claim_subject: Optional[str] = None
+    _claim_object: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -241,6 +245,18 @@ class WikiRetrievalService:
         # 1. Exact entity match
         matched_entities = self._entity_exact_match(conn, entity_candidates, vault_id)
 
+        # Build expanded entity text set for mismatch filtering (issue #102).
+        # The raw entity_candidates (e.g. "AFOMIS") may not appear as a
+        # substring in every valid claim — some claims reference the entity
+        # only through the relation graph.  Include canonical names and
+        # aliases from matched entities so that related claims pass through.
+        _expanded_entity_texts: set[str] = {e.lower() for e in entity_candidates}
+        for ent in matched_entities:
+            _expanded_entity_texts.add(ent.canonical_name.lower())
+            for alias in ent.aliases:
+                if isinstance(alias, str) and alias:
+                    _expanded_entity_texts.add(alias.lower())
+
         # 2. Relation lookup from matched entities
         if matched_entities:
             for entity in matched_entities:
@@ -266,12 +282,22 @@ class WikiRetrievalService:
             fts_claim_results = self._fts_claim_search(conn, normalized_query, vault_id)
             for ev in fts_claim_results:
                 # Entity mismatch filter: if we have explicit entity candidates,
-                # reject claims where none of those entities appear in claim text
-                if entity_candidates:
+                # reject claims where none of the expanded entity texts appear
+                # in claim text.  Uses canonical names + aliases from the
+                # relation graph, not just raw query tokens (issue #102).
+                if _expanded_entity_texts:
                     claim_text_lower = (ev.claim_text or "").lower()
                     page_title_lower = ev.title.lower()
-                    combined = claim_text_lower + " " + page_title_lower
-                    if not any(ent.lower() in combined for ent in entity_candidates):
+                    # Also check claim's structured subject/object fields
+                    # (issue #102) — FTS may match on these even when the
+                    # entity name is absent from claim_text.
+                    claim_subject_lower = (ev._claim_subject or "").lower()
+                    claim_object_lower = (ev._claim_object or "").lower()
+                    combined = (
+                        claim_text_lower + " " + page_title_lower
+                        + " " + claim_subject_lower + " " + claim_object_lower
+                    )
+                    if not any(ent in combined for ent in _expanded_entity_texts):
                         ev.filtered_reason = f"entity_mismatch: {entity_candidates}"
                         filtered_log.append(f"{ev.label_placeholder}:entity_mismatch")
                         continue
@@ -285,9 +311,9 @@ class WikiRetrievalService:
         if normalized_query and len(candidates) < self._fts_page_search_max_candidates:
             fts_page_results = self._fts_page_search(conn, normalized_query, vault_id)
             for ev in fts_page_results:
-                if entity_candidates:
+                if _expanded_entity_texts:
                     title_lower = ev.title.lower()
-                    if not any(ent.lower() in title_lower for ent in entity_candidates):
+                    if not any(ent in title_lower for ent in _expanded_entity_texts):
                         ev.filtered_reason = f"entity_mismatch: {entity_candidates}"
                         filtered_log.append(f"{ev.label_placeholder}:entity_mismatch")
                         continue
@@ -494,6 +520,8 @@ class WikiRetrievalService:
                 freshness=d.get("last_compiled_at"),
                 source_count=source_count,
                 provenance_summary=provenance,
+                _claim_subject=d.get("subject"),
+                _claim_object=d.get("object"),
             ))
         return results
 

--- a/backend/tests/test_wiki_retrieval.py
+++ b/backend/tests/test_wiki_retrieval.py
@@ -487,5 +487,150 @@ class TestWikiRetrievalEndToEnd(unittest.TestCase):
         self.assertEqual(self.service.retrieve("nonexistentword", vault_id=1), [])
 
 
+class TestEntityMismatchFilterExpandedMatch(unittest.TestCase):
+    """Regression test for issue #102: entity mismatch filter over-rejects
+    valid FTS claim results.
+
+    Scenario: query "who is AFOMIS deputy chief?" extracts entity candidate
+    "AFOMIS".  FTS finds a claim whose ``subject`` column is "AFOMIS" and
+    ``claim_text`` mentions "deputy chief" — but the claim_text itself does
+    NOT contain the literal "AFOMIS".  The entity's alias "Air Force Medical
+    Information Systems" appears in the page title.  Before the fix, the
+    claim was rejected because the filter only checked claim_text + title
+    against raw entity candidates.  After the fix, the filter also checks
+    the claim's subject/object fields and uses canonical names + aliases
+    from matched entities.
+    """
+
+    def setUp(self):
+        import tempfile
+        from pathlib import Path
+        from queue import Empty, Queue
+
+        from app.models.database import init_db, run_migrations
+
+        self._tmp = tempfile.mkdtemp()
+        db = str(Path(self._tmp) / "app.db")
+        init_db(db)
+        run_migrations(db)
+
+        class _Pool:
+            def __init__(self, path):
+                self._path = path
+                self._q = Queue(maxsize=5)
+
+            def get_connection(self):
+                try:
+                    return self._q.get_nowait()
+                except Empty:
+                    c = sqlite3.connect(self._path, check_same_thread=False)
+                    c.row_factory = sqlite3.Row
+                    return c
+
+            def release_connection(self, c):
+                try:
+                    self._q.put_nowait(c)
+                except Exception:
+                    c.close()
+
+            def close_all(self):
+                while True:
+                    try:
+                        self._q.get_nowait().close()
+                    except Empty:
+                        break
+
+        self._pool = _Pool(db)
+        self.service = WikiRetrievalService(pool=self._pool)
+
+        conn = sqlite3.connect(db)
+        try:
+            # vault
+            conn.execute(
+                "INSERT INTO vaults (id, name) VALUES (?, ?)",
+                (99, "EntityMismatchTest"),
+            )
+            # entity page
+            conn.execute(
+                "INSERT INTO wiki_pages (id, vault_id, slug, title, page_type, "
+                "markdown, status) VALUES (10, 99, 'afomis', 'AFOMIS', "
+                "'entity', '# AFOMIS', 'verified')"
+            )
+            # AFOMIS entity with an alias
+            conn.execute(
+                "INSERT INTO wiki_entities (id, vault_id, canonical_name, "
+                "entity_type, aliases_json, page_id) VALUES "
+                "(1, 99, 'AFOMIS', 'organization', "
+                "'[\"Air Force Medical Information Systems\"]', 10)"
+            )
+            # claim page — title does NOT contain "AFOMIS"
+            conn.execute(
+                "INSERT INTO wiki_pages (id, vault_id, slug, title, page_type, "
+                "markdown, status) VALUES (11, 99, 'personnel', "
+                "'Personnel Roster', "
+                "'entity', '# Personnel', 'verified')"
+            )
+            # Claim: subject="AFOMIS" (FTS matches this), claim_text has
+            # "deputy chief" but NOT "AFOMIS".
+            conn.execute(
+                "INSERT INTO wiki_claims (id, vault_id, page_id, claim_text, "
+                "subject, predicate, object, "
+                "claim_type, source_type, status, confidence) VALUES "
+                "(20, 99, 11, 'Major General Justin Woods serves as deputy chief.', "
+                "'AFOMIS', 'has_deputy_chief', 'Justin Woods', "
+                "'fact', 'document', 'active', 0.9)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def tearDown(self):
+        import shutil
+
+        self._pool.close_all()
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_fts_claim_passes_when_subject_contains_entity(self):
+        """FTS finds a claim via subject column; the entity mismatch filter
+        must accept it because the claim's subject matches the entity."""
+        results = self.service.retrieve(
+            "who is AFOMIS deputy chief?", vault_id=99
+        )
+        claim_results = [r for r in results if r.claim_id == 20]
+        self.assertTrue(
+            claim_results,
+            "FTS claim should pass entity mismatch filter when claim "
+            "subject matches entity (issue #102)",
+        )
+
+    def test_fts_claim_rejected_when_no_match_at_all(self):
+        """A claim whose text, subject, and object contain none of the
+        entity names/aliases should still be rejected."""
+        conn = self._pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO wiki_claims (id, vault_id, page_id, claim_text, "
+                "subject, predicate, object, "
+                "claim_type, source_type, status, confidence) VALUES "
+                "(21, 99, 11, 'The weather is sunny today.', "
+                "'WeatherService', 'reports', 'sunny', "
+                "'fact', 'document', 'active', 0.7)"
+            )
+            conn.commit()
+        finally:
+            self._pool.release_connection(conn)
+
+        results = self.service.retrieve(
+            "who is AFOMIS deputy chief?", vault_id=99
+        )
+        # Claim 21 should NOT appear
+        claim_21 = [r for r in results if r.claim_id == 21]
+        self.assertEqual(
+            claim_21,
+            [],
+            "unrelated claim should be filtered out by entity mismatch",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- The entity mismatch filter in `_retrieve_sync` rejected FTS claim results when the raw entity candidate (e.g. `AFOMIS`) did not appear as a substring in `claim_text + title`. This over-rejected valid claims whose FTS match came from the claim structured `subject`/`object` columns rather than the free-text body, and claims related to the entity only through the relation graph.
- Fix: (1) build an expanded entity text set from `entity_candidates` + matched entity canonical names + aliases; (2) include the claim `subject` and `object` fields in the combined text checked by the filter. Both the FTS claim filter and the FTS page filter now use the expanded set.

Closes #102

## Test plan

- [x] `backend/tests/test_wiki_retrieval.py` — regression tests: `TestEntityMismatchFilterExpandedMatch` validates that claims found via subject column pass the filter, and that unrelated claims are still rejected
- [x] `ruff check backend/` — no lint errors
- [x] Targeted pytest on affected module passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes over-aggressive entity mismatch filtering in wiki retrieval. Valid FTS results now pass when the entity is matched via subject/object or aliases, reducing false negatives.

- **Bug Fixes**
  - Build an expanded entity text set from candidates + canonical names + aliases.
  - Check claim subject and object in addition to claim_text and title.
  - Apply the expanded set to both FTS claim and FTS page filters.
  - Add regression tests to ensure subject-based matches pass and unrelated claims are rejected.

<sup>Written for commit db2ec5fc3ea20cccc022f1e61de15b1ed091559c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

