### PR TITLE
fix(rag-engine): log actual exception in A/B experiment resolution failure

### DIFF
--- a/backend/app/services/rag_engine.py
+++ b/backend/app/services/rag_engine.py
@@ -443,13 +443,13 @@ class RAGEngine:
                             prompt_version = ab_content  # A/B version label
                 finally:
                     conn.close()
-            except Exception:
+            except Exception as exc:
                 # A/B failures should not crash queries; fall through with
                 # the 3.5 effective version and no A/B metadata.
                 logger.warning(
                     "A/B experiment resolution failed for vault_id=%s: %s",
                     vault_id,
-                    None,
+                    exc,
                 )
 
         return effective_content, ab_experiment_id, ab_variant, prompt_version


### PR DESCRIPTION
## Summary
- Fixed a swallowed-exception logging bug in `RAGEngine`'s A/B experiment resolution: the `except Exception:` clause never bound the caught exception, so `logger.warning(...)` always logged the literal `None` instead of the real error, hiding the actual cause of any A/B resolution failure (DB error, `ABTestingService` bug, `PromptVersionStore` lookup failure, etc).
- Changed `except Exception:` to `except Exception as exc:` and pass `exc` to the warning log instead of `None`.

## Test plan
- [x] `python -m py_compile backend/app/services/rag_engine.py` -- compiles cleanly
- [x] `python -m pytest -k rag_engine -q` (from `backend/`) -- 99 passed, 1 xfailed, 4751 deselected
- [x] Independent reviewer pass (opus `reviewer` agent) -- approved, confirmed diff is surgical (only the two intended lines changed), format-string arity correct, no shadowing issues

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

