### PR TITLE
fix(llm): anchor legacy _lhs / "Thinking Process:" streaming markers to response prefix

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -30,6 +30,10 @@ _THINK_CLOSE_RE = re.compile(r"</think>", re.IGNORECASE)
 # Matches any partial opening sequence — used to decide whether to hold the buffer.
 # Covers: <, <t, <th, <thi, <thin, <think (any case)
 _THINK_PARTIAL_OPEN_RE = re.compile(r"^<[tT]?[hH]?[iI]?[nN]?[kK]?$")
+# Full "Thinking Process:" literal used for the anchored startswith check
+# that distinguishes a real qwen3.5-122b prefix marker from a benign
+# mid-content occurrence (e.g. quoted from a RAG document).
+_THINKING_PROCESS_MARKER = "Thinking Process:"
 
 
 class LLMError(Exception):
@@ -275,7 +279,21 @@ class LLMClient:
         # And two close markers: </think> and _rhs.
         # ``reasoning_content`` deltas are *never* streamed to users; they are
         # treated like any other thinking content and suppressed at the source.
+        #
+        # The ``_in_prefix_region`` flag is True until we yield any
+        # user-visible content. It gates the two bare-substring legacy markers
+        # (``_lhs`` and ``"Thinking Process:"``): these
+        # markers are only valid as a *prefix* of the model response
+        # (Qwen-style models always emit their reasoning up front, before
+        # the actual answer). Once any answer text has been streamed, a
+        # bare ``_lhs`` or ``"Thinking Process:"`` substring appearing in a
+        # later delta is no longer a thinking-block open marker — it is
+        # almost certainly legitimate content (e.g. an identifier like
+        # ``expr_lhs`` or a section title quoted from a RAG document), and
+        # treating it as an open would silently truncate the answer. See
+        # issue #227.
         _thinking_active = False
+        _in_prefix_region = True
         _buffer = ""
         # The bare legacy reasoning markers ("_lhs", "Thinking Process:") are only
         # ever emitted as a prefix to the whole response. Once any real content has
@@ -370,21 +388,21 @@ class LLMClient:
                                         yield pre_think
                                         _content_emitted = True
                                     _thinking_active = True
+                                    _in_prefix_region = False
                                     _buffer = _buffer[think_open_match.end() :]
                                     # Handle inline close in the same buffer
                                     close_match = _THINK_CLOSE_RE.search(_buffer)
                                     if close_match:
                                         _thinking_active = False
                                         _buffer = _buffer[close_match.end() :]
-                                elif _THINK_PARTIAL_OPEN_RE.match(_buffer):
-                                    # Partial "<think" open tag split across chunk
-                                    # boundaries — hold the buffer until the rest
-                                    # of the tag (or divergent content) arrives.
-                                    pass
-                                elif not _content_emitted and _stripped.startswith("_lhs"):
-                                    # Legacy Qwen _lhs/_rhs reasoning marker. Only
-                                    # honored at the very start of the response: a
-                                    # later "_lhs" is genuine answer text.
+                                elif _in_prefix_region and _buffer.lstrip().startswith("_lhs"):
+                                    # Legacy Qwen-style marker. Only valid as a
+                                    # prefix of the model response: once we
+                                    # have streamed any non-thinking answer
+                                    # text, a bare ``_lhs`` substring (e.g.
+                                    # ``expr_lhs``, ``node_lhs``) is just
+                                    # legitimate content and must not be
+                                    # treated as a thinking-block open.
                                     logger.debug(
                                         "Filtering thinking content from model response (_lhs/_rhs pattern)"
                                     )
@@ -393,36 +411,54 @@ class LLMClient:
                                         yield pre_think
                                         _content_emitted = True
                                     _thinking_active = True
+                                    _in_prefix_region = False
                                     _buffer = remainder
                                     if "_rhs" in _buffer:
                                         _, _, after_think = _buffer.partition("_rhs")
                                         _thinking_active = False
                                         _buffer = after_think
-                                elif not _content_emitted and (
-                                    _stripped.startswith("Thinking Process:")
-                                    or "Thinking Process:".startswith(_stripped)
+                                elif _in_prefix_region and (
+                                    _THINKING_PROCESS_MARKER.startswith(_buffer)
+                                    or _buffer.startswith(_THINKING_PROCESS_MARKER)
+                                    or _THINK_PARTIAL_OPEN_RE.match(_buffer)
                                 ):
-                                    # qwen3.5-122b "Thinking Process:" prefix. Only
-                                    # honored before any content is emitted; after
-                                    # that the substring is real answer text.
-                                    if "Thinking Process:" in _buffer:
+                                    # Two related hold-buffer cases, both
+                                    # anchored to the start of the buffer:
+                                    #
+                                    # 1. qwen3.5-122b "Thinking Process:"
+                                    #    prefix — the marker must appear at
+                                    #    the start of the buffer (either as
+                                    #    a full marker or as a partial
+                                    #    prefix still streaming in). A bare
+                                    #    substring match later in the
+                                    #    buffer is treated as legitimate
+                                    #    content. See issue #227.
+                                    #
+                                    # 2. ``<think`` partial prefix — we
+                                    #    hold the buffer while the angle-
+                                    #    bracketed open tag streams in.
+                                    if _THINKING_PROCESS_MARKER in _buffer:
                                         logger.debug(
                                             "Filtering thinking content from model response (Thinking Process pattern)"
                                         )
-                                        pre_marker, _, _ = _buffer.partition("Thinking Process:")
+                                        pre_marker, _, _ = _buffer.partition(
+                                            _THINKING_PROCESS_MARKER
+                                        )
                                         if pre_marker:
                                             yield pre_marker
                                             _content_emitted = True
                                         _thinking_active = True
+                                        _in_prefix_region = False
                                         _buffer = ""
-                                    # else: still accumulating a partial prefix —
-                                    # hold buffer until the full marker arrives or
-                                    # it diverges.
+                                    # else: still accumulating a partial
+                                    # open marker — hold buffer until full
+                                    # marker arrives or it diverges from
+                                    # any prefix.
                                 elif _buffer:
                                     # No opening pattern and no partial-open
                                     # prefix — safe to yield.
                                     yield _buffer
-                                    _content_emitted = True
+                                    _in_prefix_region = False
                                     _buffer = ""
                             else:
                                 # Currently inside a thinking block — look for any
@@ -444,20 +480,27 @@ class LLMClient:
                                 ):
                                     _buffer = _buffer[-256:]
                             # Yield any buffered content when not in thinking
-                            # mode and not holding a partial open marker. The
-                            # "Thinking Process:" prefix is only held before any
-                            # content has been emitted (afterwards it is real text).
+                            # mode and not holding a partial open marker.
+                            # The partial-prefix-holding checks (e.g. for
+                            # ``<think`` or ``Thinking Process:``) only
+                            # apply while we are still in the prefix region
+                            # of the model response; once any non-thinking
+                            # answer text has been streamed, partial
+                            # substrings of those markers are just ordinary
+                            # content and must be yielded. See issue #227.
                             if (
                                 not _thinking_active
                                 and _buffer
                                 and not (
-                                    not _content_emitted
-                                    and "Thinking Process:".startswith(_buffer)
+                                    _in_prefix_region
+                                    and (
+                                        "Thinking Process:".startswith(_buffer)
+                                        or _THINK_PARTIAL_OPEN_RE.match(_buffer)
+                                    )
                                 )
-                                and not _THINK_PARTIAL_OPEN_RE.match(_buffer)
                             ):
                                 yield _buffer
-                                _content_emitted = True
+                                _in_prefix_region = False
                                 _buffer = ""
                     stream_succeeded = True
                 except GeneratorExit:

--- a/backend/tests/test_llm_thinking_suppression.py
+++ b/backend/tests/test_llm_thinking_suppression.py
@@ -147,6 +147,87 @@ class TestStreamingSanitizer(unittest.IsolatedAsyncioTestCase):
         out = await self._stream(deltas)
         self.assertEqual(out.strip(), "final answer")
 
+    async def test_mid_content_lhs_substring_does_not_truncate(self):
+        # Regression for issue #227: a bare "_lhs" substring inside a normal
+        # answer (e.g. an identifier like ``expr_lhs`` quoted from a RAG
+        # document) must not be treated as a thinking-block open marker.
+        # The legacy Qwen _lhs/_rhs pattern is only valid as a *prefix* of
+        # the model response.
+        deltas = [
+            _delta_chunk(content="Here is the expr_lhs = 42; result follows."),
+        ]
+        out = await self._stream(deltas)
+        self.assertEqual(out.strip(), "Here is the expr_lhs = 42; result follows.")
+        self.assertNotIn("</think>", out)
+
+    async def test_mid_content_thinking_process_substring_does_not_truncate(self):
+        # Regression for issue #227: a bare "Thinking Process:" substring
+        # appearing mid-answer (e.g. quoted from a document) must not be
+        # treated as a thinking-block open marker. The qwen3.5-122b style
+        # "Thinking Process:" prefix is only valid at the start of the
+        # model response.
+        deltas = [
+            _delta_chunk(
+                content=(
+                    "Sure. The relevant section is titled "
+                    "\"Thinking Process: a primer\" and the answer is 7."
+                )
+            ),
+        ]
+        out = await self._stream(deltas)
+        self.assertIn("Thinking Process: a primer", out)
+        self.assertIn("the answer is 7", out)
+        self.assertNotIn("</think>", out)
+
+    async def test_fragmented_mid_content_lhs_does_not_truncate(self):
+        # The bug also reproduces when the dangerous substring is split across
+        # chunks: arriving content "Here is the expr_l" + "hs = 42." must
+        # not be treated as a thinking-open. (Note: the streaming code is
+        # expected to hold the buffer until a non-marker char arrives, and
+        # then yield the held text as a legitimate answer.)
+        deltas = [
+            _delta_chunk(content="Here is the expr_l"),
+            _delta_chunk(content="hs = 42; result follows."),
+        ]
+        out = await self._stream(deltas)
+        self.assertEqual(
+            out.strip(), "Here is the expr_lhs = 42; result follows."
+        )
+
+    async def test_lhs_rhs_after_preamble_does_not_truncate(self):
+        # Once any non-thinking text has been streamed, a bare "_lhs" / "_rhs"
+        # substring in later deltas is no longer a valid thinking-block
+        # marker. The first delta here is plain prose, the second delta
+        # contains a Qwen-style "_lhs..._rhs" substring as if it were
+        # part of quoted document content.
+        deltas = [
+            _delta_chunk(content="ok then "),
+            _delta_chunk(content="_lhshidden_rhsclean"),
+        ]
+        out = await self._stream(deltas)
+        # The second delta must NOT be swallowed by the thinking filter.
+        self.assertIn("ok then ", out)
+        self.assertIn("_lhshidden_rhsclean", out)
+
+    async def test_lhs_with_leading_whitespace_is_filtered(self):
+        # A whitespace-prefixed "_lhs" at the start of the response is still a
+        # thinking-block marker (Qwen models emit it as the first content), and
+        # must be filtered. The ``lstrip().startswith("_lhs")`` guard handles
+        # this case safely.
+        deltas = [
+            _delta_chunk(content="\n_lhshidden_rhsvisible"),
+        ]
+        out = await self._stream(deltas)
+        self.assertNotIn("hidden", out)
+        self.assertIn("visible", out)
+
+    async def test_unterminated_lhs_block_does_not_leak(self):
+        # Stream ends inside _lhs... with no _rhs — must suppress the thinking
+        # content (same invariant as the <think> unterminated test below).
+        deltas = [_delta_chunk(content="_lhsnever closed")]
+        out = await self._stream(deltas)
+        self.assertEqual(out, "")
+
     async def test_unterminated_think_block_does_not_leak(self):
         # Stream ends inside <think>... — must not yield any thinking text.
         deltas = [_delta_chunk(content="<think>secret never closed")]


### PR DESCRIPTION
﻿## Summary

- Anchor the legacy Qwen-style `_lhs` / `Thinking Process:` thinking-block markers to the *prefix* of the model response. Once any non-thinking answer text has been streamed, a bare `_lhs` or `Thinking Process:` substring (e.g. an identifier like `expr_lhs` or a section title quoted from a RAG document) is legitimate content, not a thinking-open marker. Closes #227.
- Gate the partial-prefix holding checks (`<think` and `Thinking Process:`) behind the same `_in_prefix_region` flag so fragments of those markers are yielded as ordinary text once the answer has started.
- Add four regression tests in `backend/tests/test_llm_thinking_suppression.py` covering: bare `_lhs` mid-content, bare `Thinking Process:` mid-content, fragmented mid-content `_lhs`, and `_lhs..._rhs` after a non-thinking preamble.

## Test plan

- [x] `python3 -m py_compile backend/app/services/llm_client.py backend/tests/test_llm_thinking_suppression.py` -- OK
- [x] `python3 -m pytest backend/tests/test_llm_thinking_suppression.py -q` -- 12 passed (4 new + 8 pre-existing)
- [ ] Frontend validation not applicable (backend-only change)
- [ ] `npm run build` not applicable (no frontend changes)

## Notes

- Pre-existing Python 3.12 `passlib/crypt` deprecation warning is unrelated to this change.
- Branch is `auto-fix/issue-227-medium-streaming-think-tag-fil` (cron-driven auto-fix prefix; human reviewer decides ready/merge).

## Review follow-up

**F-001 ù ACCEPTED** (defensive hardening ù `_buffer.lstrip().startswith`)
The `_lhs` marker check used `_buffer.startswith("_lhs")` which would fail to match if the buffer had leading whitespace (e.g. `
_lhs...`). Changed to `_buffer.lstrip().startswith("_lhs")` so whitespace-prefixed markers at the start of the prefix region are still correctly filtered. Added `test_lhs_with_leading_whitespace_is_filtered` regression test.

**F-002 ù ACCEPTED** (comment accuracy)
The docstring claimed the prefix-region flag tracks "non-whitespace" content but the code transitions on *any* yield including whitespace-only buffer content. Updated to correctly describe the actual behavior.

**F-003 ù ACCEPTED** (test coverage)
Added `test_unterminated_lhs_block_does_not_leak` ù a regression test for the `_lhs...` unterminated path (same invariant as the existing `<think>` unterminated test). All 14 tests pass.

**cubic-dev-ai P2 ù REJECTED** (intentional design)
The finding claimed clearing `_in_prefix_region` when `<think>` opens can "prematurely stop legacy-prefix suppression." This is not a valid concern: once `<think>` opens, `_thinking_active` handles all content suppression. Legacy markers are only meaningful at the response prefix (before any content), and a `<think>` tag by definition ends the prefix region.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors legacy Qwen-style `_lhs`/`_rhs` and `Thinking Process:` markers to the start of the model response to prevent mid-answer truncation during streaming. Fixes #227.

- **Bug Fixes**
  - Gate `_lhs` and `Thinking Process:` behind an `_in_prefix_region` flag; treat them only as prefix markers and yield later substrings verbatim. Handle leading-whitespace `_lhs` via `_buffer.lstrip().startswith("_lhs")`.
  - Anchor `Thinking Process:` to the buffer start with a prefix check; hold partial `Thinking Process:` and `<think` only while in the prefix. Full `<think>`/`</think>` remain detectable anywhere; entering `<think>` ends the prefix region.
  - Add six regression tests covering mid-content and fragmented `_lhs`, mid-content `Thinking Process:`, `_lhs..._rhs` after a preamble, leading-whitespace `_lhs`, and unterminated `_lhs` blocks.

<sup>Written for commit 26c2ac83ec4e5154e163927b92368f0a9d34b327. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/ragappv3/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




