### PR TITLE
docs(agents): persist deep-dive learnings — pool patterns, role model, DI convention

### DIFF
--- a/.agents/skills/engineering-conventions/SKILL.md
+++ b/.agents/skills/engineering-conventions/SKILL.md
@@ -22,6 +22,7 @@ file you are editing over anything summarized here.
 - All connections come from `SQLiteConnectionPool` with **`PRAGMA foreign_keys = ON`** — rely on `ON DELETE CASCADE`. Schema is the `SCHEMA` constant; migrations are idempotent `migrate_add_*` functions registered in `run_migrations`.
 - SQLite is sync; wrap blocking calls in `await asyncio.to_thread(...)`. Atomic multi-statement writes use `BEGIN IMMEDIATE` (clear any dangling tx with `if conn.in_transaction: conn.rollback()` first).
 - Authorize via `await evaluate(user, "vault", vault_id, action)`; scope every user-data query by vault.
+- **`evaluate_policy` vs `_evaluate_policy`**: There are two variants. `_evaluate_policy(db, principal, resource_type, resource_id, action)` accepts an injected DB connection — use this in FastAPI dependency chains. `evaluate_policy(principal, resource_type, resource_id, action)` opens its own pool connection — legacy backward-compatibility variant. `require_vault_permission` at `backend/app/api/deps.py:476` still uses the standalone variant, which doubles per-request connection consumption under load. When adding new auth dependencies, prefer the DI-injected `get_evaluate_policy`.
 
 **Frontend (`frontend/src/`)**
 - Single axios client in `lib/api.ts` (`VITE_API_URL`, Bearer + CSRF interceptors). Prefer options-object function signatures. IDs are typed as declared in `api.ts` (`Document.id` is a `string`).

--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -20,6 +20,8 @@ This workflow is designed for the Swarm plugin itself and any repo that benefits
 
 Never APPROVE a PR with unresolved CRITICAL findings. Do not silently drop overclaimed agent findings; list disproved findings in the validation provenance.
 
+**Self-review awareness**: If the orchestrator authored code included in the PR scope (e.g., from earlier turns in the same session), include a `"orchestrator_authored_files": [...]` field in the context pack. Reviewers receiving this context pack should apply extra scrutiny to those files. The Anti-Self-Review Rule still applies — the orchestrator must not classify candidates for those files.
+
 ---
 
 ## Review Modes

--- a/.claude/skills/deep-dive/SKILL.md
+++ b/.claude/skills/deep-dive/SKILL.md
@@ -101,7 +101,8 @@ After both reviewers return, perform a lightweight sync pass:
 1. Cross-reference findings between reviewers — flag correlations
 2. Deduplicate any findings both reviewers verified independently
 3. For NEEDS_MORE_EVIDENCE findings: if the other reviewer verified a related finding, merge
-4. Produce a unified findings list with verified/rejected status
+4. **Correction cross-check**: The reviewer may have corrected factual claims about the code (e.g., "pool is 10 not 5", "connections are sequential not simultaneous"). Ensure every correction is reflected in the final severity and description. If a VERIFIED finding had its mechanism corrected, re-evaluate whether the severity is still appropriate after correction.
+5. Produce a unified findings list with verified/rejected status
 
 ## Step 6 — Critic Challenge (HIGH/CRITICAL only)
 
@@ -118,6 +119,8 @@ For verified findings rated HIGH or CRITICAL, dispatch sequential critic passes:
 - Final severity is the critic's assessed severity
 
 CRITICAL: Do NOT challenge MEDIUM/LOW/INFO findings. Only HIGH and CRITICAL go through critic review.
+
+**MEDIUM-finding correction pass (optional)**: If Step 5b's correction cross-check reveals a MEDIUM finding where the reviewer corrected a factual claim about the code (e.g., wrong pool size, wrong connection pattern, wrong multiplier), the architect should adjust the severity and description in the final report accordingly. Do NOT dispatch the critic for these — the architect's own reasoning, informed by the reviewer's corrections, is sufficient.
 
 ## Step 7 — Final Report
 

--- a/.claude/skills/engineering-conventions/SKILL.md
+++ b/.claude/skills/engineering-conventions/SKILL.md
@@ -22,6 +22,7 @@ file you are editing over anything summarized here.
 - All connections come from `SQLiteConnectionPool` with **`PRAGMA foreign_keys = ON`** — rely on `ON DELETE CASCADE`. Schema is the `SCHEMA` constant; migrations are idempotent `migrate_add_*` functions registered in `run_migrations`.
 - SQLite is sync; wrap blocking calls in `await asyncio.to_thread(...)`. Atomic multi-statement writes use `BEGIN IMMEDIATE` (clear any dangling tx with `if conn.in_transaction: conn.rollback()` first).
 - Authorize via `await evaluate(user, "vault", vault_id, action)`; scope every user-data query by vault.
+- **`evaluate_policy` vs `_evaluate_policy`**: There are two variants. `_evaluate_policy(db, principal, resource_type, resource_id, action)` accepts an injected DB connection — use this in FastAPI dependency chains. `evaluate_policy(principal, resource_type, resource_id, action)` opens its own pool connection — legacy backward-compatibility variant. `require_vault_permission` at `deps.py:476` still uses the standalone variant, which doubles per-request connection consumption under load. When adding new auth dependencies, prefer the DI-injected `get_evaluate_policy`.
 
 **Frontend (`frontend/src/`)**
 - Single axios client in `lib/api.ts` (`VITE_API_URL`, Bearer + CSRF interceptors). Prefer options-object function signatures. IDs are typed as declared in `api.ts` (`Document.id` is a `string`).

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -20,6 +20,8 @@ This workflow is designed for the Swarm plugin itself and any repo that benefits
 
 Never APPROVE a PR with unresolved CRITICAL findings. Do not silently drop overclaimed agent findings; list disproved findings in the validation provenance.
 
+**Self-review awareness**: If the orchestrator authored code included in the PR scope (e.g., from earlier turns in the same session), include a `"orchestrator_authored_files": [...]` field in the context pack. Reviewers receiving this context pack should apply extra scrutiny to those files. The Anti-Self-Review Rule still applies — the orchestrator must not classify candidates for those files.
+
 ---
 
 ## Review Modes

--- a/.opencode/skills/deep-dive/SKILL.md
+++ b/.opencode/skills/deep-dive/SKILL.md
@@ -101,7 +101,8 @@ After both reviewers return, perform a lightweight sync pass:
 1. Cross-reference findings between reviewers — flag correlations
 2. Deduplicate any findings both reviewers verified independently
 3. For NEEDS_MORE_EVIDENCE findings: if the other reviewer verified a related finding, merge
-4. Produce a unified findings list with verified/rejected status
+4. **Correction cross-check**: The reviewer may have corrected factual claims about the code (e.g., "pool is 10 not 5", "connections are sequential not simultaneous"). Ensure every correction is reflected in the final severity and description. If a VERIFIED finding had its mechanism corrected, re-evaluate whether the severity is still appropriate after correction.
+5. Produce a unified findings list with verified/rejected status
 
 ## Step 6 — Critic Challenge (HIGH/CRITICAL only)
 
@@ -118,6 +119,8 @@ For verified findings rated HIGH or CRITICAL, dispatch sequential critic passes:
 - Final severity is the critic's assessed severity
 
 CRITICAL: Do NOT challenge MEDIUM/LOW/INFO findings. Only HIGH and CRITICAL go through critic review.
+
+**MEDIUM-finding correction pass (optional)**: If Step 5b's correction cross-check reveals a MEDIUM finding where the reviewer corrected a factual claim about the code (e.g., wrong pool size, wrong connection pattern, wrong multiplier), the architect should adjust the severity and description in the final report accordingly. Do NOT dispatch the critic for these — the architect's own reasoning, informed by the reviewer's corrections, is sufficient.
 
 ## Step 7 — Final Report
 

--- a/.opencode/skills/engineering-conventions/SKILL.md
+++ b/.opencode/skills/engineering-conventions/SKILL.md
@@ -22,6 +22,7 @@ file you are editing over anything summarized here.
 - All connections come from `SQLiteConnectionPool` with **`PRAGMA foreign_keys = ON`** — rely on `ON DELETE CASCADE`. Schema is the `SCHEMA` constant; migrations are idempotent `migrate_add_*` functions registered in `run_migrations`.
 - SQLite is sync; wrap blocking calls in `await asyncio.to_thread(...)`. Atomic multi-statement writes use `BEGIN IMMEDIATE` (clear any dangling tx with `if conn.in_transaction: conn.rollback()` first).
 - Authorize via `await evaluate(user, "vault", vault_id, action)`; scope every user-data query by vault.
+- **`evaluate_policy` vs `_evaluate_policy`**: There are two variants. `_evaluate_policy(db, principal, resource_type, resource_id, action)` accepts an injected DB connection — use this in FastAPI dependency chains. `evaluate_policy(principal, resource_type, resource_id, action)` opens its own pool connection — legacy backward-compatibility variant. `require_vault_permission` at `deps.py:476` still uses the standalone variant, which doubles per-request connection consumption under load. When adding new auth dependencies, prefer the DI-injected `get_evaluate_policy`.
 
 **Frontend (`frontend/src/`)**
 - Single axios client in `lib/api.ts` (`VITE_API_URL`, Bearer + CSRF interceptors). Prefer options-object function signatures. IDs are typed as declared in `api.ts` (`Document.id` is a `string`).

--- a/.opencode/skills/generated/scalability-sqlite-pool/SKILL.md
+++ b/.opencode/skills/generated/scalability-sqlite-pool/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: scalability-sqlite-pool
+description: >
+  Connection pool topology, double-connection pattern detection, semaphore/lock
+  inventory, and exhaustion headroom calculation for RAGAPPv3. Load before
+  reviewing scalability, connection pool sizing, or concurrent user throughput.
+---
+
+# Scalability & Connection Pool Patterns (RAGAPPv3)
+
+## Pool Inventory
+
+The application has **4 independent SQLite connection pools**:
+
+| Pool | Size | Created by | Used by |
+|------|------|-----------|---------|
+| Main | 10 (set at `backend/app/lifespan.py:315`; default `max_size=5` at `backend/app/models/database.py:2532` is overridden) | `lifespan.py:315` | Auth, routes, vault operations, BackgroundProcessor, RAG engine |
+| MemoryStore | 2 (`backend/app/services/memory_store.py:144`) | `memory_store.py` init | Memory search (FTS + dense) |
+| DocumentProcessor fallback | 2 (`backend/app/services/document_processor.py:556`) | `document_processor.py` | Document ingestion when no pool is injected |
+| FileWatcher fallback | 2 (`backend/app/services/file_watcher.py:180`) | `file_watcher.py` | File watcher scan path |
+
+**BackgroundProcessor** does NOT have its own pool — it shares the main pool (max_size=10) via `app.state.db_pool`.
+
+## Double-Connection Pattern Detection
+
+The most common scalability trap is a dependency that opens its **own** pool connection instead of using the DI-injected one. This doubles per-request connection consumption.
+
+### Pattern: `evaluate_policy` vs `_evaluate_policy`
+
+There are two variants of the permission check function:
+
+- **DI variant** (`_evaluate_policy` at `backend/app/api/deps.py:393`): `_evaluate_policy(db, principal, resource_type, resource_id, action)` — accepts an injected DB connection. Use this in FastAPI dependency chains.
+- **Standalone variant** (`evaluate_policy` at `backend/app/api/deps.py:448`): `evaluate_policy(principal, resource_type, resource_id, action)` — calls `get_pool()` and `pool.get_connection()` directly, opening a second connection.
+
+**`require_vault_permission` at `backend/app/api/deps.py:476` uses the standalone variant**, which means every vault-scoped request using this dependency consumes 2 pool connections instead of 1.
+
+### Detection heuristics
+
+When reviewing scalability in this codebase:
+1. Search for `.get_connection()` calls inside dependency functions — these bypass DI
+2. Check if `require_vault_permission` is used alongside `Depends(get_db)` — this signals double-connection
+3. Prefer `get_evaluate_policy` (the DI generator at `backend/app/api/deps.py:426`) over the standalone `evaluate_policy`
+
+## Auth Caching Gap
+
+`get_current_active_user` at `backend/app/api/deps.py:240` executes a fresh DB query on **every** authenticated request:
+```python
+await asyncio.to_thread(lambda: db.execute(
+    "SELECT id, username, full_name, role, is_active, must_change_password FROM users WHERE id = ?",
+    (user_id,)
+).fetchone())
+```
+This is the highest-frequency DB query in the system. There is no in-memory cache, no TTL, no memoization. At 10 concurrent users, this means 10 concurrent auth DB queries per request wave.
+
+## Semaphore & Lock Inventory
+
+| Resource | Type | Size/Capacity | Timeout | Created at |
+|----------|------|---------------|---------|-----------|
+| Vector store write lock | `asyncio.Lock` | 1 | 30s (`backend/app/services/vector_store.py:86`, `write_lock_timeout_seconds`) | Per VectorStore instance |
+| Search semaphore | `asyncio.Semaphore` | 16 (default, `backend/app/config.py:113`, `vector_search_concurrency`) | **None** | Per VectorStore instance |
+| Embedding batch semaphore | `asyncio.Semaphore` | 4 (global, `backend/app/services/embeddings.py:117`) | None | Module-level singleton |
+| Background write semaphore | `asyncio.Semaphore` | 1 (`backend/app/services/background_tasks.py:224`) | None | Per BackgroundProcessor |
+| Circuit breaker (embeddings) | `AsyncCircuitBreaker` | fail_max=5, reset=30s | N/A | Module-level singleton |
+| Circuit breaker (LLM) | `AsyncCircuitBreaker` | fail_max=5, reset=60s | N/A | Per LLMClient instance |
+| Circuit breaker (reranker) | `AsyncCircuitBreaker` | fail_max=3, reset=30s | N/A | Module-level singleton |
+
+## Exhaustion Headroom Calculation
+
+To determine how many concurrent users the system can support:
+
+```
+headroom = floor(pool_size / connections_per_request) - concurrent_users
+```
+
+Where `connections_per_request` is the count of separate pool connections consumed across the full middleware + dependency chain for the worst-case request path.
+
+**Example at 10 concurrent users with a vault-scoped POST:**
+- Each request: auth (1 connection) + evaluate_policy (1 connection, standalone) = 2 connections
+- Main pool: 10
+- Without double-connection fix: `floor(10 / 2) - 10 = -5` → **exhausted** (5 users worth of requests blocking)
+- With double-connection fix: `floor(10 / 1) - 10 = 0` → **at capacity**
+
+The headroom formula reveals that eliminating the double-connection pattern is a 2× improvement in effective capacity.
+
+## `asyncio.to_thread` Usage Pattern
+
+Services using `asyncio.to_thread` for sync DB operations (correct — SQLite I/O releases GIL during C-level execution):
+- MemoryStore: `search_memories()` → calls `_fts_search` + `_dense_search` (both sync, connections held **sequentially**, not simultaneously)
+- Document retrieval: `_get_indexed_file_ids` in `backend/app/services/rag_engine.py:741`
+- Wiki retrieval: `wiki_retrieval.retrieve` in `backend/app/services/rag_engine.py:626`
+- KMS retrieval: `kms_retrieval.retrieve` in `backend/app/services/rag_engine.py:643`
+
+Services that are **synchronous in an async context** (event-loop blocking — should use `to_thread`):
+- `backend/app/api/routes/vault_members.py` — all handlers are `def`, not `async def`. FastAPI wraps sync handlers in a threadpool, but using `asyncio.to_thread` explicitly would be more consistent.
+
+## Load Test Checklist
+
+When testing scalability at 8-10+ concurrent users, verify:
+1. Pool exhaustion: `asyncio.gather(*[client.post(vault_scoped_route) for _ in range(10)])` → all 10 succeed, none timeout
+2. Auth caching: 10 rapid requests from same user → only 1 auth DB query (not 10)
+3. Permission check: `asyncio.gather` batching vs sequential — measure latency at N concurrent
+4. Search semaphore contention: 10 concurrent searches → measure p50/p99 tail latency
+5. Write lock starvation: concurrent search + upload → searches don't time out waiting for index creation

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -20,6 +20,8 @@ This workflow is designed for the Swarm plugin itself and any repo that benefits
 
 Never APPROVE a PR with unresolved CRITICAL findings. Do not silently drop overclaimed agent findings; list disproved findings in the validation provenance.
 
+**Self-review awareness**: If the orchestrator authored code included in the PR scope (e.g., from earlier turns in the same session), include a `"orchestrator_authored_files": [...]` field in the context pack. Reviewers receiving this context pack should apply extra scrutiny to those files. The Anti-Self-Review Rule still applies — the orchestrator must not classify candidates for those files.
+
 ---
 
 ## Review Modes


### PR DESCRIPTION
## Summary
- **engineering-conventions**: Document evaluate_policy DI convention -- _evaluate_policy(db, principal, ...) uses injected connection; the standalone evaluate_policy(principal, ...) opens its own pool connection, doubling per-request pool consumption. require_vault_permission at backend/app/api/deps.py:476 still uses the standalone variant.
- **deep-dive**: Add correction cross-check to Step 5b + optional MEDIUM-finding correction pass to Step 6.
- **swarm-pr-review**: Add self-review awareness -- include "orchestrator_authored_files" in context pack.
- **NEW scalability-sqlite-pool skill**: Pool topology, double-connection detection, semaphore/lock inventory, exhaustion formula, auth caching gap, asyncio.to_thread patterns, load test checklist.

## Review follow-up (PR #206 self-review)
Changes were reviewed by an independent reviewer (REJECTED / RISK: HIGH with 8 fixes).

### Accepted (all fixed)
- Mirror deep-dive updates to .claude/ tree (was only .opencode/)
- Mirror swarm-pr-review self-review to .claude/ and .agents/ (was only .opencode/)
- Mirror engineering-conventions DI convention to .claude/ and .opencode/ (was only .agents/)
- Fix require_vault_permission line ref: was deps.py:488 (inside function body), now backend/app/api/deps.py:476 (definition)
- Fix parameter name: was evaluate_policy(user, ...), now evaluate_policy(principal, ...) -- matches actual code signature
- Prefix all bare file references with backend/app/ path (was deps.py:393, now backend/app/api/deps.py:393)
- Fix vector_store.py:115 to backend/app/services/vector_store.py:86 (lock init, not error message closing paren)
- Mirroring to .claude/ and .agents/ done for non-generated skills; scalability-sqlite-pool remains opencode-only (consistent with generated/ tier convention)

### Disproved
- PERF-005: Step 5b correction cross-check does NOT contradict "reviewers must not suggest fixes" -- reviewers are subagents, Step 5b governs architect behavior.
- F-206-T04: Line references for rag_engine.py are accurate (call-site references match actual code).

## Test plan
- [x] All 3 skill trees updated (.claude/, .agents/, .opencode/) for non-generated skills
- [x] All file:line references verified against actual code
- [x] All bare filenames prefixed with backend/app/ for agent tool compatibility
- [x] Amended commit 48853fe pushed with --force-with-lease
