### PR TITLE
fix(wiki): let caller control transaction boundary for stale-claim marking (#108)

### DIFF
--- a/backend/app/api/routes/memories.py
+++ b/backend/app/api/routes/memories.py
@@ -449,9 +449,16 @@ async def update_memory(
             if memory_vault_id is not None:
                 try:
                     from app.services.wiki_store import WikiStore as _WikiStore
+
                     await asyncio.to_thread(
                         lambda: _WikiStore(conn).mark_claims_stale_by_memory(memory_id, memory_vault_id)
                     )
+                    # The mark_claims_stale_by_memory helper no longer commits
+                    # (DD-C009 / #108) so the caller controls the transaction
+                    # boundary. Commit here so the stale markings persist on
+                    # update. Only commit when the helper succeeds to avoid
+                    # persisting partial stale state on mid-loop exceptions.
+                    await asyncio.to_thread(conn.commit)
                 except Exception as _wiki_exc:
                     logger.warning("mark_claims_stale_by_memory(%d) failed: %s", memory_id, _wiki_exc)
 
@@ -525,14 +532,20 @@ async def delete_memory(
         if not await evaluate_policy(user, "vault", memory_vault_id, "admin"):
             raise HTTPException(status_code=403, detail="No admin access to this vault")
 
-    # Mark wiki claims stale before removing the memory record
+    # Mark wiki claims stale before removing the memory record.
+    # Use a savepoint so any partial stale state from a mid-loop exception
+    # is rolled back before the DELETE commits — preventing orphan
+    # lint findings on rows that still exist (DD-C009 / #108).
     if memory_vault_id is not None:
+        await asyncio.to_thread(conn.execute, "SAVEPOINT stale_marking")
         try:
             from app.services.wiki_store import WikiStore as _WikiStore
             await asyncio.to_thread(
                 lambda: _WikiStore(conn).mark_claims_stale_by_memory(memory_id, memory_vault_id)
             )
+            await asyncio.to_thread(conn.execute, "RELEASE SAVEPOINT stale_marking")
         except Exception as _wiki_exc:
+            await asyncio.to_thread(conn.execute, "ROLLBACK TO SAVEPOINT stale_marking")
             logger.warning("mark_claims_stale_by_memory(%d) failed: %s", memory_id, _wiki_exc)
 
     # Delete the memory

--- a/backend/app/services/wiki_store.py
+++ b/backend/app/services/wiki_store.py
@@ -1164,7 +1164,12 @@ class WikiStore:
                 )
                 weak_count += 1
 
-        self._db.commit()
+        # NOTE: do NOT commit here. The caller controls the transaction
+        # boundary so that the stale marking can be made atomic with the
+        # subsequent DELETE of the source row (file/memory). If this method
+        # committed independently and the caller's DELETE later failed and
+        # rolled back, the claim would be marked stale while the source row
+        # still exists, leaving orphan lint findings (DD-C009 / #108).
         return {"stale": stale_count, "weak_provenance": weak_count}
 
     def mark_claims_stale_by_memory(self, memory_id: int, vault_id: int) -> dict:
@@ -1229,7 +1234,10 @@ class WikiStore:
                 )
                 weak_count += 1
 
-        self._db.commit()
+        # NOTE: do NOT commit here. See mark_claims_stale_by_file for the
+        # rationale (DD-C009 / #108). The caller controls the transaction
+        # boundary so the stale marking is atomic with the subsequent
+        # DELETE of the source memory.
         return {"stale": stale_count, "weak_provenance": weak_count}
 
     def update_lint_finding(self, finding_id: int, vault_id: int, status: str) -> Optional[WikiLintFinding]:

--- a/backend/tests/test_wiki_compile_processor.py
+++ b/backend/tests/test_wiki_compile_processor.py
@@ -490,6 +490,60 @@ class TestMarkClaimsStale(unittest.TestCase):
         result = self.store.mark_claims_stale_by_memory(memory_id=7777, vault_id=1)
         self.assertEqual(result, {"stale": 0, "weak_provenance": 0})
 
+    # ------------------------------------------------------------------
+    # DD-C009 / #108 — mark_claims_stale_* must NOT auto-commit. The caller
+    # controls the transaction boundary so the stale marking is atomic with
+    # the subsequent DELETE of the source file/memory. If the method
+    # committed independently and the caller's DELETE later rolled back,
+    # the claim would be marked stale while the source row still exists,
+    # leaving orphan lint findings.
+    # ------------------------------------------------------------------
+
+    def test_mark_claims_stale_by_file_does_not_commit(self):
+        # Set up a sole-source claim tied to file_id=1.
+        self._make_claim_with_file_source()
+        # Count lint findings before, so we can detect any orphan.
+        before = self.conn.execute(
+            "SELECT COUNT(*) FROM wiki_lint_findings WHERE vault_id = 1"
+        ).fetchone()[0]
+        # Call the helper but do NOT commit. With the bug, this would have
+        # already committed, so subsequent rollback would be a no-op and the
+        # stale finding would persist.
+        self.store.mark_claims_stale_by_file(file_id=1, vault_id=1)
+        self.conn.rollback()
+        # Claim must remain active, no orphan finding must have persisted.
+        claim_status = self.conn.execute(
+            "SELECT status FROM wiki_claims WHERE id IN "
+            "(SELECT claim_id FROM wiki_claim_sources WHERE file_id = 1)"
+        ).fetchone()
+        self.assertIsNotNone(claim_status)
+        self.assertNotEqual(dict(claim_status)["status"], "superseded")
+        after = self.conn.execute(
+            "SELECT COUNT(*) FROM wiki_lint_findings WHERE vault_id = 1"
+        ).fetchone()[0]
+        self.assertEqual(after, before)
+
+    def test_mark_claims_stale_by_memory_does_not_commit(self):
+        # Set up a sole-source claim tied to memory_id=42.
+        self._make_claim_with_memory_source(memory_id=42)
+        before = self.conn.execute(
+            "SELECT COUNT(*) FROM wiki_lint_findings WHERE vault_id = 1"
+        ).fetchone()[0]
+        # Call the helper but do NOT commit. Subsequent rollback must
+        # discard both the claim status update and the lint finding.
+        self.store.mark_claims_stale_by_memory(memory_id=42, vault_id=1)
+        self.conn.rollback()
+        claim_status = self.conn.execute(
+            "SELECT status FROM wiki_claims WHERE id IN "
+            "(SELECT claim_id FROM wiki_claim_sources WHERE memory_id = 42)"
+        ).fetchone()
+        self.assertIsNotNone(claim_status)
+        self.assertNotEqual(dict(claim_status)["status"], "superseded")
+        after = self.conn.execute(
+            "SELECT COUNT(*) FROM wiki_lint_findings WHERE vault_id = 1"
+        ).fetchone()[0]
+        self.assertEqual(after, before)
+
 
 # ---------------------------------------------------------------------------
 # WikiCompileProcessor lifecycle


### PR DESCRIPTION
## Summary
- Drop the implicit `self._db.commit()` from `WikiStore.mark_claims_stale_by_file` and `mark_claims_stale_by_memory` so the stale-claim marking is atomic with the caller's DELETE in `documents.py` / `memories.py`. If the DELETE fails and rolls back, the marking rolls back too G�� no more orphan lint findings on rows that still exist (DD-C009, closes #108).
- Update `memories.update_memory` to commit the marking at the end of its own transaction (the helper no longer does it) so the marking still persists when only an update is performed.
- Add regression tests in `backend/tests/test_wiki_compile_processor.py` (`test_mark_claims_stale_by_file_does_not_commit`, `test_mark_claims_stale_by_memory_does_not_commit`) that roll back after calling the helpers and assert no claim is marked stale and no lint finding persists.

Closes #108

## Test plan
- [x] `git diff origin/master..HEAD --stat` -- 3 files, +70/-2 (backend wiki_store.py, memories.py, test_wiki_compile_processor.py)
- [x] `cd backend && python -m pytest backend/tests/test_wiki_compile_processor.py::TestMarkClaimsStale -q` -- new no-commit regression tests pass; existing `TestMarkClaimsStale` cases still pass
- [ ] Full backend pytest suite -- not run locally (CI is source of truth per `AGENTS.md`)
- [ ] Frontend checks -- not applicable, backend-only change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





## Review follow-up

**F-001 -- ACCEPTED** (Partial stale-marking state on commit failure - LOW)
The `conn.commit()` after `mark_claims_stale_by_memory` in `update_memory` was moved inside the try block so it only runs when the helper succeeds. Previously, if `conn.commit()` failed after a successful helper call, the stale marking would roll back while the memory UPDATE (already committed at line 434) persisted. Now any failure (helper or commit) is caught and logged together.

**F-002 -- ACCEPTED** (Partial stale state on mid-loop exception - LOW)
The `delete_memory` path now wraps the `mark_claims_stale_by_memory` call in a SAVEPOINT (`stale_marking`). If the helper raises mid-loop (e.g., after partially updating some claims), the savepoint is rolled back before the DELETE + commit proceeds, preventing orphan lint findings from partial stale state (DD-C009/#108).

