### PR TITLE
fix(upload): raise document upload limit to 100mb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -260,7 +260,7 @@ RAG_RELEVANCE_THRESHOLD=0.1
 # FILE UPLOAD SECURITY
 # =============================================================================
 # Maximum file upload size in MB
-MAX_FILE_SIZE_MB=50
+MAX_FILE_SIZE_MB=100
 
 # Allowed file extensions for upload (comma-separated)
 ALLOWED_EXTENSIONS=.txt,.md,.pdf,.docx,.csv,.xls,.xlsx,.json,.sql,.py,.js,.ts,.html,.css,.xml,.yaml,.yml,.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Document upload limit raised to 100 MB**: the backend `max_file_size_mb`
+  default, `.env.example`, `docker-compose.yml` env forwarding, frontend
+  preflight, and schema parser guardrail now allow 100 MB per document upload.
+  Reverse proxies must allow multipart upload overhead, for example with nginx
+  `client_max_body_size 125m;`.
 - **`OLLAMA_EMBEDDING_URL` and `RERANKER_URL` are now overridable in `docker-compose.yml`** via `${VAR:-<bundled default>}`. They were previously hardcoded, so host/`.env` overrides were silently ignored; the bundled defaults are unchanged.
 - **Bare `host:8080` embedding URL now routes to native TEI `/embed`** (previously OpenAI `/v1/embeddings`). This affects only embedding URLs configured with **no path** on port 8080: such URLs previously appended `/v1/embeddings` (OpenAI mode) and now append `/embed` (native TEI mode). Default deployments are unaffected — the shipped `OLLAMA_EMBEDDING_URL` uses an explicit `/v1/embeddings` path, which still selects OpenAI mode. Operators running an OpenAI-compatible embedding server on a bare `:8080` URL should set an explicit `/v1/embeddings` path to keep OpenAI-mode behavior.
 - bcrypt password verification (cost factor 14, ~400ms) now offloaded to dedicated ThreadPoolExecutor(4) via async_verify_password(), preventing event-loop blocking during login and password-change under concurrent load

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1185,7 +1185,7 @@ async def _do_upload(
             if int(content_length) > max_size_bytes:
                 raise HTTPException(
                     status_code=413,
-                    detail=f"File too large. Max size: {settings.max_file_size_mb}MB",
+                    detail=f"File too large. Max size: {settings_dep.max_file_size_mb} MB",
                 )
         except ValueError:
             pass  # Invalid content-length header, will check during streaming
@@ -1248,7 +1248,7 @@ async def _do_upload(
                         temp_file_path.unlink(missing_ok=True)
                     raise HTTPException(
                         status_code=413,
-                        detail=f"File too large. Max size: {settings.max_file_size_mb}MB",
+                        detail=f"File too large. Max size: {settings_dep.max_file_size_mb} MB",
                     )
                 await f.write(chunk)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -475,7 +475,7 @@ class Settings(BaseSettings):
     audit_hmac_key_version: str = "v1"
 
     # Security settings
-    max_file_size_mb: int = 50
+    max_file_size_mb: int = 100
     allowed_extensions: set[str] = {
         ".txt",
         ".md",

--- a/backend/app/services/schema_parser.py
+++ b/backend/app/services/schema_parser.py
@@ -16,8 +16,8 @@ class SchemaParser:
     capturing table names and column definitions.
     """
 
-    # Maximum file size in bytes (50MB)
-    MAX_FILE_SIZE = 50 * 1024 * 1024
+    # Maximum file size in bytes (100MB)
+    MAX_FILE_SIZE = 100 * 1024 * 1024
 
     # Regex pattern to match CREATE TABLE blocks
     # Handles optional VIRTUAL keyword, IF NOT EXISTS, schema prefix, backticks/quotes
@@ -63,7 +63,7 @@ class SchemaParser:
         if file_size > self.MAX_FILE_SIZE:
             raise ValueError(
                 f"File size {file_size} bytes exceeds maximum allowed size "
-                f"of {self.MAX_FILE_SIZE} bytes (50MB)"
+                f"of {self.MAX_FILE_SIZE} bytes (100MB)"
             )
 
         # Read file content with encoding error handling

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -852,8 +852,11 @@ class TestIntegration(unittest.TestCase):
 
         client = TestClient(app)
 
-        # Create content larger than max_file_size_mb
-        large_content = b"x" * (60 * 1024 * 1024)  # 60 MB
+        # Regression F-001: use the configured limit so this remains above
+        # max_file_size_mb after future default changes.
+        from app.config import settings
+
+        large_content = b"x" * ((settings.max_file_size_mb + 1) * 1024 * 1024)
 
         response = client.post(
             "/api/documents/upload?vault_id=1",

--- a/backend/tests/test_upload_limits.py
+++ b/backend/tests/test_upload_limits.py
@@ -1,0 +1,31 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("ADMIN_SECRET_TOKEN", "test-admin-key")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-for-testing-only")
+os.environ.setdefault("USERS_ENABLED", "false")
+
+from app.api.routes.documents import _do_upload
+from app.config import settings
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_content_length_above_100_mb(tmp_path):
+    original_data_dir = settings.data_dir
+    settings.data_dir = tmp_path
+    request = SimpleNamespace(
+        headers={"content-length": str((settings.max_file_size_mb * 1024 * 1024) + 1)}
+    )
+    file = SimpleNamespace(filename="large.txt")
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await _do_upload(request, file, settings, None, None, None, None, 1)
+    finally:
+        settings.data_dir = original_data_dir
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == "File too large. Max size: 100 MB"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS:-127.0.0.1}
       # PRODUCTION: set to your domain, e.g. https://knowledgevault.example.com
       - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS:-http://localhost:5173,http://localhost:3000}
+      - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-100}
       - OLLAMA_EMBEDDING_URL=${OLLAMA_EMBEDDING_URL:-http://harrier-embed:8080/v1/embeddings}
       - OLLAMA_CHAT_URL=${OLLAMA_CHAT_URL:-http://host.docker.internal:11434}
       - INSTANT_CHAT_URL=${INSTANT_CHAT_URL:-http://host.docker.internal:1234}

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -560,6 +560,8 @@ Deploy KnowledgeVault behind a reverse proxy for additional security layers:
 server {
     listen 443 ssl http2;
     server_name knowledgevault.example.com;
+    # Must be larger than MAX_FILE_SIZE_MB to allow multipart overhead.
+    client_max_body_size 125m;
     
     # TLS configuration
     ssl_certificate /etc/ssl/certs/knowledgevault.crt;
@@ -638,6 +640,8 @@ location = /knowledgevault {
 }
 
 location /knowledgevault/ {
+    # Must be larger than MAX_FILE_SIZE_MB to allow multipart overhead.
+    client_max_body_size 125m;
     proxy_pass http://knowledgevault:9090/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/docs/release.md
+++ b/docs/release.md
@@ -682,7 +682,7 @@ groups:
 **Symptoms:** 413 Payload Too Large or 500 Server Error
 
 **Resolution:**
-- Check `max_file_size_mb` setting (default: 50MB)
+- Check `max_file_size_mb` setting (default: 100MB)
 - Verify uploads directory has disk space
 - Check document processor logs for parsing errors
 

--- a/frontend/src/components/documents/UploadDropzone.tsx
+++ b/frontend/src/components/documents/UploadDropzone.tsx
@@ -3,8 +3,7 @@ import { useDropzone, type FileRejection } from "react-dropzone";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Upload, Info } from "lucide-react";
-
-const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+import { MAX_UPLOAD_FILE_SIZE_BYTES, formatUploadSizeLimit } from "@/lib/uploadLimits";
 
 interface UploadDropzoneProps {
   hasSelectedVault: boolean;
@@ -42,7 +41,7 @@ export function UploadDropzone({
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     onDropRejected,
-    maxSize: MAX_FILE_SIZE,
+    maxSize: MAX_UPLOAD_FILE_SIZE_BYTES,
     disabled: !hasSelectedVault || !canWriteActiveVault,
   });
 
@@ -63,7 +62,7 @@ export function UploadDropzone({
         <div className="flex flex-col items-center justify-center text-center">
           <Badge variant="secondary" className="mb-3 gap-1.5 text-xs font-medium">
             <Info className="h-3 w-3" aria-hidden="true" />
-            Max 50 MB
+            Max {formatUploadSizeLimit()}
           </Badge>
           <Upload className="w-12 h-12 text-muted-foreground mb-4" />
           <p className="text-lg font-medium">
@@ -74,7 +73,7 @@ export function UploadDropzone({
                 : "Drag & drop files here, or click to select"}
           </p>
           <p className="text-sm text-muted-foreground mt-1">
-            Supports PDF, DOCX, TXT, MD files (max 50MB each). Uploads continue in background.
+            Supports PDF, DOCX, TXT, MD files (max {formatUploadSizeLimit()} each). Uploads continue in background.
           </p>
         </div>
       </CardContent>

--- a/frontend/src/fixtures/settings.ts
+++ b/frontend/src/fixtures/settings.ts
@@ -60,7 +60,7 @@ export const mockSettings: SettingsResponse = import.meta.env.DEV ? ({
     chat_model: "kv",
     chunk_size_chars: "default",
   },
-  max_file_size_mb: 50,
+  max_file_size_mb: 100,
   allowed_extensions: [".pdf", ".docx", ".md", ".txt", ".html", ".csv", ".json", ".sql"],
   backend_cors_origins: ["http://localhost:5173", "http://localhost:3000"],
 }) : ({} as SettingsResponse);

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -27,4 +27,15 @@ describe("API path configuration", () => {
     expect(API_BASE_URL).toBe("/knowledgevault/api");
     expect(loginRedirectPath()).toBe("/knowledgevault/login");
   });
+
+  it("derives meridian API path from basename when VITE_API_URL is empty", async () => {
+    vi.stubEnv("VITE_API_URL", "");
+    vi.stubEnv("VITE_APP_BASENAME", "/meridian");
+    vi.resetModules();
+
+    const { API_BASE_URL, loginRedirectPath } = await import("./api");
+
+    expect(API_BASE_URL).toBe("/meridian/api");
+    expect(loginRedirectPath()).toBe("/meridian/login");
+  });
 });

--- a/frontend/src/lib/uploadLimits.ts
+++ b/frontend/src/lib/uploadLimits.ts
@@ -1,0 +1,31 @@
+export const MAX_UPLOAD_FILE_SIZE_MB = 100;
+export const MAX_UPLOAD_FILE_SIZE_BYTES = MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024;
+
+export function formatUploadSizeLimit(maxFileSizeMb = MAX_UPLOAD_FILE_SIZE_MB): string {
+  return `${maxFileSizeMb} MB`;
+}
+
+export function uploadSizeExceededMessage(
+  fileName: string,
+  maxFileSizeMb = MAX_UPLOAD_FILE_SIZE_MB
+): string {
+  return `${fileName} is too large. Max size: ${formatUploadSizeLimit(maxFileSizeMb)}.`;
+}
+
+export function isUploadTooLarge(
+  file: File,
+  maxFileSizeBytes = MAX_UPLOAD_FILE_SIZE_BYTES
+): boolean {
+  return file.size > maxFileSizeBytes;
+}
+
+export function normalizeUploadErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : "Upload failed";
+  const status = typeof error === "object" && error !== null
+    ? (error as { status?: number }).status
+    : undefined;
+  if (status === 413 || /request entity too large|payload too large|file too large/i.test(message)) {
+    return `File too large. Max size: ${formatUploadSizeLimit()}.`;
+  }
+  return message;
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -50,6 +50,7 @@ import { FolderTree } from "@/components/documents/FolderTree";
 import { MoveFolderDialog } from "@/components/documents/MoveFolderDialog";
 import { MoveToFolderDialog } from "@/components/documents/MoveToFolderDialog";
 import { ConfirmDialog, type ConfirmDialogState } from "@/components/documents/ConfirmDialog";
+import { isUploadTooLarge, uploadSizeExceededMessage } from "@/lib/uploadLimits";
 
 const FILENAME_COL_WIDTH_KEY = "ragapp_doc_table_filename_col";
 const FILENAME_COL_WIDTH_DEFAULT = 250;
@@ -389,9 +390,18 @@ export default function DocumentsPage() {
         toast.error("Select a vault with write access before uploading");
         return;
       }
-      addUploads(acceptedFiles, activeVaultId ?? undefined);
-      setRejectedFiles([]);
-      toast.success(`Added ${acceptedFiles.length} file(s) to upload queue`);
+      const oversizedFiles = acceptedFiles.filter(isUploadTooLarge);
+      if (oversizedFiles.length > 0) {
+        const rejected = oversizedFiles.map((file) => uploadSizeExceededMessage(file.name));
+        setRejectedFiles(rejected);
+        rejected.forEach((message) => toast.error(`File rejected: ${message}`));
+      } else {
+        setRejectedFiles([]);
+      }
+      const queueableFiles = acceptedFiles.filter((file) => !isUploadTooLarge(file));
+      if (queueableFiles.length === 0) return;
+      addUploads(queueableFiles, activeVaultId ?? undefined);
+      toast.success(`Added ${queueableFiles.length} file(s) to upload queue`);
     },
     [addUploads, activeVaultId, canWriteActiveVault, hasSelectedVault]
   );

--- a/frontend/src/stores/useUploadStore.test.ts
+++ b/frontend/src/stores/useUploadStore.test.ts
@@ -32,9 +32,17 @@ vi.mock("sonner", () => ({
 }));
 
 import { useUploadStore } from "./useUploadStore";
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from "@/lib/uploadLimits";
+import { toast } from "sonner";
 
 function makeFile(name: string, bytes = 4): File {
   return new File([new Uint8Array(bytes)], name, { type: "text/plain" });
+}
+
+function makeFileWithReportedSize(name: string, bytes: number): File {
+  const file = makeFile(name);
+  Object.defineProperty(file, "size", { value: bytes });
+  return file;
 }
 
 function resetStore() {
@@ -50,6 +58,7 @@ beforeEach(() => {
   resetStore();
   uploadDocumentMock.mockReset();
   getDocumentStatusMock.mockReset();
+  vi.mocked(toast.error).mockClear();
 });
 
 afterEach(() => {
@@ -57,6 +66,35 @@ afterEach(() => {
 });
 
 describe("useUploadStore — async-aware contract", () => {
+  it("rejects files over the 100 MB per-file limit before queueing", () => {
+    useUploadStore.getState().addUploads(
+      [makeFileWithReportedSize("too-large.pdf", MAX_UPLOAD_FILE_SIZE_BYTES + 1)],
+      1
+    );
+
+    expect(useUploadStore.getState().uploads).toEqual([]);
+    expect(uploadDocumentMock).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "too-large.pdf is too large. Max size: 100 MB."
+    );
+  });
+
+  it("normalizes upload 413 errors to the 100 MB per-file limit", async () => {
+    const error = new Error("Request Entity Too Large") as Error & { status: number };
+    error.status = 413;
+    uploadDocumentMock.mockRejectedValue(error);
+
+    useUploadStore.getState().addUploads([makeFile("large.pdf")], 1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    const u = useUploadStore.getState().uploads[0];
+    expect(u.status).toBe("error");
+    expect(u.error).toBe("File too large. Max size: 100 MB.");
+    expect(toast.error).toHaveBeenCalledWith(
+      "Failed to upload large.pdf: File too large. Max size: 100 MB."
+    );
+  });
+
   it("network 100% does NOT mark indexed; status moves to processing and waits for backend", async () => {
     let progressCb: (n: number) => void = () => {};
     uploadDocumentMock.mockImplementation((_file, onProgress) => {

--- a/frontend/src/stores/useUploadStore.ts
+++ b/frontend/src/stores/useUploadStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { uploadDocument, getDocumentStatus } from "@/lib/api";
 import type { DocumentStatusResponse } from "@/lib/api";
+import { isUploadTooLarge, normalizeUploadErrorMessage, uploadSizeExceededMessage } from "@/lib/uploadLimits";
 import { toast } from "sonner";
 
 /**
@@ -196,6 +197,12 @@ export const useUploadStore = create<UploadState>((set, get) => ({
       toast.error("No vault selected. Please select a vault before uploading.");
       return;
     }
+    const acceptedFiles = files.filter((file) => {
+      if (!isUploadTooLarge(file)) return true;
+      toast.error(uploadSizeExceededMessage(file.name));
+      return false;
+    });
+    if (acceptedFiles.length === 0) return;
     const generateId = (f: File) => {
       if (typeof crypto !== "undefined" && crypto.randomUUID) {
         return crypto.randomUUID();
@@ -204,7 +211,7 @@ export const useUploadStore = create<UploadState>((set, get) => ({
     };
 
     const now = Date.now();
-    const newUploads: UploadFile[] = files.map((file) => ({
+    const newUploads: UploadFile[] = acceptedFiles.map((file) => ({
       id: generateId(file),
       file,
       uploadProgress: 0,
@@ -470,7 +477,7 @@ export const useUploadStore = create<UploadState>((set, get) => ({
             }
           }
         } catch (err) {
-          const errorMsg = err instanceof Error ? err.message : "Upload failed";
+          const errorMsg = normalizeUploadErrorMessage(err);
           get().setStatus(pendingUpload.id, "error", errorMsg);
           toast.error(`Failed to upload ${pendingUpload.file.name}: ${errorMsg}`);
         }

--- a/scripts/check_config_contract.py
+++ b/scripts/check_config_contract.py
@@ -7,7 +7,6 @@ import re
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -46,6 +45,37 @@ def backend_cors_default(config_text: str) -> list[str]:
     return re.findall(r'"([^"]+)"', match.group("body"))
 
 
+def backend_int_default(config_text: str, field_name: str) -> str | None:
+    match = re.search(
+        rf"{re.escape(field_name)}:\s*int\s*=\s*(\d+)",
+        config_text,
+    )
+    return match.group(1) if match else None
+
+
+def schema_parser_limit_mb(schema_parser_text: str) -> str | None:
+    match = re.search(
+        r"MAX_FILE_SIZE\s*=\s*(\d+)\s*\*\s*1024\s*\*\s*1024",
+        schema_parser_text,
+    )
+    return match.group(1) if match else None
+
+
+def frontend_upload_limit_mb(upload_limits_text: str) -> str | None:
+    match = re.search(
+        r"MAX_UPLOAD_FILE_SIZE_MB\s*=\s*(\d+)",
+        upload_limits_text,
+    )
+    return match.group(1) if match else None
+
+
+def nginx_client_max_body_sizes_mb(docs_text: str) -> list[int]:
+    return [
+        int(value)
+        for value in re.findall(r"client_max_body_size\s+(\d+)m;", docs_text)
+    ]
+
+
 def contains_all(text: str, needles: list[str]) -> bool:
     return all(needle in text for needle in needles)
 
@@ -59,8 +89,11 @@ def main() -> int:
     root_dockerfile = read("Dockerfile")
     frontend_dockerfile = read("frontend/Dockerfile")
     frontend_api = read("frontend/src/lib/api.ts")
+    frontend_upload_limits = read("frontend/src/lib/uploadLimits.ts")
     frontend_paths = read("frontend/src/lib/paths.ts")
     vite_config = read("frontend/vite.config.ts")
+    schema_parser = read("backend/app/services/schema_parser.py")
+    release_docs = read("docs/release.md")
     docs_text = read("INSTALLATION.md") + "\n" + read("docs/admin-guide.md")
 
     backend_default = backend_cors_default(backend_config)
@@ -81,12 +114,37 @@ def main() -> int:
             f"{compose_cors_default!r} does not match backend default {backend_default!r}"
         )
 
+    upload_default = backend_int_default(backend_config, "max_file_size_mb")
+    if upload_default is None:
+        failures.append("backend/app/config.py max_file_size_mb default could not be parsed")
+    if env_value(env_text, "MAX_FILE_SIZE_MB") != upload_default:
+        failures.append(
+            ".env.example MAX_FILE_SIZE_MB default "
+            f"{env_value(env_text, 'MAX_FILE_SIZE_MB')!r} does not match backend default {upload_default!r}"
+        )
+    if compose_default(compose_text, "MAX_FILE_SIZE_MB") != upload_default:
+        failures.append(
+            "docker-compose.yml MAX_FILE_SIZE_MB default "
+            f"{compose_default(compose_text, 'MAX_FILE_SIZE_MB')!r} does not match backend default {upload_default!r}"
+        )
+    if schema_parser_limit_mb(schema_parser) != upload_default:
+        failures.append(
+            "backend/app/services/schema_parser.py MAX_FILE_SIZE "
+            f"{schema_parser_limit_mb(schema_parser)!r} does not match backend default {upload_default!r}"
+        )
+    if frontend_upload_limit_mb(frontend_upload_limits) != upload_default:
+        failures.append(
+            "frontend/src/lib/uploadLimits.ts MAX_UPLOAD_FILE_SIZE_MB "
+            f"{frontend_upload_limit_mb(frontend_upload_limits)!r} does not match backend default {upload_default!r}"
+        )
+
     required_env = [
         "APP_ROOT_PATH",
         "VITE_APP_BASENAME",
         "VITE_API_URL",
         "FORWARDED_ALLOW_IPS",
         "BACKEND_CORS_ORIGINS",
+        "MAX_FILE_SIZE_MB",
     ]
     for name in required_env:
         if env_value(env_text, name) is None:
@@ -98,6 +156,7 @@ def main() -> int:
         "VITE_API_URL",
         "FORWARDED_ALLOW_IPS",
         "BACKEND_CORS_ORIGINS",
+        "MAX_FILE_SIZE_MB",
     ]
     for name in compose_required:
         if name not in compose_text:
@@ -125,6 +184,21 @@ def main() -> int:
         failures.append(".env.example is missing the coordinated /knowledgevault example")
     if not contains_all(docs_text, prefix_example):
         failures.append("docs are missing the coordinated /knowledgevault example")
+    if upload_default is not None:
+        upload_default_mb = int(upload_default)
+        required_nginx_mb = (upload_default_mb * 125 + 99) // 100
+        nginx_limits = nginx_client_max_body_sizes_mb(docs_text)
+        if not nginx_limits or max(nginx_limits) < required_nginx_mb:
+            failures.append(
+                "docs are missing nginx client_max_body_size guidance "
+                f">= {required_nginx_mb}m for {upload_default_mb} MB uploads"
+            )
+        release_default = f"default: {upload_default_mb}MB"
+        if release_default not in release_docs:
+            failures.append(
+                "docs/release.md troubleshooting default "
+                f"does not mention {release_default!r}"
+            )
 
     for dockerfile_name, dockerfile_text in [
         ("Dockerfile", root_dockerfile),


### PR DESCRIPTION
# PR Body

## Summary
- raise document upload limits from 50 MB to 100 MB across backend defaults, `.env.example`, Docker Compose env forwarding, frontend preflight validation, and parser guardrails
- add frontend rejection and 413 normalization so oversized files fail before queueing when possible and proxy/backend 413s show the 100 MB limit
- document required reverse-proxy `client_max_body_size 125m` and extend config-contract checks to keep the 100 MB contract wired

Fixes #208.

## Test plan
- [x] `git diff --check` -- passed
- [x] `python -m py_compile app\api\routes\documents.py app\config.py app\services\schema_parser.py tests\test_upload_limits.py tests\test_integration.py` -- passed
- [x] `python -m ruff check .` -- passed
- [x] `python -m pytest --tb=short -v tests/test_path_prefix.py tests/test_auth_routes.py tests/test_main_catchall.py tests/test_integration.py::TestIntegration::test_upload_file_too_large tests/test_upload_limits.py` -- passed, 69 tests
- [x] `python scripts\check_config_contract.py` -- passed
- [x] `python scripts\check_pr_scope_drift.py` -- passed
- [x] `npm run typecheck` -- passed
- [x] `npm run lint` -- passed
- [x] `npm test -- src/lib/api.test.ts src/stores/useUploadStore.test.ts` -- passed, 12 tests
- [x] `npm test -- src/tests/ui-performance.test.tsx` -- passed, 12 tests
- [x] `npm run build` -- passed with existing Vite CSS minify and chunk-size warnings
- [ ] `npm test` -- local Windows full-suite run timed out twice in unrelated `src/tests/ui-performance.test.tsx`; that exact file passes by itself, and GitHub Frontend CI was green on the previous head before these backend/docs/script-only follow-up edits.

## Review follow-up

**F-001 - ACCEPTED** (stale oversized integration test)
Updated `test_upload_file_too_large` to build content from `settings.max_file_size_mb + 1` instead of a stale 60 MB literal. Reproduced the failure first (`500 != 413`), then verified the test passes.

**F-002 - ACCEPTED** (backend/frontend 413 format drift)
Changed backend 413 details to `100 MB` spacing and updated the backend upload-limit regression assertion.

**F-003 - DEFERRED** (SchemaParser hardcoded limit)
The hardcoded parser limit pattern pre-existed this PR. This follow-up adds config-contract coverage so `SchemaParser.MAX_FILE_SIZE` must match the backend default; a runtime settings injection refactor is deferred as separate cleanup.

**F-004 - DEFERRED** (frontend hardcoded limit)
The frontend limit was already hardcoded before this PR; this PR extracted it to one module. This follow-up adds config-contract coverage so `MAX_UPLOAD_FILE_SIZE_MB` must match the backend default; wiring uploads to live settings is deferred as separate UX/config work.

**F-005 - ACCEPTED** (stale release docs default)
Updated `docs/release.md` troubleshooting from `50MB` to `100MB` and ratcheted it in `check_config_contract.py`.

**F-006 - ACCEPTED** (missing changelog entry)
Added an `[Unreleased]` changelog entry for the 100 MB upload limit and proxy guidance.

**F-007 - DEFERRED** (upload route rate limit)
Confirmed the upload endpoints do not currently have per-route slowapi decorators, but this is pre-existing rate-limit design work and not introduced by the limit-bump patch. It should be handled in a separate security/config PR with a new setting and focused rate-limit tests.

**F-008 - ACCEPTED** (literal nginx contract check)
Replaced the literal-only nginx check with a parsed `client_max_body_size` threshold and extended the contract check to cover SchemaParser, frontend upload constants, and release docs.

**Rejected:** none.

## Notes
- Email ingestion keeps its separate 50 MB attachment cap because issue #208 is the document upload route.
