### PR TITLE
feat(memory): make the periodic eviction interval configurable

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -186,6 +186,10 @@ class Settings(BaseSettings):
     this bounds the Python-side cosine work while giving semantic recall a wide pool.
     For vaults larger than this, the oldest memories fall outside the dense scan; raise
     it (at O(n) CPU cost) if a vault needs deeper recency reach."""
+    memory_eviction_interval_seconds: int = 300
+    """Interval, in seconds, between periodic background sweeps that delete expired
+    memories (rows with a past `expires_at`). Runs off the search hot path (issue #263);
+    see `MemoryStore.periodic_eviction_loop` in memory_store.py."""
     rag_trace_in_response: bool = False
     """When True, RAG queries emit a ``trace`` field in the streaming
     done event with detailed retrieval/generation observability. Default
@@ -778,6 +782,15 @@ class Settings(BaseSettings):
                 "lower values bottleneck concurrent MemoryStore retrieval"
             )
         return v
+
+    @field_validator("memory_eviction_interval_seconds", mode="after")
+    @classmethod
+    def validate_memory_eviction_interval_seconds(cls, v: int) -> int:
+        """Validate memory_eviction_interval_seconds is >= 1.
+
+        0 or negative would make the periodic eviction loop a tight/instant busy loop.
+        """
+        return cls._validate_int_range(v, 1, None, "memory_eviction_interval_seconds")
 
     @field_validator("embedding_concurrent_batches", mode="after")
     @classmethod

--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -580,7 +580,9 @@ async def lifespan(app: FastAPI):
     # evict_expired_memories no longer runs on every search_memories call
     # (issue #263 — moves a DELETE + COMMIT off the RAG query hot path).
     memory_eviction_task = asyncio.create_task(
-        app.state.memory_store.periodic_eviction_loop()
+        app.state.memory_store.periodic_eviction_loop(
+            interval=settings.memory_eviction_interval_seconds
+        )
     )
 
     # Start LLM keep-alive tasks for both backends to prevent unload on idle.

--- a/backend/tests/test_issue_263_eviction_off_hot_path.py
+++ b/backend/tests/test_issue_263_eviction_off_hot_path.py
@@ -6,6 +6,7 @@ background eviction loop performs cleanup correctly.
 """
 
 import asyncio
+import os
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -119,3 +120,30 @@ def test_periodic_eviction_loop_survives_errors(memory_store):
 
     # The loop must have survived the first error and called evict again.
     assert call_count["n"] >= 2
+
+
+def test_lifespan_spawns_eviction_loop_with_configured_interval():
+    """lifespan() must pass settings.memory_eviction_interval_seconds into
+    periodic_eviction_loop() rather than relying on the method's hardcoded
+    default — otherwise the setting would be dead/unwired configuration.
+
+    Reads lifespan.py's source text directly (matches this repo's existing
+    precedent, e.g. test_lifespan_model_assertion.py, for avoiding heavy
+    optional-dependency import issues in restricted CI runners) instead of
+    importing+introspecting the module.
+    """
+    lifespan_path = os.path.join(
+        os.path.dirname(__file__), "..", "app", "lifespan.py"
+    )
+    with open(lifespan_path, "r") as f:
+        source = f.read()
+
+    assert "periodic_eviction_loop(" in source, (
+        "lifespan() must spawn MemoryStore.periodic_eviction_loop via "
+        "asyncio.create_task (issue #263 — eviction must run off the search "
+        "hot path)"
+    )
+    assert "settings.memory_eviction_interval_seconds" in source, (
+        "the eviction interval must be read from settings, not hardcoded, "
+        "so memory_eviction_interval_seconds is not dead configuration"
+    )

--- a/backend/tests/test_memory_store.py
+++ b/backend/tests/test_memory_store.py
@@ -234,6 +234,27 @@ class TestMemoryStore(unittest.TestCase):
                 if _cached is not None:
                     _cached.close_all()
 
+    def test_memory_eviction_interval_seconds_default_is_300(self):
+        """Test that the periodic eviction interval defaults to 300 seconds."""
+        s = Settings()
+        self.assertEqual(s.memory_eviction_interval_seconds, 300)
+
+    def test_memory_eviction_interval_seconds_rejects_zero_and_negative(self):
+        """Test that Settings rejects a non-positive eviction interval (issue #263).
+
+        0 or negative would turn the periodic eviction loop into a tight/instant
+        busy loop instead of a genuine periodic sweep.
+        """
+        with self.assertRaises(pydantic.ValidationError):
+            Settings(memory_eviction_interval_seconds=0)
+        with self.assertRaises(pydantic.ValidationError):
+            Settings(memory_eviction_interval_seconds=-1)
+
+    def test_memory_eviction_interval_seconds_accepts_custom_value(self):
+        """Test that Settings accepts a custom eviction interval."""
+        s = Settings(memory_eviction_interval_seconds=60)
+        self.assertEqual(s.memory_eviction_interval_seconds, 60)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- PR #266 already moved `MemoryStore`'s expired-memory eviction off the RAG
  search hot path onto a periodic background task
  (`MemoryStore.periodic_eviction_loop`, hardcoded `interval=300`), closing
  issue #263 before this PR landed.
- This is a small follow-up: it makes that interval **configurable** via a
  new `settings.memory_eviction_interval_seconds` field (default `300`,
  validated `>= 1`, matching the repo's other `memory_*` settings
  convention) and wires it into the `lifespan.py` startup call instead of
  relying on the method's hardcoded default.
- Adds tests for the new setting/validator and a wiring check proving
  `lifespan()` actually reads `settings.memory_eviction_interval_seconds`
  (not the hardcoded default) — so the setting can't silently become dead
  configuration if the call site regresses.

No functional/behavioral change beyond making the interval tunable; the
core hot-path fix and its test coverage are unchanged from what #266 merged.

## Test plan
- [x] `pytest tests/test_issue_263_eviction_off_hot_path.py tests/test_memory_store.py tests/test_issue_249_runtime_contracts.py -v` -- 36 passed
- [x] `pytest tests/test_memory_hybrid_retrieval.py tests/test_memory_regression.py tests/test_memory_store_pool_adversarial.py tests/test_retrieval_top_k_migration.py tests/test_rag_engine.py -q` -- 66 passed, 1 xfailed (pre-existing)
- [x] `ruff check app/config.py app/lifespan.py tests/test_issue_263_eviction_off_hot_path.py tests/test_memory_store.py` -- all checks passed
- [x] `python scripts/check_config_contract.py` -- all checks passed
- [x] `python scripts/check_pr_scope_drift.py` -- all checks passed

## Review follow-up

Original PR body/commit targeted issue #263 directly, assuming it was still
open. While this branch was in flight, #266 merged an equivalent fix and
closed #263 first. Rebased this branch onto current `master` (which already
contains #266's fix) and reduced scope to only the genuinely additive piece
described above, rather than force-landing a duplicate/competing
implementation.
