### PR TITLE
fix(security): reverse-proxy hardening (#231)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,12 @@ BACKEND_CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 # Use "*" only inside a trusted private network where untrusted clients cannot connect directly.
 FORWARDED_ALLOW_IPS=127.0.0.1
 
+# Allowed Host header values for TrustedHostMiddleware (comma-separated).
+# When set, requests with a Host header not in this list are rejected (400).
+# Leave empty to disable (default — useful for local dev and bare-IP access).
+# Example for production: ALLOWED_HOSTS=knowledgevault.example.com
+ALLOWED_HOSTS=
+
 # =============================================================================
 # MULTI-USER AUTHENTICATION (JWT)
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- **Reverse-proxy hardening (issue #231)**: Added TrustedHostMiddleware with ALLOWED_HOSTS support to guard against HTTP Host header attacks. Fixed FORWARDED_ALLOW_IPS documentation (no longer recommends `*`). Added SSE heartbeat keepalive comment (`': heartbeat\n\n'`) during long generation gaps to prevent proxy connection timeouts. Session IP capture now uses the trust-proxy-aware `_request_ip()` helper.
+
 - **Phase 2 phase council APPROVED (2 rounds) and Final council APPROVED (5 members)**: issue #265 vault-access fixes reviewed and accepted by full council.
 
 - **Member/user vault access fixes (issue #265)**: `ProfilePage` now calls `GET /vaults/accessible` (available to all authenticated roles) instead of the admin-only `GET /vaults`, eliminating 403 errors for member/viewer users on the profile page. Vault state is now initialized on login and `init()` to validate the cached `vault_id` from localStorage against server state, preventing stale vault selections. `MemoryPage` now guards on `activeVaultId === null` and shows a user-friendly empty-state prompt instead of issuing API calls that would fail with 403 for users with no vault selected.

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -36,7 +36,10 @@ from app.services.auth_service import (
     password_strength_check,
     purge_expired_denied_tokens,
 )
-from app.services.security_audit import safe_record_security_event
+from app.services.security_audit import (
+    _request_ip,
+    safe_record_security_event,
+)
 from app.utils.paths import csrf_cookie_path, refresh_cookie_path
 
 logger = logging.getLogger(__name__)
@@ -245,7 +248,7 @@ async def register(
 
     # Store refresh token session
     expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_MAX_AGE_DAYS)
-    ip_address = request.client.host if request.client else None
+    ip_address = _request_ip(request)
 
     try:
         def _register_session_db():
@@ -416,7 +419,7 @@ async def login(
 
     # Store refresh token session
     expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_MAX_AGE_DAYS)
-    ip_address = request.client.host if request.client else None
+    ip_address = _request_ip(request)
 
     try:
         def _login_create_session():

--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -287,12 +287,33 @@ def stream_chat_response(
         yield f"data: {json.dumps({'type': 'mode', 'mode': resolved_mode.value})}\n\n"
 
         try:
-            async for chunk in rag_engine.query(
+            # Heartbeat: emit a periodic SSE comment (": heartbeat\n\n") during
+            # long generation gaps so intermediate proxies with short read
+            # timeouts (e.g. the nginx default 60s) don't drop the connection.
+            # Per the SSE spec, lines starting with ":" are comments that
+            # EventSource clients silently discard.
+            HEARTBEAT_INTERVAL = 15.0  # seconds
+
+            rag_gen = rag_engine.query(
                 message, history, stream=True, vault_id=vault_id, mode=mode,
                 require_vault=require_vault, user_id=user_id,
                 temperature=temperature, retrieval_mode=retrieval_mode,
                 citation_mode=citation_mode,
-            ):
+            )
+            rag_gen_ait = rag_gen.__aiter__()
+
+            while True:
+                try:
+                    chunk = await asyncio.wait_for(
+                        rag_gen_ait.__anext__(), timeout=HEARTBEAT_INTERVAL
+                    )
+                except asyncio.TimeoutError:
+                    # No data from the model for a full interval — send keepalive.
+                    yield ": heartbeat\n\n"
+                    continue
+                except StopAsyncIteration:
+                    break
+
                 chunk_type = chunk.get("type")
 
                 if chunk_type == "content":

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -643,7 +643,11 @@ class Settings(BaseSettings):
                 parsed = json.loads(value)
                 if not isinstance(parsed, list):
                     raise ValueError("allowed_hosts JSON value must be a list")
-                return [host.strip() for host in parsed if host.strip()]
+                return [
+                    host.strip()
+                    for host in parsed
+                    if isinstance(host, str) and host.strip()
+                ]
             return [host.strip() for host in value.split(",") if host.strip()]
         return v
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -469,6 +469,12 @@ class Settings(BaseSettings):
     trust_proxy_headers: bool = False
     """When True, trust X-Forwarded-For for client IP (use behind trusted reverse proxy). Default False for security."""
 
+    # Host-header validation (defense-in-depth for reverse-proxy deployments).
+    # When non-empty, TrustedHostMiddleware rejects requests whose Host header
+    # is not in this list. Leave empty to disable (the default — useful for
+    # local dev and root deployments accessed by bare IP).
+    allowed_hosts: list[str] = []
+
     health_check_api_key: str = ""
     csrf_cookie_secure: bool = False
     """Set Secure flag on CSRF cookie. Default False for local development. Set to True in production with HTTPS."""
@@ -621,6 +627,24 @@ class Settings(BaseSettings):
                     raise ValueError("backend_cors_origins JSON value must be a list")
                 return parsed
             return [origin.strip() for origin in value.split(",") if origin.strip()]
+        return v
+
+    @field_validator("allowed_hosts", mode="before")
+    @classmethod
+    def parse_allowed_hosts(cls, v):
+        """Support JSON lists and comma-separated env values for allowed hosts."""
+        if isinstance(v, str):
+            value = v.strip()
+            if not value:
+                return []
+            if value.startswith("["):
+                import json
+
+                parsed = json.loads(value)
+                if not isinstance(parsed, list):
+                    raise ValueError("allowed_hosts JSON value must be a list")
+                return [host.strip() for host in parsed if host.strip()]
+            return [host.strip() for host in value.split(",") if host.strip()]
         return v
 
     # Migration validators for backward compatibility

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -118,10 +118,25 @@ if "*" in settings.backend_cors_origins:
 # Host-header validation (defense-in-depth for reverse-proxy deployments).
 # Only activated when ALLOWED_HOSTS is configured — disabled by default so
 # local dev and root deployments accessed by bare IP keep working.
+# Health check endpoints are exempted so Docker/K8s/lb probes (which send
+# Host: localhost) continue to work without needing the probe hostname in
+# ALLOWED_HOSTS.
+_HEALTH_EXEMPT_PATHS = {"/health", "/api/health"}
+
+class _TrustedHostWithHealthExempt(TrustedHostMiddleware):
+    """TrustedHostMiddleware that exempts health-check paths."""
+
+    async def dispatch(self, request, call_next):
+        path = (request.scope.get("path") or "").rstrip("/") or "/"
+        if path in _HEALTH_EXEMPT_PATHS:
+            return await call_next(request)
+        return await super().dispatch(request, call_next)
+
 if settings.allowed_hosts:
-    app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
+    _hosts = list(settings.allowed_hosts)
+    app.add_middleware(_TrustedHostWithHealthExempt, allowed_hosts=_hosts)
     logger.info(
-        "TrustedHostMiddleware enabled with allowed_hosts=%r",
+        "TrustedHostMiddleware enabled with allowed_hosts=%r (health endpoints exempted)",
         settings.allowed_hosts,
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from slowapi.middleware import SlowAPIMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import FileResponse
 
 from app.api.routes.admin import router as admin_router
@@ -112,6 +113,16 @@ if "*" in settings.backend_cors_origins:
         "SECURITY WARNING: CORS origins contain wildcard ('*') with allow_credentials=True. "
         "This configuration is insecure and will be rejected by browsers. "
         "Set BACKEND_CORS_ORIGINS to specific origins (e.g., http://localhost:5173)."
+    )
+
+# Host-header validation (defense-in-depth for reverse-proxy deployments).
+# Only activated when ALLOWED_HOSTS is configured — disabled by default so
+# local dev and root deployments accessed by bare IP keep working.
+if settings.allowed_hosts:
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
+    logger.info(
+        "TrustedHostMiddleware enabled with allowed_hosts=%r",
+        settings.allowed_hosts,
     )
 
 app.include_router(health_router, prefix="/api")

--- a/backend/tests/test_reverse_proxy_hardening_231.py
+++ b/backend/tests/test_reverse_proxy_hardening_231.py
@@ -1,0 +1,268 @@
+"""
+Regression tests for issue #231 — reverse-proxy hardening.
+
+Covers four fixes:
+1. FORWARDED_ALLOW_IPS docs contradiction (admin-guide no longer recommends *)
+2. TrustedHostMiddleware gated on ALLOWED_HOSTS config setting
+3. SSE heartbeat keepalive during long generation gaps
+4. auth.py session ip_address uses trust-proxy-aware helper (_request_ip)
+"""
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Stub missing optional dependencies (matching test_chat_streaming.py pattern)
+try:
+    import lancedb
+except ImportError:
+    import types
+    sys.modules['lancedb'] = types.ModuleType('lancedb')
+
+try:
+    import pyarrow
+except ImportError:
+    import types
+    sys.modules['pyarrow'] = types.ModuleType('pyarrow')
+
+try:
+    from unstructured.partition.auto import partition
+except ImportError:
+    import types
+    _unstructured = types.ModuleType('unstructured')
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType('unstructured.partition')
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType('unstructured.partition.auto')
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType('unstructured.chunking')
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType('unstructured.chunking.title')
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType('unstructured.documents')
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType('unstructured.documents.elements')
+    _unstructured.documents.elements.Element = type('Element', (), {})
+    sys.modules['unstructured'] = _unstructured
+    sys.modules['unstructured.partition'] = _unstructured.partition
+    sys.modules['unstructured.partition.auto'] = _unstructured.partition.auto
+    sys.modules['unstructured.chunking'] = _unstructured.chunking
+    sys.modules['unstructured.chunking.title'] = _unstructured.chunking.title
+    sys.modules['unstructured.documents'] = _unstructured.documents
+    sys.modules['unstructured.documents.elements'] = _unstructured.documents.elements
+
+
+class TestForwardedAllowIpsDocs(unittest.TestCase):
+    """Fix 1: docs/admin-guide.md no longer recommends FORWARDED_ALLOW_IPS=*."""
+
+    def test_admin_guide_does_not_recommend_star(self):
+        """The subpath deployment example must not use FORWARDED_ALLOW_IPS=*."""
+        guide_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'docs', 'admin-guide.md'
+        )
+        with open(guide_path, 'r') as f:
+            content = f.read()
+
+        # The env block example must not show FORWARDED_ALLOW_IPS=*
+        # Find the minimal configuration block and check it uses a CIDR
+        self.assertNotIn(
+            'FORWARDED_ALLOW_IPS=*',
+            content,
+            "admin-guide.md still recommends FORWARDED_ALLOW_IPS=* — "
+            "should use a specific CIDR (e.g. 172.16.0.0/12)"
+        )
+
+
+class TestTrustedHostMiddleware(unittest.TestCase):
+    """Fix 2: TrustedHostMiddleware is wired and gated on ALLOWED_HOSTS."""
+
+    def test_config_has_allowed_hosts_field(self):
+        """Settings must have an allowed_hosts field defaulting to empty list."""
+        from app.config import Settings
+        # Check the field exists on the model
+        field_info = Settings.model_fields.get("allowed_hosts")
+        self.assertIsNotNone(field_info, "allowed_hosts field missing from Settings")
+
+    def test_config_parses_comma_separated_allowed_hosts(self):
+        """The allowed_hosts validator must parse comma-separated strings."""
+        from app.config import Settings
+        s = Settings(allowed_hosts="example.com, api.example.com")
+        self.assertEqual(s.allowed_hosts, ["example.com", "api.example.com"])
+
+    def test_config_parses_empty_allowed_hosts(self):
+        """Empty string should produce an empty list."""
+        from app.config import Settings
+        s = Settings(allowed_hosts="")
+        self.assertEqual(s.allowed_hosts, [])
+
+    def test_main_imports_trusted_host_middleware(self):
+        """main.py must import TrustedHostMiddleware."""
+        main_path = os.path.join(
+            os.path.dirname(__file__), '..', 'app', 'main.py'
+        )
+        with open(main_path, 'r') as f:
+            content = f.read()
+        self.assertIn('TrustedHostMiddleware', content)
+
+    def test_main_gates_on_allowed_hosts(self):
+        """TrustedHostMiddleware must be gated on settings.allowed_hosts being non-empty."""
+        main_path = os.path.join(
+            os.path.dirname(__file__), '..', 'app', 'main.py'
+        )
+        with open(main_path, 'r') as f:
+            content = f.read()
+        self.assertIn('if settings.allowed_hosts:', content)
+        self.assertIn('TrustedHostMiddleware', content)
+
+    def test_trusted_host_rejects_unknown_host(self):
+        """When ALLOWED_HOSTS is set, requests with unlisted Host are rejected."""
+        from fastapi import FastAPI
+        from starlette.middleware.trustedhost import TrustedHostMiddleware
+        from starlette.testclient import TestClient
+
+        app = FastAPI()
+        app.add_middleware(TrustedHostMiddleware, allowed_hosts=["trusted.example.com"])
+
+        @app.get("/")
+        def read_root():
+            return {"hello": "world"}
+
+        client = TestClient(app)
+
+        # Valid host — should pass
+        resp = client.get("/", headers={"Host": "trusted.example.com"})
+        self.assertEqual(resp.status_code, 200)
+
+        # Invalid host — should be rejected
+        resp = client.get("/", headers={"Host": "evil.example.com"})
+        self.assertEqual(resp.status_code, 400)
+
+
+class TestSSEHeartbeat(unittest.TestCase):
+    """Fix 3: SSE heartbeat keepalive comment during long generation gaps."""
+
+    def test_chat_stream_has_heartbeat_logic(self):
+        """chat.py stream_chat_response must contain heartbeat logic."""
+        chat_path = os.path.join(
+            os.path.dirname(__file__), '..', 'app', 'api', 'routes', 'chat.py'
+        )
+        with open(chat_path, 'r') as f:
+            content = f.read()
+        self.assertIn('heartbeat', content.lower())
+        self.assertIn('HEARTBEAT_INTERVAL', content)
+
+    def test_heartbeat_emitted_on_timeout(self):
+        """When the RAG engine stalls, a ': heartbeat\\n\\n' comment is emitted."""
+        import asyncio
+        import json
+
+        # Build a mock RAG engine whose first chunk arrives after a simulated stall.
+        # We patch asyncio.wait_for to raise TimeoutError on the first call to
+        # simulate a 15s gap, then delegate to the real wait_for for subsequent calls.
+        async def mock_query(*args, **kwargs):
+            yield {"type": "content", "content": "late"}
+            yield {"type": "done", "sources": [], "memories_used": []}
+
+        mock_engine = MagicMock()
+        mock_engine.query = mock_query
+
+        from app.api.routes.chat import stream_chat_response
+
+        original_wait_for = asyncio.wait_for
+        call_count = [0]
+
+        async def mock_wait_for(coro, timeout):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                coro.close()
+                raise asyncio.TimeoutError()
+            return await original_wait_for(coro, timeout)
+
+        async def run_test():
+            results = []
+            with patch('app.api.routes.chat.asyncio.wait_for', mock_wait_for):
+                response = stream_chat_response(
+                    message="test", history=[], rag_engine=mock_engine
+                )
+                async for chunk in response.body_iterator:
+                    results.append(chunk)
+            return results
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            results = loop.run_until_complete(run_test())
+        finally:
+            loop.close()
+
+        heartbeat_found = any(
+            isinstance(r, str) and 'heartbeat' in r for r in results
+        )
+        self.assertTrue(heartbeat_found, "No heartbeat comment found in SSE output")
+
+
+class TestAuthSessionIpUsesRequestHelper(unittest.TestCase):
+    """Fix 4: auth.py session ip_address uses _request_ip, not raw request.client.host."""
+
+    def test_auth_imports_request_ip(self):
+        """auth.py must import _request_ip from security_audit."""
+        auth_path = os.path.join(
+            os.path.dirname(__file__), '..', 'app', 'api', 'routes', 'auth.py'
+        )
+        with open(auth_path, 'r') as f:
+            content = f.read()
+        self.assertIn('_request_ip', content)
+
+    def test_auth_no_raw_client_host_for_session_ip(self):
+        """auth.py must not use raw request.client.host for session IP capture."""
+        auth_path = os.path.join(
+            os.path.dirname(__file__), '..', 'app', 'api', 'routes', 'auth.py'
+        )
+        with open(auth_path, 'r') as f:
+            content = f.read()
+
+        # The old pattern: ip_address = request.client.host if request.client else None
+        # should no longer appear in the session capture lines
+        self.assertNotIn(
+            'ip_address = request.client.host',
+            content,
+            "auth.py still uses raw request.client.host for session IP — "
+            "should use _request_ip(request) instead"
+        )
+
+    def test_request_ip_respects_trust_proxy_headers(self):
+        """_request_ip should read X-Forwarded-For when trust_proxy_headers is True."""
+        from app.services.security_audit import _request_ip
+
+        mock_request = MagicMock()
+        mock_request.headers = {
+            "x-forwarded-for": "203.0.113.5, 10.0.0.1",
+        }
+        mock_request.client = MagicMock()
+        mock_request.client.host = "10.0.0.1"
+
+        with patch('app.services.security_audit.settings') as mock_settings:
+            mock_settings.trust_proxy_headers = True
+            result = _request_ip(mock_request)
+            self.assertEqual(result, "203.0.113.5")
+
+    def test_request_ip_ignores_forwarded_when_trust_off(self):
+        """_request_ip should use request.client.host when trust_proxy_headers is False."""
+        from app.services.security_audit import _request_ip
+
+        mock_request = MagicMock()
+        mock_request.headers = {"x-forwarded-for": "203.0.113.5"}
+        mock_request.client = MagicMock()
+        mock_request.client.host = "10.0.0.1"
+
+        with patch('app.services.security_audit.settings') as mock_settings:
+            mock_settings.trust_proxy_headers = False
+            result = _request_ip(mock_request)
+            self.assertEqual(result, "10.0.0.1")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_reverse_proxy_hardening_231.py
+++ b/backend/tests/test_reverse_proxy_hardening_231.py
@@ -114,7 +114,6 @@ class TestTrustedHostMiddleware(unittest.TestCase):
         )
         with open(main_path, 'r') as f:
             content = f.read()
-        self.assertIn('if settings.allowed_hosts:', content)
         self.assertIn('TrustedHostMiddleware', content)
 
     def test_trusted_host_rejects_unknown_host(self):
@@ -139,6 +138,40 @@ class TestTrustedHostMiddleware(unittest.TestCase):
         # Invalid host — should be rejected
         resp = client.get("/", headers={"Host": "evil.example.com"})
         self.assertEqual(resp.status_code, 400)
+
+
+class TestAllowedHostsJSONParsing(unittest.TestCase):
+    """Fix for FB-006/E-T002: ALLOWED_HOSTS JSON list format parsing."""
+
+    def test_parses_empty_json_list(self):
+        """Empty JSON list produces an empty list."""
+        from app.config import Settings
+        s = Settings(allowed_hosts='[]')
+        self.assertEqual(s.allowed_hosts, [])
+
+    def test_parses_json_single_host(self):
+        """JSON list with single host parses correctly."""
+        from app.config import Settings
+        s = Settings(allowed_hosts='["example.com"]')
+        self.assertEqual(s.allowed_hosts, ["example.com"])
+
+    def test_parses_json_multiple_hosts(self):
+        """JSON list with multiple hosts parses correctly."""
+        from app.config import Settings
+        s = Settings(allowed_hosts='["example.com", "api.example.com", "www.example.com"]')
+        self.assertEqual(s.allowed_hosts, ["example.com", "api.example.com", "www.example.com"])
+
+    def test_malformed_json_raises_value_error(self):
+        """Malformed JSON raises ValueError."""
+        from app.config import Settings
+        with self.assertRaises(ValueError):
+            Settings(allowed_hosts='[invalid')
+
+    def test_single_host_parsed_as_csv(self):
+        """Single host without JSON format (plain/comma) parses as CSV."""
+        from app.config import Settings
+        s = Settings(allowed_hosts="localhost")
+        self.assertEqual(s.allowed_hosts, ["localhost"])
 
 
 class TestSSEHeartbeat(unittest.TestCase):
@@ -191,17 +224,23 @@ class TestSSEHeartbeat(unittest.TestCase):
                     results.append(chunk)
             return results
 
+        try:
+            original_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except (RuntimeError, AttributeError):
+            original_loop = None
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
             results = loop.run_until_complete(run_test())
         finally:
             loop.close()
+            if original_loop is not None:
+                asyncio.get_event_loop_policy().set_event_loop(original_loop)
 
         heartbeat_found = any(
-            isinstance(r, str) and 'heartbeat' in r for r in results
+            isinstance(r, str) and ': heartbeat\n\n' in r for r in results
         )
-        self.assertTrue(heartbeat_found, "No heartbeat comment found in SSE output")
+        self.assertTrue(heartbeat_found, "No ': heartbeat\\n\\n' comment found in SSE output")
 
 
 class TestAuthSessionIpUsesRequestHelper(unittest.TestCase):

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -992,6 +992,7 @@ For a subpath deployment such as `https://example.com/knowledgevault/`, configur
 | `VITE_API_URL` | Build arg (optional) | API URL override. Derived from `VITE_APP_BASENAME` when empty |
 | `BACKEND_CORS_ORIGINS` | Runtime env | Allowed CORS origins for your domain |
 | `FORWARDED_ALLOW_IPS` | Runtime env | Trusted proxy IPs for forwarded headers |
+| `ALLOWED_HOSTS` | Runtime env | Allowed Host header values for TrustedHostMiddleware |
 
 **Minimal configuration** (`.env` or environment):
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -999,8 +999,17 @@ For a subpath deployment such as `https://example.com/knowledgevault/`, configur
 APP_ROOT_PATH=/knowledgevault
 VITE_APP_BASENAME=/knowledgevault
 BACKEND_CORS_ORIGINS=https://example.com
-FORWARDED_ALLOW_IPS=*
+FORWARDED_ALLOW_IPS=172.16.0.0/12
 ```
+
+> **Security:** `FORWARDED_ALLOW_IPS` must be the CIDR or IP of your **trusted
+> reverse proxy** — never `*`. With `*`, uvicorn trusts `X-Forwarded-*` from any
+> peer, making `X-Forwarded-For` and `X-Forwarded-Proto` attacker-controlled. The
+> Docker bridge subnet (commonly `172.16.0.0/12`) is safe for a Docker-Compose
+> deployment where the proxy runs in a sibling container; substitute the
+> appropriate IP or CIDR for your environment (e.g. `10.0.0.5` for a host-level
+> nginx). Only use `*` inside a trusted private network where untrusted clients
+> cannot connect directly to port 9090.
 
 `VITE_API_URL` is automatically derived as `/knowledgevault/api` when left empty. To set it explicitly (e.g., for a custom API gateway), add it to your config:
 


### PR DESCRIPTION
## Summary
- **FORWARDED_ALLOW_IPS docs fix**: `docs/admin-guide.md` no longer recommends `*` for subpath deployment — now shows a specific Docker bridge CIDR (`172.16.0.0/12`) with a security warning explaining why `*` is dangerous (attacker-controlled `X-Forwarded-For`/`Proto`).
- **TrustedHostMiddleware**: added `ALLOWED_HOSTS` config setting (defaults to empty = disabled, preserving local dev). When set, Starlette `TrustedHostMiddleware` validates `Host` headers — cheap defense-in-depth for proxied deployments.
- **SSE heartbeat**: `stream_chat_response` now emits a `: heartbeat` SSE comment every 15s during model generation gaps, preventing proxy connections with short read timeouts (e.g. nginx default 60s) from dropping idle-but-active streams.
- **Session IP capture**: `auth.py` registration and login now use the trust-proxy-aware `_request_ip()` helper (from `security_audit`) instead of raw `request.client.host`, making session IP records consistent with security-audit logging when `TRUST_PROXY_HEADERS` is enabled.

Closes #231

## Test plan
- [x] `python3 -m py_compile backend/app/config.py backend/app/main.py backend/app/api/routes/auth.py backend/app/api/routes/chat.py` — OK
- [x] `git diff --check` — clean (no whitespace errors)
- [x] New test suite: `backend/tests/test_reverse_proxy_hardening_231.py` (268 lines covering TrustedHost middleware activation/rejection, `ALLOWED_HOSTS` parsing via JSON list and CSV, SSE heartbeat emission, and session IP capture via `_request_ip`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

