### PR TITLE
fix(authz): close role management gaps

### DIFF
--- a/backend/app/api/routes/organizations.py
+++ b/backend/app/api/routes/organizations.py
@@ -6,7 +6,7 @@ import re
 import secrets
 import sqlite3
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
@@ -569,16 +569,33 @@ async def add_org_member(
 # ---------------------------------------------------------------------------
 
 
-def _invite_status(invite_row: tuple) -> str:
+ORG_INVITE_COLUMNS = (
+    "id",
+    "org_id",
+    "email",
+    "token_hash",
+    "role",
+    "expires_at",
+    "created_at",
+    "created_by_user_id",
+    "accepted_at",
+    "accepted_by_user_id",
+    "revoked_at",
+)
+
+
+def _org_invite_row(row: tuple[Any, ...]) -> dict[str, Any]:
+    """Convert a selected org_invites row to named fields without mutating row_factory."""
+    return dict(zip(ORG_INVITE_COLUMNS, row))
+
+
+def _invite_status(invite_row: dict[str, Any]) -> str:
     """Determine invite status from a org_invites row."""
-    # row: id, org_id, email, token_hash, role, expires_at, created_at,
-    #      created_by_user_id, accepted_at, accepted_by_user_id, revoked_at
-    if invite_row[8]:  # accepted_at
+    if invite_row["accepted_at"]:
         return "accepted"
-    if invite_row[10]:  # revoked_at
+    if invite_row["revoked_at"]:
         return "revoked"
-    # Check expiry
-    expires_at = datetime.fromisoformat(invite_row[5])
+    expires_at = datetime.fromisoformat(invite_row["expires_at"])
     if expires_at < datetime.now(timezone.utc):
         return "expired"
     return "pending"
@@ -804,14 +821,15 @@ async def list_org_invites(
         )
         invites = []
         for row in await asyncio.to_thread(cursor.fetchall):
+            invite = _org_invite_row(row)
             invites.append(
                 {
-                    "id": row[0],
-                    "email": row[2],
-                    "role": row[4],
-                    "status": _invite_status(row),
-                    "expires_at": row[5],
-                    "created_at": row[6],
+                    "id": invite["id"],
+                    "email": invite["email"],
+                    "role": invite["role"],
+                    "status": _invite_status(invite),
+                    "expires_at": invite["expires_at"],
+                    "created_at": invite["created_at"],
                 }
             )
         return {"invites": invites}
@@ -980,6 +998,11 @@ async def update_org_member_role(
             raise HTTPException(
                 status_code=403,
                 detail="Cannot change the role of the organization owner",
+            )
+        if req.role == "owner":
+            raise HTTPException(
+                status_code=403,
+                detail="Use the ownership transfer endpoint to assign the owner role",
             )
 
         # Update role

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -860,6 +860,7 @@ async def update_user_groups(
 
         # For non-superadmins, verify caller shares an org with target user
         # (parity with get_user_groups and update_user_organizations).
+        caller_orgs = None
         if user.get("role") != "superadmin":
             cursor = conn.execute(
                 "SELECT org_id FROM org_members WHERE user_id = ?", (user_id,)
@@ -876,11 +877,37 @@ async def update_user_groups(
                     detail="Cannot update group memberships of users outside your organization",
                 )
 
-        # If group_ids is empty, just delete all memberships and return empty list
+        # If group_ids is empty, clear only the caller-managed org scope.
         if not body.group_ids:
-            conn.execute("DELETE FROM group_members WHERE user_id = ?", (user_id,))
+            if caller_orgs is None:
+                conn.execute("DELETE FROM group_members WHERE user_id = ?", (user_id,))
+            else:
+                placeholders = ",".join("?" * len(caller_orgs))
+                conn.execute(
+                    f"""DELETE FROM group_members
+                        WHERE user_id = ?
+                          AND group_id IN (
+                              SELECT id FROM groups WHERE org_id IN ({placeholders})
+                          )""",
+                    (user_id, *caller_orgs),
+                )
             conn.commit()
-            return []
+            cursor = conn.execute(
+                """SELECT g.id, g.name, g.description, g.org_id
+                   FROM groups g
+                   JOIN group_members gm ON g.id = gm.group_id
+                   WHERE gm.user_id = ?""",
+                (user_id,),
+            )
+            return [
+                {
+                    "id": row[0],
+                    "name": row[1],
+                    "description": row[2] or "",
+                    "org_id": row[3],
+                }
+                for row in cursor.fetchall()
+            ]
 
         # Validate all group_ids exist and get their org_ids
         placeholders = ",".join("?" * len(body.group_ids))
@@ -896,6 +923,15 @@ async def update_user_groups(
                 status_code=400, detail=f"Groups not found: {sorted(missing_groups)}"
             )
 
+        if caller_orgs is not None:
+            requested_orgs = set(found_groups.values())
+            unauthorized = requested_orgs - caller_orgs
+            if unauthorized:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Cannot assign groups from organizations you are not a member of: {sorted(unauthorized)}",
+                )
+
         # Check user is a member of each group's organization (skip for superadmins)
         if user.get("role") != "superadmin":
             for group_id, org_id in found_groups.items():
@@ -909,8 +945,19 @@ async def update_user_groups(
                         detail=f"User is not a member of organization for group {group_id}",
                     )
 
-        # Delete existing memberships
-        cursor.execute("DELETE FROM group_members WHERE user_id = ?", (user_id,))
+        # Replace only memberships in the caller-managed org scope.
+        if caller_orgs is None:
+            cursor.execute("DELETE FROM group_members WHERE user_id = ?", (user_id,))
+        else:
+            placeholders = ",".join("?" * len(caller_orgs))
+            cursor.execute(
+                f"""DELETE FROM group_members
+                    WHERE user_id = ?
+                      AND group_id IN (
+                          SELECT id FROM groups WHERE org_id IN ({placeholders})
+                      )""",
+                (user_id, *caller_orgs),
+            )
 
         # Insert new memberships
         for group_id in body.group_ids:

--- a/backend/app/api/routes/vault_members.py
+++ b/backend/app/api/routes/vault_members.py
@@ -3,7 +3,11 @@ import sqlite3
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from app.api.deps import require_vault_permission
+from app.api.deps import (
+    get_current_active_user,
+    get_evaluate_policy,
+    require_vault_permission,
+)
 from app.config import settings
 from app.models.database import get_pool
 from app.security import csrf_protect
@@ -310,9 +314,9 @@ def remove_vault_member(
 
 
 @group_access_router.get("/")
-def list_vault_group_access(
+async def list_vault_group_access(
     vault_id: int,
-    current_user: dict = Depends(require_vault_permission("read")),
+    current_user: dict = Depends(get_current_active_user),
 ):
     """List all groups with access to a vault."""
     pool = get_pool(str(settings.sqlite_path))
@@ -324,6 +328,12 @@ def list_vault_group_access(
         cursor.execute("SELECT id FROM vaults WHERE id = ?", (vault_id,))
         if not cursor.fetchone():
             raise HTTPException(status_code=404, detail="Vault not found")
+
+        evaluate = get_evaluate_policy(conn)
+        if not await evaluate(current_user, "vault", vault_id, "admin"):
+            raise HTTPException(
+                status_code=403, detail="Insufficient vault permissions"
+            )
 
         # Count total group access entries
         cursor.execute(

--- a/backend/app/api/routes/vaults.py
+++ b/backend/app/api/routes/vaults.py
@@ -435,7 +435,7 @@ async def create_vault(
             pass
         raise HTTPException(status_code=500, detail="Failed to create vault")
 
-    if vault_id is None:
+    if vault_id is None or vault_id <= 0:
         try:
             await asyncio.to_thread(conn.rollback)
         except Exception:

--- a/backend/tests/test_admin_user_management.py
+++ b/backend/tests/test_admin_user_management.py
@@ -9,7 +9,6 @@ These tests verify:
 
 import os
 import shutil
-import sqlite3
 import tempfile
 
 import pytest
@@ -22,56 +21,18 @@ os.environ["JWT_SECRET_KEY"] = (
 )
 os.environ["USERS_ENABLED"] = "true"
 
-# Now safe to import app modules
-from backend.tests.schema_constants import TEST_SCHEMA
-
-from app.services.auth_service import (
-    compute_client_fingerprint,
-    create_access_token,
-    hash_password,
+from backend.tests.user_route_helpers import (
+    create_user,
+    get_token,
+)
+from backend.tests.user_route_helpers import (
+    setup_test_db as _setup_user_route_test_db,
 )
 
 
-def setup_test_db(db_path: str) -> sqlite3.Connection:
+def setup_test_db(db_path: str):
     """Set up test database with schema and initial users."""
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA foreign_keys = ON;")
-    conn.executescript(TEST_SCHEMA)
-
-    # Extra index on locked_until (local supplement)
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_users_locked_until ON users(locked_until)"
-    )
-
-    conn.commit()
-    return conn
-
-
-def create_user(
-    conn: sqlite3.Connection,
-    username: str,
-    password: str,
-    role: str,
-    full_name: str = "",
-    is_active: int = 1,
-    must_change_password: int = 0,
-) -> int:
-    """Create a test user and return its ID."""
-    hashed = hash_password(password)
-    cursor = conn.execute(
-        """INSERT INTO users (username, hashed_password, full_name, role, is_active, must_change_password)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (username, hashed, full_name, role, is_active, must_change_password),
-    )
-    conn.commit()
-    return cursor.lastrowid
-
-
-def get_token(user_id: int, username: str, role: str) -> str:
-    """Generate a JWT token for a test user."""
-    return create_access_token(user_id, username, role,
-                            client_fingerprint=compute_client_fingerprint(""))
+    return _setup_user_route_test_db(db_path, include_locked_until_index=True)
 
 
 class TestUpdateUser:

--- a/backend/tests/test_groups_membership.py
+++ b/backend/tests/test_groups_membership.py
@@ -23,48 +23,18 @@ os.environ["JWT_SECRET_KEY"] = (
 )
 os.environ["USERS_ENABLED"] = "true"
 
-from backend.tests.schema_constants import TEST_SCHEMA
-
-from app.services.auth_service import (
-    compute_client_fingerprint,
-    create_access_token,
-    hash_password,
+from backend.tests.user_route_helpers import (
+    create_user,
+    get_token,
+)
+from backend.tests.user_route_helpers import (
+    setup_test_db as _setup_user_route_test_db,
 )
 
 
 def setup_test_db(db_path: str) -> sqlite3.Connection:
     """Set up test database with full schema including groups and vault_group_access."""
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA foreign_keys = ON;")
-    conn.executescript(TEST_SCHEMA)
-
-    # Insert default vault (local supplement)
-    conn.execute(
-        "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (1, 'Default', 'Default vault')"
-    )
-
-    conn.commit()
-    return conn
-
-
-def create_user(
-    conn: sqlite3.Connection,
-    username: str,
-    password: str,
-    role: str,
-    full_name: str = "",
-    is_active: int = 1,
-) -> int:
-    """Create a test user and return its ID."""
-    hashed = hash_password(password)
-    cursor = conn.execute(
-        """INSERT INTO users (username, hashed_password, full_name, role, is_active)
-           VALUES (?, ?, ?, ?, ?)""",
-        (username, hashed, full_name, role, is_active),
-    )
-    conn.commit()
-    return cursor.lastrowid
+    return _setup_user_route_test_db(db_path, include_default_vault=True)
 
 
 def create_organization(conn: sqlite3.Connection, name: str, slug: str = None) -> int:
@@ -147,12 +117,6 @@ def add_user_to_vault(
         (vault_id, user_id, permission, granted_by),
     )
     conn.commit()
-
-
-def get_token(user_id: int, username: str, role: str) -> str:
-    """Generate a JWT token for a test user."""
-    return create_access_token(user_id, username, role,
-                          client_fingerprint=compute_client_fingerprint(""))
 
 
 class TestUserGroupMembershipSetup:
@@ -493,8 +457,10 @@ class TestUpdateUserGroups(TestUserGroupMembershipSetup):
         assert "Groups not found" in response.json()["detail"]
 
     def test_validates_user_is_org_member_for_each_group(self):
-        """Admin must be member of each group's org (non-superadmin)."""
-        # group3 is in org2, admin_org1 is only in org1
+        """Target user must be a member of each requested group's org."""
+        # group3 is in org2. Give the caller org2 admin rights so this test
+        # reaches the target-user org membership validation branch.
+        add_user_to_org(self.conn, self.admin_org1_id, self.org2_id, "admin")
         token = get_token(self.admin_org1_id, "admin_org1", "admin")
         response = self.client.put(
             f"/users/{self.member_org1_id}/groups",

--- a/backend/tests/test_memories_auth.py
+++ b/backend/tests/test_memories_auth.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -342,6 +342,46 @@ class TestMemoriesAuthorization(TestMemoriesAuthBase):
         )
         # Should succeed since we mocked memory_store
         self.assertEqual(response.status_code, 200)
+
+    def test_put_memories_member_without_vault_write_returns_403(self):
+        """PUT /memories/{id} by member without vault write access returns 403."""
+        conn = self._get_db_conn()
+        try:
+            cursor = conn.execute("SELECT id FROM memories WHERE vault_id = 2")
+            memory_id = cursor.fetchone()[0]
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.put(
+            f"/api/memories/{memory_id}",
+            json={"content": "Updated memory"},
+            headers=self._auth_headers(self._member_no_access_token()),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertIn("No write access", data.get("detail", ""))
+
+    def test_put_memories_member_with_vault_write_succeeds(self):
+        """PUT /memories/{id} by member with vault write access succeeds."""
+        self._mock_memory_store._has_embedding_columns = MagicMock(return_value=False)
+        self._mock_memory_store.embed_and_store = AsyncMock()
+        conn = self._get_db_conn()
+        try:
+            cursor = conn.execute("SELECT id FROM memories WHERE vault_id = 2")
+            memory_id = cursor.fetchone()[0]
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        response = self.client.put(
+            f"/api/memories/{memory_id}",
+            json={"content": "Updated memory"},
+            headers=self._auth_headers(self._member_token()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["content"], "Updated memory")
 
     def test_delete_memories_member_without_vault_admin_returns_403(self):
         """DELETE /memories/{id} by member without vault admin access returns 403."""

--- a/backend/tests/test_organizations_routes.py
+++ b/backend/tests/test_organizations_routes.py
@@ -478,6 +478,51 @@ class TestUpdateOrgMemberRole:
         )
         assert response.status_code == 403
 
+    def test_org_admin_cannot_patch_member_to_owner(self, client):
+        """Org admin cannot bypass transfer-ownership by PATCH-promoting a member."""
+        org_id = _create_org("Admin Patch Owner Org", 1)
+        _add_org_member(org_id, 2, "admin")
+        _add_org_member(org_id, 3, "member")
+
+        response = client.patch(
+            f"/api/organizations/{org_id}/members/3",
+            json={"role": "owner"},
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 403
+        conn = _get_db_conn()
+        try:
+            role = conn.execute(
+                "SELECT role FROM org_members WHERE org_id = ? AND user_id = ?",
+                (org_id, 3),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert role == "member"
+
+    def test_org_admin_cannot_patch_self_to_owner(self, client):
+        """Org admin cannot self-promote to owner through member role PATCH."""
+        org_id = _create_org("Admin Self Owner Org", 1)
+        _add_org_member(org_id, 2, "admin")
+
+        response = client.patch(
+            f"/api/organizations/{org_id}/members/2",
+            json={"role": "owner"},
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 403
+        conn = _get_db_conn()
+        try:
+            role = conn.execute(
+                "SELECT role FROM org_members WHERE org_id = ? AND user_id = ?",
+                (org_id, 2),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert role == "admin"
+
 
 class TestRemoveOrgMember:
     """Tests for DELETE /organizations/{org_id}/members/{member_user_id} endpoint."""

--- a/backend/tests/test_require_vault_permission_di_adversarial.py
+++ b/backend/tests/test_require_vault_permission_di_adversarial.py
@@ -888,16 +888,38 @@ class TestSecuritySummary:
         """
         Verify all DI refactor attack vectors are defined.
         """
-        required_tests = [
-            "test_require_vault_permission_uses_injected_db_not_standalone_pool",
-            "test_require_vault_permission_negative_vault_id_denied",
-            "test_require_vault_permission_zero_vault_id_denied",
-            "test_require_vault_permission_empty_actions_denies_all",
-            "test_require_vault_permission_none_vault_id_denies_superadmin",
-            "test_evaluate_policy_non_vault_non_group_member_denied",
-            "test_superadmin_id_zero_escalation_blocked",
-            "test_require_vault_permission_multi_action_any_match_passes",
-            "test_concurrent_vault_access_same_user_different_vaults",
-        ]
+        required_tests = {
+            "TestDIConnectionReuse": [
+                "test_require_vault_permission_uses_injected_db_not_standalone_pool",
+            ],
+            "TestMalformedVaultIdAttacks": [
+                "test_require_vault_permission_negative_vault_id_denied",
+                "test_require_vault_permission_zero_vault_id_denied",
+            ],
+            "TestEmptyActionsBypass": [
+                "test_require_vault_permission_empty_actions_denies_all",
+            ],
+            "TestNoneVaultIdPrivilegeEscalation": [
+                "test_require_vault_permission_none_vault_id_denies_superadmin",
+            ],
+            "TestResourceTypeConfusion": [
+                "test_evaluate_policy_non_vault_non_group_member_denied",
+            ],
+            "TestPrivilegeEscalation": [
+                "test_superadmin_id_zero_escalation_blocked",
+            ],
+            "TestDependencyOverrideBypass": [
+                "test_require_vault_permission_multi_action_any_match_passes",
+            ],
+            "TestConcurrentAccessAttacks": [
+                "test_concurrent_vault_access_same_user_different_vaults",
+            ],
+        }
 
-        assert len(required_tests) == 9
+        for class_name, test_names in required_tests.items():
+            test_class = globals().get(class_name)
+            assert test_class is not None, f"Missing test class {class_name}"
+            for test_name in test_names:
+                assert callable(getattr(test_class, test_name, None)), (
+                    f"Missing required test {class_name}.{test_name}"
+                )

--- a/backend/tests/test_users_routes.py
+++ b/backend/tests/test_users_routes.py
@@ -11,7 +11,6 @@ These tests verify:
 """
 
 import os
-import sqlite3
 import tempfile
 
 import pytest
@@ -24,54 +23,11 @@ os.environ["JWT_SECRET_KEY"] = (
 )
 os.environ["USERS_ENABLED"] = "true"
 
-# Now safe to import app modules
-from backend.tests.schema_constants import TEST_SCHEMA
-
-from app.services.auth_service import (
-    compute_client_fingerprint,
-    create_access_token,
-    hash_password,
+from backend.tests.user_route_helpers import (
+    create_user,
+    get_token,
+    setup_test_db,
 )
-
-
-def setup_test_db(db_path: str) -> sqlite3.Connection:
-    """Set up test database with schema and initial users.
-
-    Includes all tables touched by the current user-management routes:
-    users, organizations, org_members, groups, and group_members.
-    """
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA foreign_keys = ON;")
-    conn.executescript(TEST_SCHEMA)
-
-    conn.commit()
-    return conn
-
-
-def create_user(
-    conn: sqlite3.Connection,
-    username: str,
-    password: str,
-    role: str,
-    full_name: str = "",
-    is_active: int = 1,
-) -> int:
-    """Create a test user and return its ID."""
-    hashed = hash_password(password)
-    cursor = conn.execute(
-        """INSERT INTO users (username, hashed_password, full_name, role, is_active)
-           VALUES (?, ?, ?, ?, ?)""",
-        (username, hashed, full_name, role, is_active),
-    )
-    conn.commit()
-    return cursor.lastrowid
-
-
-def get_token(user_id: int, username: str, role: str) -> str:
-    """Generate a JWT token for a test user."""
-    return create_access_token(user_id, username, role,
-                        client_fingerprint=compute_client_fingerprint(""))
 
 
 class TestUserRoutes:
@@ -1332,6 +1288,20 @@ class TestUpdateUserGroupsCallerOrgCheck(TestUserRoutes):
             "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
             (self.org_id, self.member_id, "member"),
         )
+        cursor = self.conn.execute(
+            "INSERT INTO organizations (name, description) VALUES (?, ?)",
+            ("PF002 Other Org", "Foreign org for group scope checks"),
+        )
+        self.other_org_id = cursor.lastrowid
+        cursor = self.conn.execute(
+            "INSERT INTO groups (org_id, name, description) VALUES (?, ?, ?)",
+            (self.other_org_id, "PF002 Other Group", "Foreign group"),
+        )
+        self.other_group_id = cursor.lastrowid
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.other_org_id, self.member_id, "member"),
+        )
         self.conn.commit()
         yield
 
@@ -1370,3 +1340,109 @@ class TestUpdateUserGroupsCallerOrgCheck(TestUserRoutes):
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 200
+
+    def test_admin_in_one_org_cannot_assign_group_from_other_org(self):
+        """Non-superadmin admin cannot assign groups outside caller org scope."""
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org_id, self.admin_id, "member"),
+        )
+        self.conn.commit()
+        token = get_token(self.admin_id, "admin", "admin")
+
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": [self.other_group_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 403
+        assert "Cannot assign" in response.json()["detail"]
+
+    def test_admin_partial_update_preserves_foreign_org_group_membership(self):
+        """Caller-scoped group updates must not delete target memberships in other orgs."""
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org_id, self.admin_id, "member"),
+        )
+        self.conn.execute(
+            "INSERT INTO group_members (group_id, user_id) VALUES (?, ?)",
+            (self.other_group_id, self.member_id),
+        )
+        self.conn.commit()
+        token = get_token(self.admin_id, "admin", "admin")
+
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": [self.group_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        rows = self.conn.execute(
+            "SELECT group_id FROM group_members WHERE user_id = ?",
+            (self.member_id,),
+        ).fetchall()
+        assert {row[0] for row in rows} == {self.group_id, self.other_group_id}
+
+    def test_admin_empty_update_preserves_foreign_org_group_membership(self):
+        """Empty caller-scoped updates must not clear target memberships in other orgs."""
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org_id, self.admin_id, "member"),
+        )
+        self.conn.execute(
+            "INSERT INTO group_members (group_id, user_id) VALUES (?, ?)",
+            (self.group_id, self.member_id),
+        )
+        self.conn.execute(
+            "INSERT INTO group_members (group_id, user_id) VALUES (?, ?)",
+            (self.other_group_id, self.member_id),
+        )
+        self.conn.commit()
+        token = get_token(self.admin_id, "admin", "admin")
+
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": []},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        rows = self.conn.execute(
+            "SELECT group_id FROM group_members WHERE user_id = ?",
+            (self.member_id,),
+        ).fetchall()
+        assert {row[0] for row in rows} == {self.other_group_id}
+
+    def test_admin_cannot_assign_caller_org_group_when_target_not_in_group_org(self):
+        """Caller-org validation must not bypass target-user org membership validation."""
+        cursor = self.conn.execute(
+            "INSERT INTO organizations (name, description) VALUES (?, ?)",
+            ("PF002 Caller Only Org", "Caller-only org for target validation"),
+        )
+        caller_only_org_id = cursor.lastrowid
+        cursor = self.conn.execute(
+            "INSERT INTO groups (org_id, name, description) VALUES (?, ?, ?)",
+            (caller_only_org_id, "PF002 Caller Only Group", "Target is not in this org"),
+        )
+        caller_only_group_id = cursor.lastrowid
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (self.org_id, self.admin_id, "member"),
+        )
+        self.conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (caller_only_org_id, self.admin_id, "member"),
+        )
+        self.conn.commit()
+        token = get_token(self.admin_id, "admin", "admin")
+
+        response = self.client.put(
+            f"/users/{self.member_id}/groups",
+            json={"group_ids": [caller_only_group_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 400
+        assert "User is not a member of organization" in response.json()["detail"]

--- a/backend/tests/test_users_routes_adversarial.py
+++ b/backend/tests/test_users_routes_adversarial.py
@@ -28,43 +28,17 @@ os.environ["JWT_SECRET_KEY"] = (
 )
 os.environ["USERS_ENABLED"] = "true"
 
-from backend.tests.schema_constants import TEST_SCHEMA
+from backend.tests.user_route_helpers import (
+    create_user,
+    get_token,
+    setup_test_db,
+)
 
 from app.services.auth_service import (
     compute_client_fingerprint,
     create_access_token,
     hash_password,
 )
-
-
-def setup_test_db(db_path: str) -> sqlite3.Connection:
-    """Set up test database with schema and initial users."""
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA foreign_keys = ON;")
-    conn.executescript(TEST_SCHEMA)
-
-    conn.commit()
-    return conn
-
-
-def create_user(
-    conn: sqlite3.Connection,
-    username: str,
-    password: str,
-    role: str,
-    full_name: str = "",
-    is_active: int = 1,
-) -> int:
-    """Create a test user and return its ID."""
-    hashed = hash_password(password)
-    cursor = conn.execute(
-        """INSERT INTO users (username, hashed_password, full_name, role, is_active)
-           VALUES (?, ?, ?, ?, ?)""",
-        (username, hashed, full_name, role, is_active),
-    )
-    conn.commit()
-    return cursor.lastrowid
 
 
 def create_user_with_xss_payload(
@@ -86,12 +60,6 @@ def create_user_with_xss_payload(
     )
     conn.commit()
     return cursor.lastrowid
-
-
-def get_token(user_id: int, username: str, role: str) -> str:
-    """Generate a valid JWT token for a test user."""
-    return create_access_token(user_id, username, role,
-                        client_fingerprint=compute_client_fingerprint(""))
 
 
 def get_expired_token(user_id: int, username: str, role: str) -> str:
@@ -135,6 +103,7 @@ def get_token_with_modified_role(
         "sub": str(user_id),
         "username": username,
         "role": new_role,  # Attempting to escalate to superadmin
+        "type": "access",
         "exp": expires,
     }
     return jwt.encode(payload, secret, algorithm="HS256")
@@ -1084,12 +1053,7 @@ class TestJWTTokenManipulation:
         response = self.client.get(
             "/users/", headers={"Authorization": f"Bearer {modified_token}"}
         )
-        # The token is valid JWT-wise, but the user_id doesn't match a superadmin
-        # in the database, so either 401 (token missing type claim), 403
-        # (user not found/inactive), or 200 if role is DB-verified
-        assert response.status_code in (200, 401, 403), (
-            f"Unexpected status: {response.status_code}"
-        )
+        assert response.status_code == 403
 
     def test_tampered_token_signature(self):
         """Token with tampered signature should be rejected (401 per RFC 6750)."""

--- a/backend/tests/test_vault_group_access_routes.py
+++ b/backend/tests/test_vault_group_access_routes.py
@@ -216,6 +216,27 @@ class TestListVaultGroupAccess:
         )
         assert response.status_code == 403
 
+    def test_read_permission_user_cannot_list_group_acl_metadata(self, client):
+        """Read-only vault users cannot list group ACL metadata."""
+        conn = _get_db_conn()
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+            (1, 3, "read", 1),
+        )
+        conn.execute(
+            "INSERT INTO vault_group_access (vault_id, group_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+            (1, 1, "read", 1),
+        )
+        conn.commit()
+        conn.close()
+
+        response = client.get(
+            "/api/vaults/1/group-access", headers=auth_headers(member_token)
+        )
+
+        assert response.status_code == 403
+
 
 class TestGrantVaultGroupAccessCrossOrg:
     """Tests for cross-org validation in grant_vault_group_access."""

--- a/backend/tests/test_vault_members_routes.py
+++ b/backend/tests/test_vault_members_routes.py
@@ -298,6 +298,29 @@ class TestUpdateVaultMember:
         )
         assert response.status_code == 404
 
+    def test_read_permission_user_cannot_update_member(self, client):
+        """User with read permission cannot update vault members (403)."""
+        conn = _get_db_conn()
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+            (1, 3, "read", 1),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+            (1, 4, "read", 1),
+        )
+        conn.commit()
+        conn.close()
+
+        response = client.patch(
+            "/api/vaults/1/members/4",
+            json={"permission": "write"},
+            headers=auth_headers(member_token),
+        )
+
+        assert response.status_code == 403
+
 
 class TestRemoveVaultMember:
     """Tests for DELETE /vaults/{vault_id}/members/{member_user_id} endpoint."""
@@ -327,6 +350,27 @@ class TestRemoveVaultMember:
             "/api/vaults/1/members/999", headers=auth_headers(superadmin_token)
         )
         assert response.status_code == 404
+
+    def test_read_permission_user_cannot_remove_member(self, client):
+        """User with read permission cannot remove vault members (403)."""
+        conn = _get_db_conn()
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+            (1, 3, "read", 1),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission, granted_by) VALUES (?, ?, ?, ?)",
+            (1, 4, "read", 1),
+        )
+        conn.commit()
+        conn.close()
+
+        response = client.delete(
+            "/api/vaults/1/members/4", headers=auth_headers(member_token)
+        )
+
+        assert response.status_code == 403
 
     def test_self_removal_rejected(self, client):
         """Self-removal is rejected with 400."""

--- a/backend/tests/test_vault_path_migration.py
+++ b/backend/tests/test_vault_path_migration.py
@@ -327,7 +327,7 @@ class TestVaultPathMigration:
         assert (new_path / "subdir" / "file2.txt").exists()
         assert (new_path / "subdir" / "file2.txt").read_text() == "nested file"
 
-    def test_error_handling_continues_with_other_vaults(self, temp_db_and_vaults):
+    def test_error_handling_continues_with_other_vaults(self, temp_db_and_vaults, caplog):
         """
         Test that migration continues with other vaults when one fails.
         """
@@ -350,11 +350,24 @@ class TestVaultPathMigration:
         old_2.mkdir(parents=True, exist_ok=True)
         (old_2 / "file2.txt").write_text("another vault")
 
+        original_rename = Path.rename
+
+        def fail_first_vault_rename(path: Path, target: Path):
+            if path == old_1:
+                raise OSError("simulated rename failure")
+            return original_rename(path, target)
+
         # Run migration
-        with patch("app.models.database.settings") as mock_settings:
+        caplog.set_level("WARNING", logger="app.models.database")
+        with patch("app.models.database.settings") as mock_settings, patch.object(
+            Path, "rename", fail_first_vault_rename
+        ):
             mock_settings.vaults_dir = data["vaults_dir"]
             migrate_vault_paths(str(data["db_path"]))
 
-        # VERIFY: Both vaults were processed (per-vault try/except)
-        assert (data["vaults_dir"] / "1" / "file.txt").exists()
+        # VERIFY: Failed vault stayed put, the next vault still migrated, and the error was logged.
+        assert (data["vaults_dir"] / "Good_Vault" / "file.txt").exists()
+        assert not (data["vaults_dir"] / "1" / "file.txt").exists()
         assert (data["vaults_dir"] / "2" / "file2.txt").exists()
+        assert "Failed to migrate vault 'Good Vault' (ID 1)" in caplog.text
+        assert "simulated rename failure" in caplog.text

--- a/backend/tests/test_vault_transaction_adversarial.py
+++ b/backend/tests/test_vault_transaction_adversarial.py
@@ -72,6 +72,17 @@ from app.main import app
 from app.services.auth_service import compute_client_fingerprint, create_access_token
 
 
+class CursorWithLastrowid:
+    """Proxy cursor that overrides lastrowid while delegating other cursor behavior."""
+
+    def __init__(self, cursor, lastrowid):
+        self._cursor = cursor
+        self.lastrowid = lastrowid
+
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+
 class FailOnConnection:
     """A connection wrapper that fails on specific SQL commands.
 
@@ -130,11 +141,7 @@ class FailOnConnection:
                 raise self._config["vault_insert_raises"]
             result = self._real_conn.execute(sql, *args, **kwargs)
             if self._config["lastrowid_override"] is not None:
-                # Temporarily override lastrowid
-                original_lastrowid = result.lastrowid
-                result.lastrowid = self._config["lastrowid_override"]
-                # Restore after call
-                result.lastrowid = original_lastrowid
+                return CursorWithLastrowid(result, self._config["lastrowid_override"])
             return result
 
         # Member INSERT failure
@@ -694,13 +701,22 @@ class TestVaultTransactionAdversarial(unittest.TestCase):
                 headers=headers,
             )
 
-            # The current code has a bug: it checks `if vault_id is None:`
-            # but 0 is not None, so the check passes and vault_id=0 is used.
-            # This should either succeed with a malformed vault or fail later.
-            self.assertIn(
-                response.status_code, [201, 500],
-                f"Expected 201 or 500 but got {response.status_code}"
-            )
+            self.assertEqual(response.status_code, 500)
+            self.assertIn(("rollback",), fail_on.call_log)
+
+            conn = sqlite3.connect(self._db_path)
+            try:
+                vault_count = conn.execute(
+                    "SELECT COUNT(*) FROM vaults WHERE name = ?",
+                    ("Test Vault",),
+                ).fetchone()[0]
+                member_count = conn.execute(
+                    "SELECT COUNT(*) FROM vault_members WHERE vault_id = 0"
+                ).fetchone()[0]
+            finally:
+                conn.close()
+            self.assertEqual(vault_count, 0)
+            self.assertEqual(member_count, 0)
         finally:
             fail_on.reset()
             self._disable_fail_on()

--- a/backend/tests/user_route_helpers.py
+++ b/backend/tests/user_route_helpers.py
@@ -1,0 +1,66 @@
+"""Shared helpers for user-route style backend tests."""
+
+import sqlite3
+
+from backend.tests.schema_constants import TEST_SCHEMA
+
+from app.services.auth_service import (
+    compute_client_fingerprint,
+    create_access_token,
+    hash_password,
+)
+
+
+def setup_test_db(
+    db_path: str,
+    *,
+    include_default_vault: bool = False,
+    include_locked_until_index: bool = False,
+) -> sqlite3.Connection:
+    """Set up a user-route test database with the shared schema."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA foreign_keys = ON;")
+    conn.executescript(TEST_SCHEMA)
+
+    if include_default_vault:
+        conn.execute(
+            "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (1, 'Default', 'Default vault')"
+        )
+    if include_locked_until_index:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_users_locked_until ON users(locked_until)"
+        )
+
+    conn.commit()
+    return conn
+
+
+def create_user(
+    conn: sqlite3.Connection,
+    username: str,
+    password: str,
+    role: str,
+    full_name: str = "",
+    is_active: int = 1,
+    must_change_password: int = 0,
+) -> int:
+    """Create a test user and return its ID."""
+    hashed = hash_password(password)
+    cursor = conn.execute(
+        """INSERT INTO users (username, hashed_password, full_name, role, is_active, must_change_password)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (username, hashed, full_name, role, is_active, must_change_password),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def get_token(user_id: int, username: str, role: str) -> str:
+    """Generate a JWT token for a test user."""
+    return create_access_token(
+        user_id,
+        username,
+        role,
+        client_fingerprint=compute_client_fingerprint(""),
+    )

--- a/frontend/src/pages/VaultsPage.test.tsx
+++ b/frontend/src/pages/VaultsPage.test.tsx
@@ -1,52 +1,54 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import * as fs from "fs";
 import * as path from "path";
+
+const vaultStoreMock = vi.hoisted(() => ({
+  vaults: [
+    {
+      id: 1,
+      name: "Research",
+      description: "",
+      file_count: 0,
+      memory_count: 0,
+      session_count: 0,
+      current_user_permission: "admin",
+    },
+    {
+      id: 2,
+      name: "Admin Vault",
+      description: "",
+      file_count: 0,
+      memory_count: 0,
+      session_count: 0,
+      current_user_permission: "admin",
+    },
+    {
+      id: 3,
+      name: "Write Vault",
+      description: "",
+      file_count: 0,
+      memory_count: 0,
+      session_count: 0,
+      current_user_permission: "write",
+    },
+  ],
+  loading: false,
+  fetchVaults: vi.fn(),
+  addVault: vi.fn(),
+  editVault: vi.fn(),
+  removeVault: vi.fn(),
+  activeVaultId: 2,
+  setActiveVault: vi.fn(),
+}));
 
 vi.mock("@/lib/api", () => ({
   listOrganizations: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/stores/useVaultStore", () => ({
-  useVaultStore: vi.fn(() => ({
-    vaults: [
-      {
-        id: 1,
-        name: "Research",
-        description: "",
-        file_count: 0,
-        memory_count: 0,
-        session_count: 0,
-        current_user_permission: "admin",
-      },
-      {
-        id: 2,
-        name: "Admin Vault",
-        description: "",
-        file_count: 0,
-        memory_count: 0,
-        session_count: 0,
-        current_user_permission: "admin",
-      },
-      {
-        id: 3,
-        name: "Write Vault",
-        description: "",
-        file_count: 0,
-        memory_count: 0,
-        session_count: 0,
-        current_user_permission: "write",
-      },
-    ],
-    loading: false,
-    fetchVaults: vi.fn(),
-    addVault: vi.fn(),
-    editVault: vi.fn(),
-    removeVault: vi.fn(),
-    activeVaultId: 2,
-    setActiveVault: vi.fn(),
-  })),
+  useVaultStore: vi.fn(() => vaultStoreMock),
 }));
 
 vi.mock("sonner", () => ({
@@ -70,13 +72,15 @@ vi.mock("@/components/ui/button", () => ({
     disabled,
     title,
     onClick,
+    type,
   }: {
     children: React.ReactNode;
     disabled?: boolean;
     title?: string;
     onClick?: () => void;
+    type?: "button" | "submit" | "reset";
   }) => (
-    <button disabled={disabled} title={title} onClick={onClick}>
+    <button disabled={disabled} title={title} onClick={onClick} type={type}>
       {children}
     </button>
   ),
@@ -101,7 +105,8 @@ vi.mock("@/components/ui/skeleton", () => ({
 }));
 
 vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div>{children}</div> : null,
   DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -191,5 +196,55 @@ describe("VaultsPage isDefaultVault removal (5.4)", () => {
     for (const button of permissionRequiredButtons) {
       expect(button).toBeDisabled();
     }
+  });
+});
+
+describe("VaultsPage dialog forms", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits the create dialog through its form", async () => {
+    render(<VaultsPage />);
+    await screen.findByText("Admin Vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /new vault/i }));
+
+    const createNameInput = screen.getByLabelText("Vault Name");
+    const form = createNameInput.closest("form");
+    expect(form).not.toBeNull();
+
+    fireEvent.change(createNameInput, { target: { value: "New Vault" } });
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(vaultStoreMock.addVault).toHaveBeenCalledWith({
+        name: "New Vault",
+        description: "",
+        org_id: null,
+      });
+    });
+  });
+
+  it("submits the edit dialog through its form", async () => {
+    render(<VaultsPage />);
+    await screen.findByText("Admin Vault");
+
+    const editButtons = screen.getAllByTitle("Edit vault");
+    fireEvent.click(editButtons[0]);
+
+    const editNameInput = screen.getByLabelText("Vault Name");
+    const form = editNameInput.closest("form");
+    expect(form).not.toBeNull();
+
+    fireEvent.change(editNameInput, { target: { value: "Renamed Vault" } });
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(vaultStoreMock.editVault).toHaveBeenCalledWith(1, {
+        name: "Renamed Vault",
+        description: "",
+      });
+    });
   });
 });

--- a/frontend/src/pages/VaultsPage.tsx
+++ b/frontend/src/pages/VaultsPage.tsx
@@ -268,7 +268,13 @@ export default function VaultsPage() {
               Add a new knowledge vault to organize your documents and memories.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleCreate();
+            }}
+            className="space-y-4"
+          >
             <div>
               <Label htmlFor="vault-name">Vault Name</Label>
               <Input
@@ -312,22 +318,22 @@ export default function VaultsPage() {
                 )}
               </div>
             )}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleCreate} disabled={saving}>
-              {saving ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Creating...
-                </>
-              ) : (
-                "Create"
-              )}
-            </Button>
-          </DialogFooter>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  "Create"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
 
@@ -340,7 +346,13 @@ export default function VaultsPage() {
               Update vault name or description.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleEdit();
+            }}
+            className="space-y-4"
+          >
             <div>
               <Label htmlFor="vault-name">Vault Name</Label>
               <Input
@@ -359,22 +371,22 @@ export default function VaultsPage() {
                 onChange={(e) => setDescription(e.target.value)}
               />
             </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleEdit} disabled={saving}>
-              {saving ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                "Save"
-              )}
-            </Button>
-          </DialogFooter>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setEditDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Summary
- Hardened role and ACL management for issue #272: org admins can no longer promote members to owner through role patching, vault group ACL listing now requires vault admin permission, and non-superadmin group assignment is scoped to the caller's organizations without deleting foreign-org memberships.
- Fixed VaultsPage create/edit dialogs so pressing Enter submits the active form instead of doing nothing.
- Closed verified test-quality gaps around shared user-route setup, memory/vault auth coverage, dependency-adversarial assertions, vault transaction rollback, and path migration partial-failure coverage.

## Test plan
- [x] `python -m pytest backend/tests/test_organizations_routes.py::TestUpdateOrgMemberRole::test_org_admin_cannot_patch_member_to_owner ... -q` -- `52 passed, 19 warnings`
- [x] `python -m pytest tests/test_groups_membership.py::TestUpdateUserGroups::test_validates_user_is_org_member_for_each_group tests/test_users_routes.py::TestUpdateUserGroupsCallerOrgCheck -q --tb=short` -- `8 passed, 4 warnings`
- [x] `python -m pytest tests/test_vault_group_access_routes.py::TestListVaultGroupAccess::test_returns_404_when_vault_not_found tests/test_vault_group_access_routes.py::TestListVaultGroupAccess::test_read_permission_user_cannot_list_group_acl_metadata -q --tb=short` -- `2 passed, 4 warnings`
- [x] `python -m pytest --tb=short -v --timeout=300 -n auto tests/` -- `4794 passed, 65 skipped, 2 xfailed, 1 xpassed`
- [x] `python -m ruff check .` -- passed
- [x] `npm run typecheck` -- passed
- [x] `npm run lint` -- passed
- [x] `npm test -- src/pages/VaultsPage.test.tsx` -- `7 passed`
- [x] `npm run test:a11y` -- passed
- [x] `npm test -- src/lib/api.test.ts src/lib/api.csrf.test.ts src/lib/api.sse.test.ts src/pages/WikiPage.sse.test.tsx src/stores/useAuthStore.api-base.test.ts` -- `59 passed`
- [x] `npm test -- src/tests/DocumentsPage.adversarial.virtualization.test.tsx -t "should handle rapid document additions"` -- passed after the full suite exposed a single unrelated load-sensitive timeout in that test
- [x] `npm run build` -- passed
- [x] `$env:VITE_APP_BASENAME='/knowledgevault'; $env:VITE_API_URL='/knowledgevault/api'; npm run build` -- passed
- [x] `$env:VITE_APP_BASENAME='/meridian'; Remove-Item Env:\VITE_API_URL -ErrorAction SilentlyContinue; npm run build` -- passed
- [x] `python scripts/check_config_contract.py` -- passed
- [x] `python scripts/check_pr_scope_drift.py` -- passed

Closes #272


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

