### PR TITLE
refactor(wiki): move evict_expired_memories off search hot path to periodic background task

### DIFF
--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -576,6 +576,13 @@ async def lifespan(app: FastAPI):
 
     asyncio.create_task(_run_memory_backfill())
 
+    # Start periodic memory eviction as a background task so
+    # evict_expired_memories no longer runs on every search_memories call
+    # (issue #263 — moves a DELETE + COMMIT off the RAG query hot path).
+    memory_eviction_task = asyncio.create_task(
+        app.state.memory_store.periodic_eviction_loop()
+    )
+
     # Start LLM keep-alive tasks for both backends to prevent unload on idle.
     keepalive_task_thinking = None
     keepalive_task_instant = None
@@ -605,6 +612,13 @@ async def lifespan(app: FastAPI):
                 await kt
             except asyncio.CancelledError:
                 pass
+    # Cancel the periodic memory eviction background task.
+    if memory_eviction_task:
+        memory_eviction_task.cancel()
+        try:
+            await memory_eviction_task
+        except asyncio.CancelledError:
+            pass
     if app.state.file_watcher:
         await app.state.file_watcher.stop()
     if app.state.background_processor:

--- a/backend/app/services/memory_store.py
+++ b/backend/app/services/memory_store.py
@@ -170,6 +170,32 @@ class MemoryStore:
         finally:
             self.pool.release_connection(conn)
 
+    async def periodic_eviction_loop(self, interval: int = 300) -> None:
+        """Run evict_expired_memories on a fixed interval.
+
+        Designed to be spawned as a background asyncio task at application
+        startup so expired-memory cleanup no longer runs on the search hot
+        path.  Catches and logs its own errors so the loop never silently
+        dies; CancelledError breaks the loop for clean shutdown.
+        """
+        logger.info("Starting periodic memory eviction task (interval: %ds)", interval)
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                removed = await asyncio.to_thread(self.evict_expired_memories)
+                if removed:
+                    logger.info(
+                        "Periodic eviction removed %d expired memories", removed
+                    )
+            except asyncio.CancelledError:
+                logger.info("Periodic memory eviction task cancelled")
+                break
+            except Exception as exc:  # noqa: BLE001 — keep the loop alive
+                logger.warning(
+                    "Periodic memory eviction failed (will retry next cycle): %s",
+                    exc,
+                )
+
     async def _embed_text(self, text: str) -> Optional[List[float]]:
         """Best-effort embed; never raises. Returns None on failure or when
         no embedding service is wired in.
@@ -596,7 +622,6 @@ class MemoryStore:
         otherwise.
         """
         # FTS results — always run.
-        self.evict_expired_memories()
         fts_records = self._fts_search(query, limit, vault_id)
 
         # Dense results — best-effort, run UNFILTERED across the vault.

--- a/backend/tests/test_issue_249_runtime_contracts.py
+++ b/backend/tests/test_issue_249_runtime_contracts.py
@@ -88,9 +88,15 @@ def test_memory_store_filters_and_evicts_expired_memories():
             )
             store.add_memory("fresh fact about retention", importance=0.8)
 
+            # search_memories no longer evicts expired rows inline (issue
+            # #263 moved eviction to a periodic background task), but it
+            # still filters them out of results at read time.
             results = store.search_memories("retention", limit=10)
 
             assert [record.content for record in results] == ["fresh fact about retention"]
+            # Explicit eviction now removes the expired row that search
+            # left behind.
+            assert store.evict_expired_memories() == 1
             assert store.evict_expired_memories() == 0
         finally:
             pool.close_all()

--- a/backend/tests/test_issue_263_eviction_off_hot_path.py
+++ b/backend/tests/test_issue_263_eviction_off_hot_path.py
@@ -1,0 +1,121 @@
+"""Regression tests for issue #263.
+
+Verifies that evict_expired_memories() is no longer called synchronously
+inside search_memories() (the RAG query hot path) and that the periodic
+background eviction loop performs cleanup correctly.
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from app.models.database import SQLiteConnectionPool, init_db, run_migrations
+from app.services.memory_store import MemoryStore
+
+
+@pytest.fixture()
+def memory_store():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "memories.db"
+        init_db(str(db_path))
+        run_migrations(str(db_path))
+        pool = SQLiteConnectionPool(str(db_path), max_size=2)
+        store = MemoryStore(pool=pool)
+        try:
+            yield store
+        finally:
+            pool.close_all()
+
+
+def test_search_memories_does_not_call_eviction(memory_store):
+    """search_memories() must NOT call evict_expired_memories() — that
+    DELETE + COMMIT was moved off the hot path to a periodic background
+    task (issue #263)."""
+    with mock.patch.object(
+        memory_store, "evict_expired_memories", return_value=0
+    ) as patched_evict:
+        memory_store.search_memories("anything", limit=5)
+        patched_evict.assert_not_called()
+
+
+def test_search_memories_still_filters_expired_rows_at_read_time(memory_store):
+    """Even without synchronous eviction, expired memories must not appear
+    in search results because the FTS and dense queries filter on
+    expires_at at read time."""
+    memory_store.add_memory(
+        "expired fact about retention",
+        importance=0.9,
+        expires_at="2000-01-01T00:00:00",
+    )
+    memory_store.add_memory("fresh fact about retention", importance=0.8)
+
+    results = memory_store.search_memories("retention", limit=10)
+    assert [r.content for r in results] == ["fresh fact about retention"]
+
+
+def test_periodic_eviction_loop_removes_expired_rows(memory_store):
+    """The periodic_eviction_loop coroutine should evict expired memories
+    when it wakes up."""
+    memory_store.add_memory(
+        "ephemeral secret",
+        expires_at="2000-01-01T00:00:00",
+    )
+    memory_store.add_memory("permanent record")
+
+    # Drive one iteration of the loop with a tiny interval.  We cancel
+    # after the first eviction cycle completes.
+    async def _drive():
+        task = asyncio.create_task(
+            memory_store.periodic_eviction_loop(interval=0.05)
+        )
+        # Give the loop time to run at least one eviction cycle.
+        await asyncio.sleep(0.15)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_drive())
+
+    # Expired row should be physically gone now.
+    conn = memory_store.pool.get_connection()
+    try:
+        rows = conn.execute("SELECT content FROM memories ORDER BY id").fetchall()
+    finally:
+        memory_store.pool.release_connection(conn)
+    assert [r[0] for r in rows] == ["permanent record"]
+
+
+def test_periodic_eviction_loop_survives_errors(memory_store):
+    """A single failed eviction must not kill the loop — it should log
+    and retry on the next cycle."""
+    call_count = {"n": 0}
+
+    original = memory_store.evict_expired_memories
+
+    def flaky_evict():
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("transient db lock")
+        return original()
+
+    async def _drive():
+        task = asyncio.create_task(
+            memory_store.periodic_eviction_loop(interval=0.01)
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    with mock.patch.object(memory_store, "evict_expired_memories", side_effect=flaky_evict):
+        asyncio.run(_drive())
+
+    # The loop must have survived the first error and called evict again.
+    assert call_count["n"] >= 2


### PR DESCRIPTION
## Summary
- Removed the synchronous `evict_expired_memories()` call from `search_memories()` so a `DELETE` + `COMMIT` no longer runs on every memory-assisted RAG query.
- Added `MemoryStore.periodic_eviction_loop()` (default 300s interval), spawned as an asyncio task at app startup (`lifespan.py`) and cancelled on shutdown. The loop catches and logs its own errors so it never silently dies.
- Functional behaviour is unchanged — expired memories are still filtered at read time by the FTS and dense queries; only the physical cleanup cadence moves from per-query to periodic.

## Test plan
- [x] `ruff check app/services/memory_store.py app/lifespan.py tests/test_issue_263_eviction_off_hot_path.py tests/test_issue_249_runtime_contracts.py` — all checks passed
- [x] `pytest tests/test_issue_263_eviction_off_hot_path.py tests/test_issue_249_runtime_contracts.py -v` — 9 passed (Python 3.11)
- [x] `python scripts/check_config_contract.py` — all checks passed
- [x] `python scripts/check_pr_scope_drift.py` — all checks passed

Closes #263

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

