### PR TITLE
fix(users): add csrf_protect and caller-org scoping to membership PUT routes

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -596,6 +596,7 @@ async def update_user_organizations(
     user_id: int,
     body: UserOrgsUpdateRequest,
     user: dict = Depends(require_role("admin")),
+    _csrf_token: str = Depends(csrf_protect),
 ):
     """Replace user's organization memberships (admin/superadmin only)."""
     pool = get_pool(str(settings.sqlite_path))
@@ -606,6 +607,25 @@ async def update_user_organizations(
         cursor = conn.execute("SELECT id FROM users WHERE id = ?", (user_id,))
         if not cursor.fetchone():
             raise HTTPException(status_code=404, detail="User not found")
+
+        # For non-superadmins, verify caller shares an org with target user
+        # and can only assign orgs they belong to (parity + scope restriction).
+        caller_orgs = None
+        if user.get("role") != "superadmin":
+            cursor = conn.execute(
+                "SELECT org_id FROM org_members WHERE user_id = ?", (user_id,)
+            )
+            target_orgs = {row[0] for row in cursor.fetchall()}
+            caller_id = user.get("id")
+            cursor = conn.execute(
+                "SELECT org_id FROM org_members WHERE user_id = ?", (caller_id,)
+            )
+            caller_orgs = {row[0] for row in cursor.fetchall()}
+            if not target_orgs & caller_orgs:  # intersection
+                raise HTTPException(
+                    status_code=403,
+                    detail="Cannot update organization memberships of users outside your organization",
+                )
 
         memberships = body.resolved_memberships()
         valid_roles = ("admin", "member")
@@ -627,6 +647,16 @@ async def update_user_organizations(
             missing = set(org_ids) - found
             if missing:
                 raise HTTPException(status_code=400, detail=f"Organizations not found: {sorted(missing)}")
+
+        # Non-superadmins can only assign memberships to orgs they belong to
+        if caller_orgs is not None and memberships:
+            assigned_org_ids = {m.org_id for m in memberships}
+            unauthorized = assigned_org_ids - caller_orgs
+            if unauthorized:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Cannot assign to organizations you are not a member of: {sorted(unauthorized)}",
+                )
 
         try:
             # Delete existing memberships (except owner roles to protect org ownership)
@@ -735,6 +765,7 @@ async def update_user_groups(
     user_id: int,
     body: UserGroupsUpdateRequest,
     user: dict = Depends(require_role("admin")),
+    _csrf_token: str = Depends(csrf_protect),
 ):
     """Replace user's group memberships (admin/superadmin only).
 
@@ -749,9 +780,27 @@ async def update_user_groups(
         if not cursor.fetchone():
             raise HTTPException(status_code=404, detail="User not found")
 
+        # For non-superadmins, verify caller shares an org with target user
+        # (parity with get_user_groups and update_user_organizations).
+        if user.get("role") != "superadmin":
+            cursor = conn.execute(
+                "SELECT org_id FROM org_members WHERE user_id = ?", (user_id,)
+            )
+            target_orgs = {row[0] for row in cursor.fetchall()}
+            caller_id = user.get("id")
+            cursor = conn.execute(
+                "SELECT org_id FROM org_members WHERE user_id = ?", (caller_id,)
+            )
+            caller_orgs = {row[0] for row in cursor.fetchall()}
+            if not target_orgs & caller_orgs:  # intersection
+                raise HTTPException(
+                    status_code=403,
+                    detail="Cannot update group memberships of users outside your organization",
+                )
+
         # If group_ids is empty, just delete all memberships and return empty list
         if not body.group_ids:
-            cursor.execute("DELETE FROM group_members WHERE user_id = ?", (user_id,))
+            conn.execute("DELETE FROM group_members WHERE user_id = ?", (user_id,))
             conn.commit()
             return []
 

--- a/backend/tests/test_user_org_roles.py
+++ b/backend/tests/test_user_org_roles.py
@@ -113,6 +113,23 @@ def setup_db(monkeypatch):
         "INSERT INTO organizations (id, name, slug) VALUES (?,?,?)",
         (ORG2_ID, "Org2", "org2"),
     )
+    # Admin must be in both orgs for the caller-org intersection check and
+    # the PF-001 assigned-org validation to pass.
+    conn.execute(
+        "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+        (ORG1_ID, ADMIN_ID, "admin"),
+    )
+    conn.execute(
+        "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+        (ORG2_ID, ADMIN_ID, "admin"),
+    )
+    # Target must share at least one org with the caller for the intersection
+    # check to pass. Use ORG2 (not ORG1) because TestDeleteUserOwnerGuard.test_cannot_delete_org_owner
+    # INSERTs TARGET_ID into ORG1_ID — using ORG2 here avoids a UNIQUE(org_id, user_id) constraint violation.
+    conn.execute(
+        "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+        (ORG2_ID, TARGET_ID, "member"),
+    )
     conn.commit()
     conn.close()
 

--- a/backend/tests/test_users_routes.py
+++ b/backend/tests/test_users_routes.py
@@ -1226,3 +1226,230 @@ class TestGetUserOrganizations(TestUserRoutes):
         )
 
         assert response.status_code == 403
+
+
+class TestUpdateUserOrganizations(TestUserRoutes):
+    """Tests for PUT /users/{user_id}/organizations endpoint.
+
+    Regression coverage for issue #225: a non-superadmin admin must share an
+    org with the target user before reassigning that user's org memberships
+    (parity with the get_user_groups caller-org intersection check).
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_orgs(self):
+        """Seed two organizations; target member starts in org1 only."""
+        cursor = self.conn.execute(
+            "INSERT INTO organizations (name, description) VALUES (?, ?)",
+            ("Test Org 1", "First test organization"),
+        )
+        self.org1_id = cursor.lastrowid
+        cursor = self.conn.execute(
+            "INSERT INTO organizations (name, description) VALUES (?, ?)",
+            ("Test Org 2", "Second test organization"),
+        )
+        self.org2_id = cursor.lastrowid
+        # Target member starts in org1; admin and superadmin belong to no org.
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org1_id, self.member_id, "member"),
+        )
+        self.conn.commit()
+        yield
+
+    def _user_org_ids(self, user_id):
+        cursor = self.conn.execute(
+            "SELECT org_id FROM org_members WHERE user_id = ?", (user_id,)
+        )
+        return {row[0] for row in cursor.fetchall()}
+
+    def test_superadmin_can_update_user_organizations(self):
+        """Superadmin bypasses caller-org scoping and can reassign memberships."""
+        token = get_token(self.superadmin_id, "superadmin", "superadmin")
+        response = self.client.put(
+            f"/users/{self.member_id}/organizations",
+            json={
+                "memberships": [
+                    {"org_id": self.org1_id, "role": "member"},
+                    {"org_id": self.org2_id, "role": "admin"},
+                ]
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        orgs = response.json()["organizations"]
+        by_id = {o["id"]: o["role"] for o in orgs}
+        assert by_id == {self.org1_id: "member", self.org2_id: "admin"}
+        assert self._user_org_ids(self.member_id) == {self.org1_id, self.org2_id}
+
+    def test_admin_outside_target_org_rejected_403(self):
+        """Non-superadmin admin who shares no org with the target gets 403."""
+        # Admin belongs to no org; member is only in org1 -> no intersection.
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.put(
+            f"/users/{self.member_id}/organizations",
+            json={"memberships": [{"org_id": self.org2_id, "role": "member"}]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 403
+        assert "outside your organization" in response.json()["detail"]
+        # No mutation occurred: member still in org1 only.
+        assert self._user_org_ids(self.member_id) == {self.org1_id}
+
+    def test_admin_same_org_can_update_user_organizations(self):
+        """Non-superadmin admin sharing an org with the target may reassign."""
+        # Put the admin in org1 so caller and target now overlap.
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org1_id, self.admin_id, "admin"),
+        )
+        self.conn.commit()
+
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.put(
+            f"/users/{self.member_id}/organizations",
+            json={
+                "memberships": [
+                    {"org_id": self.org1_id, "role": "member"},
+                ]
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        orgs = response.json()["organizations"]
+        by_id = {o["id"]: o["role"] for o in orgs}
+        assert by_id == {self.org1_id: "member"}
+        assert self._user_org_ids(self.member_id) == {self.org1_id}
+
+    def test_admin_cannot_assign_to_org_outside_their_scope(self):
+        """Non-superadmin admin cannot assign target to an org the admin
+        does not belong to, even when they share a different org."""
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org1_id, self.admin_id, "admin"),
+        )
+        self.conn.commit()
+
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.put(
+            f"/users/{self.member_id}/organizations",
+            json={
+                "memberships": [
+                    {"org_id": self.org1_id, "role": "member"},
+                    {"org_id": self.org2_id, "role": "member"},
+                ]
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 403
+        assert "not a member of" in response.json()["detail"]
+        assert self._user_org_ids(self.member_id) == {self.org1_id}
+
+
+class TestUserRoutesCsrfParity:
+    """Every mutating /users route must declare csrf_protect (defense-in-depth).
+
+    Regression for issue #225: the two membership PUT routes were the only
+    mutating routes missing the csrf_protect dependency. Auth is carried by the
+    Authorization header, so this is a consistency/defense-in-depth guard, not
+    an active CSRF vector. Asserting the dependency is wired is the most robust
+    way to lock the parity invariant without reconstructing the double-submit
+    cookie/header flow.
+    """
+
+    MUTATING = {"POST", "PUT", "PATCH", "DELETE"}
+
+    def _has_csrf(self, route) -> bool:
+        from app.security import csrf_protect
+
+        dependant = getattr(route, "dependant", None)
+        if dependant is None:
+            return False
+        stack = list(dependant.dependencies)
+        while stack:
+            dep = stack.pop()
+            if dep.call is csrf_protect:
+                return True
+            stack.extend(dep.dependencies)
+        return False
+
+    def test_all_mutating_user_routes_have_csrf_protect(self):
+        from app.api.routes import users as users_mod
+
+        missing = []
+        for route in users_mod.router.routes:
+            methods = getattr(route, "methods", None) or set()
+            if methods & self.MUTATING and not self._has_csrf(route):
+                path = getattr(route, "path", "?")
+                missing.append(f"{','.join(sorted(methods & self.MUTATING))} {path}")
+        assert not missing, (
+            "Mutating user routes missing csrf_protect: " + ", ".join(missing)
+        )
+
+
+class TestUpdateUserGroupsCallerOrgCheck(TestUserRoutes):
+    """Regression for PF-002: PUT /users/{id}/groups must enforce caller-org
+    intersection for non-superadmins (parity with get_user_groups and
+    update_user_organizations)."""
+
+    @pytest.fixture(autouse=True)
+    def setup_groups(self):
+        """Seed an org, a group, and a target member in that org."""
+        cursor = self.conn.execute(
+            "INSERT INTO organizations (name, description) VALUES (?, ?)",
+            ("PF002 Org", "Test org for groups caller-org check"),
+        )
+        self.org_id = cursor.lastrowid
+        cursor = self.conn.execute(
+            "INSERT INTO groups (org_id, name, description) VALUES (?, ?, ?)",
+            (self.org_id, "PF002 Group", "Test group"),
+        )
+        self.group_id = cursor.lastrowid
+        # Target member is in the org so the existing target-org check passes,
+        # but the admin (caller) is NOT in any org -> intersection fails.
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org_id, self.member_id, "member"),
+        )
+        self.conn.commit()
+        yield
+
+    def test_admin_outside_target_org_cannot_update_groups(self):
+        """Non-superadmin admin who shares no org with target gets 403."""
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": [self.group_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
+        assert "outside your organization" in response.json()["detail"]
+
+    def test_superadmin_can_update_groups_regardless(self):
+        """Superadmin bypasses caller-org scoping."""
+        token = get_token(self.superadmin_id, "superadmin", "superadmin")
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": [self.group_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+    def test_admin_in_same_org_can_update_groups(self):
+        """Non-superadmin admin who shares an org with target gets 200."""
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org_id, self.admin_id, "member"),
+        )
+        self.conn.commit()
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": [self.group_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Adds the missing `csrf_protect` dependency to the two org/group membership PUT routes (`update_user_organizations`, `update_user_groups`), restoring parity with all six sibling mutating routes in `users.py`.
- Ports the caller-org intersection check (already present on `get_user_groups`) into `update_user_organizations`, so a non-superadmin admin can no longer reassign org memberships for a user they share no organization with (403). This is a defense-in-depth / authz-consistency fix — auth is carried by the `Authorization` header, so there is no active CSRF vector, but the inconsistency was flagged in #225.
- Adds assigned-org validation to `update_user_organizations`: non-superadmin admins can only assign memberships to orgs they themselves belong to (403 for out-of-scope assignments).
- Adds caller-org intersection check to `update_user_groups` for full authz parity with `get_user_groups` and `update_user_organizations`.
- Adds regression tests covering all new authz paths.

## Test plan
- [x] `python -m pytest tests/test_users_routes.py -q` -- 68 passed (includes `TestUpdateUserOrganizations`, `TestUserRoutesCsrfParity`, `TestUpdateUserGroupsCallerOrgCheck`)
- [x] `python -m pytest tests/test_groups_membership.py -q` -- 43 passed (no regressions)
- [x] `python -m ruff check app/api/routes/users.py tests/test_users_routes.py` -- All checks passed!
- [x] `python -m py_compile app/api/routes/users.py` -- OK
- [ ] CI (`.github/workflows/ci.yml`) Backend + Quality contracts jobs on this branch

Closes #225

## Review follow-up

Findings from a swarm-pr-review + swarm-pr-feedback cycle. All findings verified against source code on the branch.

**PF-001 — ACCEPTED: Cross-org assignment escalation on `update_user_organizations`**
The caller-org intersection check only validated that the caller shares at least 1 org with the target's *current* memberships, but did not restrict which orgs the caller could *assign*. A same-org admin could reassign the target to arbitrary orgs they don't belong to.
Fix: Added assigned-org validation (`assigned_org_ids` must be a subset of `caller_orgs` for non-superadmins, 403 if violated). Updated `test_admin_same_org_can_update_user_organizations` to assign org1-only; added `test_admin_cannot_assign_to_org_outside_their_scope`.

**PF-002 — ACCEPTED: `update_user_groups` missing caller-org intersection check**
The groups PUT route had no caller-org intersection check (unlike `get_user_groups` and `update_user_organizations`). A non-superadmin admin could reassign any user's group memberships without sharing an org.
Fix: Added caller-org intersection check mirroring the sibling routes. Added `TestUpdateUserGroupsCallerOrgCheck` (3 tests: outside-org 403, superadmin bypass 200, same-org 200). Also fixed `cursor.execute` to `conn.execute` in the empty-group_ids early-return path for robustness.

**PF-003 — REJECTED: "No tests for `update_user_groups`"**
Disproved: `test_groups_membership.py:537` (`TestUpdateUserGroups`, 10 tests) already covers the endpoint comprehensively.

**PF-004 — REJECTED: "Backward-compat regression needs migration"**
Disproved: The behavior change (non-superadmin cross-org to 403) is the explicit intent of issue #225. Documented in the commit message and asserted by tests.

**PF-005 — DEFERRED: IDOR user enumeration via sequential IDs**
Pre-existing, admin-only (behind `require_role("admin")`), low impact — admins already have `list_users` access. Separate issue if warranted.

**PF-006 — DEFERRED: Additional edge-case test coverage for `update_user_organizations`**
Missing tests for empty-memberships, 404 not-found, invalid-role 400, owner-role preservation, duplicate org_id. These are pre-existing behaviors unchanged by this PR. Separate coverage pass if warranted.
