### PR TITLE
fix(security): onboarding hardening - register gate, password rotation, viewer invite validation

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -227,6 +227,8 @@ async def register(
     _csrf_token: str = Depends(csrf_protect),
 ):
     """Register a new user. First user becomes superadmin. Issues CSRF token on success."""
+    if not settings.users_enabled:
+        raise HTTPException(status_code=403, detail="Registration disabled")
     if not body.username or len(body.username) < 3:
         raise HTTPException(
             status_code=400, detail="Username must be at least 3 characters"

--- a/backend/app/api/routes/organizations.py
+++ b/backend/app/api/routes/organizations.py
@@ -628,6 +628,22 @@ async def create_org_invite(
                 detail="Insufficient privileges. Organization admin or owner required",
             )
 
+        # Check invitee global role
+        cursor = await asyncio.to_thread(
+            conn.execute,
+            "SELECT role FROM users WHERE username = ? COLLATE NOCASE",
+            (req.email.lower(),),
+        )
+        invitee_row = await asyncio.to_thread(cursor.fetchone)
+        if invitee_row:
+            from app.api.deps import UserRole
+            invitee_role = invitee_row[0]
+            if UserRole.level(invitee_role) < UserRole.level("member"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot invite user with viewer role - they cannot accept organization invites",
+                )
+
         # Generate token
         raw_token, token_hash = _generate_invite_token()
         now = datetime.now(timezone.utc)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -136,8 +136,8 @@ async def create_user(
             )
 
         # Insert the new user and default assignments in one transaction.
-        cursor = await asyncio.to_thread(conn.execute, """INSERT INTO users (username, hashed_password, full_name, role, is_active)
-            VALUES (?, ?, ?, ?, 1)""", (body.username, hashed_password, body.full_name, body.role))
+        cursor = await asyncio.to_thread(conn.execute, """INSERT INTO users (username, hashed_password, full_name, role, is_active, must_change_password)
+            VALUES (?, ?, ?, ?, 1, 1)""", (body.username, hashed_password, body.full_name, body.role))
         user_id = cursor.lastrowid
 
         # Fetch the created user before commit so response construction remains

--- a/backend/tests/test_auth_register_users_enabled.py
+++ b/backend/tests/test_auth_register_users_enabled.py
@@ -1,0 +1,324 @@
+"""
+Verification tests for the /register endpoint users_enabled guard.
+
+Covers:
+- 403 + "Registration disabled" when users_enabled=False
+- Happy-path registration when users_enabled=True
+- users_enabled guard fires before other validation (username/password)
+- setup-status reflects users_enabled=False correctly
+- Toggling users_enabled between requests
+
+Source: backend/app/api/routes/auth.py lines 230-231
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies (same pattern as conftest.py / other test files)
+try:
+    import lancedb
+except ImportError:
+    import types
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow
+except ImportError:
+    import types
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition
+except ImportError:
+    import types
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType("unstructured.documents.elements")
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _unstructured
+    sys.modules["unstructured.partition"] = _unstructured.partition
+    sys.modules["unstructured.partition.auto"] = _unstructured.partition.auto
+    sys.modules["unstructured.chunking"] = _unstructured.chunking
+    sys.modules["unstructured.chunking.title"] = _unstructured.chunking.title
+    sys.modules["unstructured.documents"] = _unstructured.documents
+    sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.models.database import SQLiteConnectionPool, init_db, run_migrations
+
+
+class TestRegisterUsersEnabledGuard(unittest.TestCase):
+    """Tests for the /register endpoint users_enabled guard (auth.py lines 230-231)."""
+
+    def setUp(self):
+        """Set up test client with temporary database and users_enabled=True."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+
+        # Save originals
+        self._orig_jwt_secret = settings.jwt_secret_key
+        self._orig_users_enabled = settings.users_enabled
+        self._orig_app_root_path = settings.app_root_path
+
+        # Configure for testing
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+        settings.app_root_path = ""
+
+        # Test pool and app
+        self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        from app.api.deps import get_db
+        from app.main import app as main_app
+        from app.security import csrf_protect
+
+        class TestCSRFManager:
+            def generate_token(self):
+                return "test-csrf-token"
+
+            def validate_token(self, token):
+                return token == "test-csrf-token"
+
+        def get_test_db():
+            conn = self.test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.test_pool.release_connection(conn)
+
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        main_app.state.csrf_manager = TestCSRFManager()
+
+        self.client = TestClient(main_app)
+        self.app = main_app
+
+    def tearDown(self):
+        """Restore settings and clean up resources."""
+        settings.jwt_secret_key = self._orig_jwt_secret
+        settings.users_enabled = self._orig_users_enabled
+        settings.app_root_path = self._orig_app_root_path
+
+        self.app.dependency_overrides.clear()
+        self.test_pool.close_all()
+
+        import shutil
+        try:
+            shutil.rmtree(self.temp_dir)
+        except Exception:
+            pass
+
+    # -------------------------------------------------------------------------
+    # users_enabled=False → 403 "Registration disabled"
+    # -------------------------------------------------------------------------
+
+    def test_register_returns_403_when_users_enabled_false(self):
+        """POST /auth/register with users_enabled=False → 403 + detail 'Registration disabled'."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_users_enabled_false_does_not_create_user(self):
+        """When users_enabled=False, no user record should be created."""
+        settings.users_enabled = False
+
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "ghostuser", "password": "Password123"},
+        )
+
+        # Verify no user was created in the database
+        from app.api.deps import get_db
+        conn = self.test_pool.get_connection()
+        try:
+            cursor = conn.execute("SELECT id FROM users WHERE username = ?", ("ghostuser",))
+            row = cursor.fetchone()
+            self.assertIsNone(row, "No user should be created when users_enabled=False")
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def test_register_users_enabled_false_allows_any_username_and_password(self):
+        """Guard fires before username/password validation — weak creds still get 403, not 400."""
+        settings.users_enabled = False
+
+        # These would be 400 if validation ran first; guard short-circuits first
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "ab", "password": "weak"},  # too short for both fields
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    # -------------------------------------------------------------------------
+    # users_enabled=True → registration proceeds normally
+    # -------------------------------------------------------------------------
+
+    def test_register_succeeds_when_users_enabled_true(self):
+        """POST /auth/register with users_enabled=True → 200 + user object."""
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "newuser", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["user"]["username"], "newuser")
+        self.assertEqual(data["user"]["role"], "superadmin")  # first user
+        self.assertIn("access_token", data)
+        self.assertEqual(data["token_type"], "bearer")
+
+    def test_register_first_user_is_superadmin_when_users_enabled_true(self):
+        """First registered user gets superadmin role."""
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "firstadmin", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["user"]["role"], "superadmin")
+
+    def test_register_second_user_is_member_when_users_enabled_true(self):
+        """Second registered user gets member role."""
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "admin1", "password": "Password123"},
+        )
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "member1", "password": "Password456"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["user"]["role"], "member")
+
+    # -------------------------------------------------------------------------
+    # Toggle: disabled → enabled
+    # -------------------------------------------------------------------------
+
+    def test_register_toggle_from_disabled_to_enabled(self):
+        """Can re-enable registration after testing disabled state within same test."""
+        # Disabled first
+        settings.users_enabled = False
+        resp_disabled = self.client.post(
+            "/api/auth/register",
+            json={"username": "user_disabled", "password": "Password123"},
+        )
+        self.assertEqual(resp_disabled.status_code, 403)
+
+        # Re-enable
+        settings.users_enabled = True
+        resp_enabled = self.client.post(
+            "/api/auth/register",
+            json={"username": "user_reenabled", "password": "Password123"},
+        )
+        self.assertEqual(resp_enabled.status_code, 200)
+        self.assertEqual(resp_enabled.json()["user"]["username"], "user_reenabled")
+
+    # -------------------------------------------------------------------------
+    # setup-status reflects users_enabled correctly
+    # -------------------------------------------------------------------------
+
+    def test_setup_status_reports_single_admin_when_users_enabled_false(self):
+        """GET /auth/setup-status with users_enabled=False returns auth_mode='single_admin'."""
+        settings.users_enabled = False
+
+        response = self.client.get("/api/auth/setup-status")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["users_enabled"], False)
+        self.assertEqual(data["auth_mode"], "single_admin")
+        self.assertEqual(data["needs_setup"], False)
+
+    def test_setup_status_reports_jwt_when_users_enabled_true(self):
+        """GET /auth/setup-status with users_enabled=True returns auth_mode='jwt'."""
+        settings.users_enabled = True
+
+        response = self.client.get("/api/auth/setup-status")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["users_enabled"], True)
+        self.assertEqual(data["auth_mode"], "jwt")
+
+    # -------------------------------------------------------------------------
+    # Guard fires before other validations
+    # -------------------------------------------------------------------------
+
+    def test_users_enabled_guard_precedes_username_validation(self):
+        """users_enabled=False check runs before username length check."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "x", "password": "Password123"},
+        )
+
+        # Would be 400 "Username must be at least 3 characters" if guard didn't fire first
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_users_enabled_guard_precedes_password_validation(self):
+        """users_enabled=False check runs before password strength check."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": "weak"},
+        )
+
+        # Would be 400 if guard didn't short-circuit
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_users_enabled_guard_precedes_username_uniqueness_check(self):
+        """users_enabled=False check runs before duplicate-username check."""
+        # Pre-create a user (normal flow)
+        settings.users_enabled = True
+        self.client.post(
+            "/api/auth/register",
+            json={"username": "duplicate", "password": "Password123"},
+        )
+
+        # Now disable and try to register same username
+        settings.users_enabled = False
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "duplicate", "password": "Password456"},
+        )
+
+        # Would be 409 "Username already exists" if guard didn't fire first
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_auth_register_users_enabled_adversarial.py
+++ b/backend/tests/test_auth_register_users_enabled_adversarial.py
@@ -1,0 +1,754 @@
+"""
+Adversarial security tests for /register endpoint users_enabled guard.
+
+Covers ONLY attack vectors against the users_enabled guard at auth.py:230-231:
+- Malformed inputs (invalid JSON, wrong types, missing fields)
+- Oversized payloads (strings exceeding limits, deeply nested objects)
+- Injection attempts (SQL injection in username, special chars in full_name)
+- Auth bypass attempts (header manipulation, method confusion)
+- Boundary violations (exact boundary values, null bytes, Unicode edge cases)
+
+Constraint: ONLY attack vectors against the register endpoint users_enabled guard.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies (same pattern as conftest.py)
+try:
+    import lancedb
+except ImportError:
+    import types
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow
+except ImportError:
+    import types
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition
+except ImportError:
+    import types
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType("unstructured.documents.elements")
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _unstructured
+    sys.modules["unstructured.partition"] = _unstructured.partition
+    sys.modules["unstructured.partition.auto"] = _unstructured.partition.auto
+    sys.modules["unstructured.chunking"] = _unstructured.chunking
+    sys.modules["unstructured.chunking.title"] = _unstructured.chunking.title
+    sys.modules["unstructured.documents"] = _unstructured.documents
+    sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.models.database import SQLiteConnectionPool, init_db, run_migrations
+
+
+class TestRegisterUsersEnabledGuardAdversarial(unittest.TestCase):
+    """Adversarial security tests for /register endpoint users_enabled guard."""
+
+    def setUp(self):
+        """Set up test client with temporary database and users_enabled=True."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+
+        # Save originals
+        self._orig_jwt_secret = settings.jwt_secret_key
+        self._orig_users_enabled = settings.users_enabled
+        self._orig_app_root_path = settings.app_root_path
+
+        # Configure for testing
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+        settings.app_root_path = ""
+
+        # Test pool and app
+        self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        from app.api.deps import get_db
+        from app.main import app as main_app
+        from app.security import csrf_protect
+
+        class TestCSRFManager:
+            def generate_token(self):
+                return "test-csrf-token"
+
+            def validate_token(self, token):
+                return token == "test-csrf-token"
+
+        def get_test_db():
+            conn = self.test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.test_pool.release_connection(conn)
+
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        main_app.state.csrf_manager = TestCSRFManager()
+
+        self.client = TestClient(main_app)
+        self.app = main_app
+
+    def tearDown(self):
+        """Restore settings and clean up resources."""
+        settings.jwt_secret_key = self._orig_jwt_secret
+        settings.users_enabled = self._orig_users_enabled
+        settings.app_root_path = self._orig_app_root_path
+
+        self.app.dependency_overrides.clear()
+        self.test_pool.close_all()
+
+        import shutil
+        try:
+            shutil.rmtree(self.temp_dir)
+        except Exception:
+            pass
+
+    # =========================================================================
+    # ATTACK VECTOR: Oversized Payloads
+    # =========================================================================
+
+    def test_register_oversized_username_256_chars_when_users_disabled(self):
+        """Username at max_length+1 (256) → Pydantic validation 422 BEFORE guard."""
+        settings.users_enabled = False
+        oversized_username = "a" * 256  # exceeds Field(max_length=255)
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": oversized_username, "password": "Password123"},
+        )
+
+        # Pydantic validation happens before guard - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_oversized_password_129_chars_when_users_disabled(self):
+        """Password at max_length+1 (129) → Pydantic validation 422 BEFORE guard."""
+        settings.users_enabled = False
+        oversized_password = "a" * 129  # exceeds Field(max_length=128)
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": oversized_password},
+        )
+
+        # Pydantic validation happens before guard - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_oversized_full_name_256_chars_when_users_disabled(self):
+        """full_name at max_length+1 (256) → Pydantic validation 422 BEFORE guard."""
+        settings.users_enabled = False
+        oversized_full_name = "a" * 256  # exceeds Field(max_length=255)
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={
+                "username": "validuser",
+                "password": "Password123",
+                "full_name": oversized_full_name,
+            },
+        )
+
+        # Pydantic validation happens before guard - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_massive_payload_10kb_when_users_disabled(self):
+        """10KB payload with users_enabled=False should be rejected, not crash."""
+        settings.users_enabled = False
+        massive_username = "a" * 10000
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": massive_username, "password": "Password123"},
+        )
+
+        # Should not return 200 (not registered) and should not crash (500)
+        self.assertIn(
+            response.status_code,
+            [400, 403, 413, 422],
+            f"Massive payload should be rejected, got {response.status_code}",
+        )
+
+    # =========================================================================
+    # ATTACK VECTOR: Malformed Inputs
+    # =========================================================================
+
+    def test_register_invalid_json_when_users_disabled(self):
+        """Invalid JSON body with users_enabled=False should return 403 or 422, not 500."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            content=b"{invalid json",
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertIn(
+            response.status_code,
+            [400, 403, 422],
+            f"Invalid JSON should be rejected, got {response.status_code}",
+        )
+
+    def test_register_empty_username_when_users_disabled(self):
+        """Empty string username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_username_too_short_when_users_disabled(self):
+        """1-char username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "a", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_exactly_3_chars_username_when_users_disabled(self):
+        """Exactly 3-char username (boundary) with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "abc", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_missing_username_when_users_disabled(self):
+        """Missing username field → Pydantic validation 422 BEFORE guard (correct behavior)."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"password": "Password123"},
+        )
+
+        # Validation happens before the guard - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_missing_password_when_users_disabled(self):
+        """Missing password field → Pydantic validation 422 BEFORE guard (correct behavior)."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser"},
+        )
+
+        # Validation happens before the guard - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_null_username_when_users_disabled(self):
+        """null username → Pydantic validation 422 BEFORE guard (correct behavior)."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": None, "password": "Password123"},
+        )
+
+        # Validation happens before the guard - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_type_confusion_integer_username_when_users_disabled(self):
+        """Integer username (type confusion) → Pydantic validation 422 BEFORE guard."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": 12345, "password": "Password123"},
+        )
+
+        # Pydantic validates types before guard fires - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    def test_register_type_confusion_object_password_when_users_disabled(self):
+        """Object password (type confusion) → Pydantic validation 422 BEFORE guard."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": {"nested": "object"}},
+        )
+
+        # Pydantic validates types before guard fires - correct behavior is 422
+        self.assertEqual(response.status_code, 422)
+
+    # =========================================================================
+    # ATTACK VECTOR: Injection Attempts
+    # =========================================================================
+
+    def test_register_sql_injection_when_users_disabled(self):
+        """SQL injection in username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        injection_payloads = [
+            "'; DROP TABLE users; --",
+            "' OR '1'='1",
+            "admin'--",
+            "'; INSERT INTO users VALUES (999,'hacker','pw','','superadmin',1); --",
+            "' UNION SELECT * FROM users --",
+            "' OR 1=1 --",
+            "' OR ''='",
+        ]
+
+        for payload in injection_payloads:
+            response = self.client.post(
+                "/api/auth/register",
+                json={"username": payload, "password": "Password123"},
+            )
+            self.assertEqual(
+                response.status_code,
+                403,
+                f"SQL injection '{payload[:20]}...' should be rejected with 403, got {response.status_code}",
+            )
+            self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_path_traversal_in_username_when_users_disabled(self):
+        """Path traversal in username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        traversal_payloads = [
+            "../../../etc/passwd",
+            "..\\..\\..\\windows\\system32",
+            "....//....//....//etc/passwd",
+            "validuser/../../../etc/passwd",
+        ]
+
+        for payload in traversal_payloads:
+            response = self.client.post(
+                "/api/auth/register",
+                json={"username": payload, "password": "Password123"},
+            )
+            self.assertEqual(
+                response.status_code,
+                403,
+                f"Path traversal '{payload[:20]}...' should be rejected with 403, got {response.status_code}",
+            )
+
+    def test_register_xss_in_full_name_when_users_disabled(self):
+        """XSS payloads in full_name with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        xss_payloads = [
+            "<script>alert(1)</script>",
+            "javascript:alert(1)",
+            "<img src=x onerror=alert(1)>",
+            "{{constructor.constructor('alert(1)')()}}",
+            "<svg onload=alert(1)>",
+        ]
+
+        for payload in xss_payloads:
+            response = self.client.post(
+                "/api/auth/register",
+                json={
+                    "username": "validuser",
+                    "password": "Password123",
+                    "full_name": payload,
+                },
+            )
+            self.assertEqual(
+                response.status_code,
+                403,
+                f"XSS payload '{payload[:20]}...' should be rejected with 403, got {response.status_code}",
+            )
+
+    def test_register_null_bytes_in_username_when_users_disabled(self):
+        """Null bytes in username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        null_byte_payloads = [
+            "validuser\x00",
+            "\x00admin",
+            "admi\x00n",
+        ]
+
+        for payload in null_byte_payloads:
+            response = self.client.post(
+                "/api/auth/register",
+                json={"username": payload, "password": "Password123"},
+            )
+            self.assertEqual(
+                response.status_code,
+                403,
+                f"Null byte payload should be rejected with 403, got {response.status_code}",
+            )
+
+    def test_register_unicode_rtl_override_in_username_when_users_disabled(self):
+        """RTL override Unicode in username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        # RTL override character (U+202E)
+        rtl_payload = "validuser\u202Eadmin"
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": rtl_payload, "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_zero_width_chars_in_username_when_users_disabled(self):
+        """Zero-width characters in username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        # Zero-width space (U+200B), zero-width joiner (U+200D), etc.
+        zwc_payload = "vali\u200B\u200D\u200Cuser"
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": zwc_payload, "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_emoji_in_username_when_users_disabled(self):
+        """Emoji in username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        emoji_payloads = [
+            "admin🔥",
+            "👨‍💻admin",  # ZWJ sequence
+            "admin🏴",  # flag emoji
+        ]
+
+        for payload in emoji_payloads:
+            response = self.client.post(
+                "/api/auth/register",
+                json={"username": payload, "password": "Password123"},
+            )
+            self.assertEqual(
+                response.status_code,
+                403,
+                f"Emoji payload should be rejected with 403, got {response.status_code}",
+            )
+
+    # =========================================================================
+    # ATTACK VECTOR: Auth Bypass Attempts
+    # =========================================================================
+
+    def test_register_auth_bypass_via_x_forwarded_proto_when_disabled(self):
+        """X-Forwarded-Proto cannot enable registration when users_enabled=False."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+            headers={"X-Forwarded-Proto": "https"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_auth_bypass_via_x_original_url_when_disabled(self):
+        """X-Original-URL cannot enable registration when users_enabled=False."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+            headers={"X-Original-URL": "/api/auth/register"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_auth_bypass_via_x_http_method_override_when_disabled(self):
+        """X-HTTP-Method-Override cannot enable registration when users_enabled=False."""
+        settings.users_enabled = False
+
+        # Try to override POST with a more "permissive" method
+        response = self.client.request(
+            "OPTIONS",
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+            headers={"X-HTTP-Method-Override": "POST"},
+        )
+
+        # OPTIONS should not register a user
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_register_http_method_confusion_get_when_disabled(self):
+        """GET on /register endpoint should not register when users_enabled=False."""
+        settings.users_enabled = False
+
+        response = self.client.request(
+            "GET",
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+        )
+
+        # GET should not result in registration (404 - route not found for GET)
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_register_http_method_confusion_put_when_disabled(self):
+        """PUT on /register endpoint should not register when users_enabled=False."""
+        settings.users_enabled = False
+
+        response = self.client.put(
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+        )
+
+        # PUT should not result in registration (405 - method not allowed)
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_register_http_method_confusion_delete_when_disabled(self):
+        """DELETE on /register endpoint should not register when users_enabled=False."""
+        settings.users_enabled = False
+
+        response = self.client.request(
+            "DELETE",
+            "/api/auth/register",
+            json={"username": "anyuser", "password": "Password123"},
+        )
+
+        # DELETE should not result in registration (404/405 - route/method not found)
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_register_wrong_content_type_when_disabled(self):
+        """Non-JSON content type → FastAPI raises exception (not 200)."""
+        settings.users_enabled = False
+
+        # FastAPI raises an exception for malformed content
+        # instead of processing the request - this is secure behavior
+        with self.assertRaises(Exception):
+            self.client.post(
+                "/api/auth/register",
+                content=b"username=admin&password=Password123",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+
+    def test_register_double_content_length_when_disabled(self):
+        """Duplicate Content-Length headers with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        # This may be rejected by the server before reaching the endpoint
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": "Password123"},
+            headers={
+                "Content-Length": "45",
+                "X-Content-Length": "45",  # Alternative header
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    # =========================================================================
+    # ATTACK VECTOR: Boundary Violations
+    # =========================================================================
+
+    def test_register_exactly_max_length_username_when_disabled(self):
+        """Username exactly at max_length (255) with users_enabled=False should 403."""
+        settings.users_enabled = False
+        max_username = "a" * 255
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": max_username, "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_exactly_max_length_password_when_disabled(self):
+        """Password exactly at max_length (128) with users_enabled=False should 403."""
+        settings.users_enabled = False
+        max_password = "a" * 128
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": max_password},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["detail"], "Registration disabled")
+
+    def test_register_whitespace_only_username_when_disabled(self):
+        """Whitespace-only username with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "   ", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_register_newline_in_username_when_disabled(self):
+        """Username with newline character with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "admin\n", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_register_tab_in_username_when_disabled(self):
+        """Username with tab character with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "admin\t", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_register_carriage_return_in_username_when_disabled(self):
+        """Username with carriage return with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "admin\r", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_register_bell_char_in_username_when_disabled(self):
+        """Username with bell character (0x07) with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "admin\x07", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_register_extended_ascii_in_username_when_disabled(self):
+        """Username with extended ASCII with users_enabled=False should still 403."""
+        settings.users_enabled = False
+        extended_ascii_username = "admin\x80"  # Extended ASCII 128
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": extended_ascii_username, "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    # =========================================================================
+    # ATTACK VECTOR: Timing/State Attacks
+    # =========================================================================
+
+    def test_register_rapid_toggle_users_enabled_between_requests(self):
+        """Rapid toggle of users_enabled between requests should not leak state."""
+        # Request 1: disabled
+        settings.users_enabled = False
+        response1 = self.client.post(
+            "/api/auth/register",
+            json={"username": "user1", "password": "Password123"},
+        )
+        self.assertEqual(response1.status_code, 403)
+
+        # Request 2: enabled (rapid toggle)
+        settings.users_enabled = True
+        response2 = self.client.post(
+            "/api/auth/register",
+            json={"username": "user2", "password": "Password123"},
+        )
+        self.assertEqual(response2.status_code, 200)
+
+        # Request 3: disabled again
+        settings.users_enabled = False
+        response3 = self.client.post(
+            "/api/auth/register",
+            json={"username": "user3", "password": "Password123"},
+        )
+        self.assertEqual(response3.status_code, 403)
+
+    # =========================================================================
+    # ATTACK VECTOR: Header Injection
+    # =========================================================================
+
+    def test_register_header_injection_in_user_agent_when_disabled(self):
+        """User-Agent header injection with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": "Password123"},
+            headers={"User-Agent": "Mozilla/5.0\r\nX-Injected-Header: true"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_register_accept_headerManipulation_when_disabled(self):
+        """Accept header manipulation with users_enabled=False should still 403."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": "Password123"},
+            headers={"Accept": "application/json\r\nX-Injected: true"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    # =========================================================================
+    # VERIFY: Guard correctly allows when users_enabled=True
+    # =========================================================================
+
+    def test_register_accepts_valid_input_when_users_enabled_true(self):
+        """Verify that valid registration still works when users_enabled=True."""
+        settings.users_enabled = True
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["user"]["username"], "validuser")
+        self.assertEqual(data["user"]["role"], "superadmin")  # first user
+
+    def test_register_rejects_weak_password_when_enabled(self):
+        """Verify password strength check still works when users_enabled=True."""
+        settings.users_enabled = True
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "validuser2", "password": "weak"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("password", response.json()["detail"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -222,6 +222,18 @@ class TestAuthRoutes(unittest.TestCase):
             },
         )
 
+    def test_register_disabled_when_users_enabled_false(self):
+        """Register endpoint should return 403 when users_enabled is False."""
+        settings.users_enabled = False
+
+        response = self.client.post(
+            "/api/auth/register",
+            json={"username": "newuser", "password": "Password123"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("Registration disabled", response.json()["detail"])
+
     def test_login_success(self):
         """Register then login, verify access_token returned."""
         # First register

--- a/backend/tests/test_org_invites.py
+++ b/backend/tests/test_org_invites.py
@@ -76,6 +76,11 @@ def setup_db(monkeypatch):
         "VALUES (?, ?, ?, ?, ?, 1)",
         (4, "member2@x.com", pw, "Member Two", "member"),
     )
+    conn.execute(
+        "INSERT INTO users (id, username, hashed_password, full_name, role, is_active) "
+        "VALUES (?, ?, ?, ?, ?, 1)",
+        (5, "viewer1@x.com", pw, "Viewer One", "viewer"),
+    )
     conn.commit()
     conn.close()
 
@@ -167,6 +172,11 @@ def member2_token():
                         client_fingerprint=compute_client_fingerprint(""))
 
 
+def viewer_token():
+    return create_access_token(5, "viewer1@x.com", "viewer",
+                        client_fingerprint=compute_client_fingerprint(""))
+
+
 def auth_headers(token_fn):
     return {"Authorization": f"Bearer {token_fn()}"}
 
@@ -207,6 +217,46 @@ class TestCreateInvite:
         assert data["invite_id"] is not None
         assert data["token"].startswith("inv_")
         assert "expires_at" in data
+
+    def test_admin_cannot_invite_viewer_user(self, client):
+        """Admin cannot invite a viewer role user (400)."""
+        org_id = _create_org("Test Org", 2)
+
+        response = client.post(
+            f"/api/organizations/{org_id}/invites",
+            json={"email": "viewer1@x.com", "role": "member"},
+            headers=auth_headers(admin_token),
+        )
+        assert response.status_code == 400
+        assert "viewer role" in response.json()["detail"].lower()
+
+    def test_admin_can_invite_member_user(self, client):
+        """Admin can invite an existing member user (201)."""
+        org_id = _create_org("Test Org", 2)
+
+        response = client.post(
+            f"/api/organizations/{org_id}/invites",
+            json={"email": "member1@x.com", "role": "member"},
+            headers=auth_headers(admin_token),
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["email"] == "member1@x.com"
+        assert data["role"] == "member"
+
+    def test_admin_can_invite_nonexistent_user(self, client):
+        """Admin can invite a nonexistent (not-yet-registered) user (201)."""
+        org_id = _create_org("Test Org", 2)
+
+        response = client.post(
+            f"/api/organizations/{org_id}/invites",
+            json={"email": "notregistered@x.com", "role": "member"},
+            headers=auth_headers(admin_token),
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["email"] == "notregistered@x.com"
+        assert data["role"] == "member"
 
     def test_admin_creates_admin_invite(self, client):
         """Admin creates an admin invite (201)."""

--- a/backend/tests/test_refresh_reuse_revokes_family.py
+++ b/backend/tests/test_refresh_reuse_revokes_family.py
@@ -86,6 +86,8 @@ class TestRefreshReuseRevokesFamily(unittest.TestCase):
         self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
 
         from app.main import app as main_app
+        from app.config import settings
+        settings.users_enabled = True
         from app.security import csrf_protect
 
         class TestCSRFManager:

--- a/backend/tests/test_refresh_reuse_revokes_family.py
+++ b/backend/tests/test_refresh_reuse_revokes_family.py
@@ -85,8 +85,8 @@ class TestRefreshReuseRevokesFamily(unittest.TestCase):
         # Create a test pool for the temporary database
         self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
 
-        from app.main import app as main_app
         from app.config import settings
+        from app.main import app as main_app
         settings.users_enabled = True
         from app.security import csrf_protect
 

--- a/backend/tests/test_users_routes.py
+++ b/backend/tests/test_users_routes.py
@@ -832,6 +832,31 @@ class TestCreateUser(TestUserRoutes):
         assert response.status_code == 403
         assert "superadmin" in response.json()["detail"].lower()
 
+    def test_create_user_sets_must_change_password(self):
+        """Admin-created user has must_change_password=1 in DB and in login response."""
+        from app.security import csrf_protect
+        self.client.app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.post(
+            "/users/",
+            json={
+                "username": "newuser",
+                "password": "SecurePass123!",
+                "full_name": "New User",
+                "role": "member",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+
+        # Verify DB has must_change_password=1
+        row = self.conn.execute(
+            "SELECT must_change_password FROM users WHERE username = ?", ("newuser",)
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 1
+
     def test_create_user_duplicate_username_returns_400(self):
         """Duplicate username returns 400."""
         from app.security import csrf_protect

--- a/backend/tests/test_users_routes_must_change_password.py
+++ b/backend/tests/test_users_routes_must_change_password.py
@@ -1,0 +1,404 @@
+"""
+Verification tests for must_change_password=1 in POST /users/ (create_user) INSERT.
+
+These tests complement the existing TestCreateUser.test_create_user_sets_must_change_password
+test by verifying:
+1. All roles get must_change_password=1 on creation (superadmin, admin, member, viewer)
+2. Both is_active=1 AND must_change_password=1 are set atomically in the INSERT
+3. The INSERT literal values are hardcoded (not parameterized)
+
+These are source-inspection + behavioral tests that verify the INSERT statement itself.
+"""
+
+import os
+import tempfile
+import re
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Set up test environment BEFORE importing app modules
+os.environ["JWT_SECRET_KEY"] = (
+    "test-jwt-secret-key-for-testing-only-12345678901234567890"
+)
+os.environ["USERS_ENABLED"] = "true"
+
+from backend.tests.user_route_helpers import (
+    create_user,
+    get_token,
+    setup_test_db,
+)
+
+
+class TestMustChangePasswordInCreateUserInsert:
+    """Tests verifying must_change_password=1 and is_active=1 are set in create_user INSERT."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test database for each test."""
+        # Create temp directory and database
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+
+        # Clear the global pool cache to ensure test isolation
+        from app.models.database import _pool_cache
+
+        _pool_cache.clear()
+
+        # Set up test database
+        self.conn = setup_test_db(self.db_path)
+
+        # Create test users
+        self.superadmin_id = create_user(
+            self.conn, "superadmin", "pass123", "superadmin", "Super Admin"
+        )
+        self.admin_id = create_user(
+            self.conn, "admin", "pass123", "admin", "Admin User"
+        )
+        self.member_id = create_user(
+            self.conn, "member", "pass123", "member", "Regular Member"
+        )
+        self.viewer_id = create_user(
+            self.conn, "viewer", "pass123", "viewer", "Viewer User"
+        )
+
+        # Create app with users router
+        from app.api.routes.users import router as users_router
+
+        app = FastAPI()
+        app.include_router(users_router)
+
+        # Override the get_db dependency to use our test database
+        from app.api import deps
+        from app.models.database import SQLiteConnectionPool
+
+        # Create a test pool
+        test_pool = SQLiteConnectionPool(self.db_path, max_size=3)
+
+        def override_get_db():
+            """Override get_db to return a connection from test pool."""
+            conn = test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                test_pool.release_connection(conn)
+
+        # Patch get_pool in users module to return our test pool
+        from app.api.routes import users
+
+        original_get_pool = users.get_pool
+        users.get_pool = lambda path: test_pool
+
+        app.dependency_overrides[deps.get_db] = override_get_db
+
+        from app.security import csrf_protect
+
+        app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+
+        # Store for cleanup
+        self.test_pool = test_pool
+        self.original_get_pool = original_get_pool
+
+        from app.config import settings
+        self._orig_users_enabled = settings.users_enabled
+        self._orig_jwt_secret = settings.jwt_secret_key
+        settings.users_enabled = True
+        settings.jwt_secret_key = os.environ["JWT_SECRET_KEY"]
+
+        self.client = TestClient(app)
+        # Override default User-Agent so fingerprint validation matches token
+        self.client.headers["user-agent"] = ""
+
+        yield
+
+        # Cleanup
+        self.client.close()
+        _pool_cache.clear()
+        self.conn.close()
+
+        # Restore original get_pool
+        from app.api.routes import users
+
+        users.get_pool = self.original_get_pool
+        self.test_pool.close_all()
+        settings.users_enabled = self._orig_users_enabled
+        settings.jwt_secret_key = self._orig_jwt_secret
+
+        # Clean up temp directory
+        import shutil
+
+        try:
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+        except Exception:
+            pass
+
+    def _create_user_via_api(self, username: str, role: str) -> dict:
+        """Helper to create a user via the API and return the response data."""
+        from app.security import csrf_protect
+
+        self.client.app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        token = get_token(self.admin_id, "admin", "admin")
+        response = self.client.post(
+            "/users/",
+            json={
+                "username": username,
+                "password": "SecurePass123!",
+                "full_name": f"Test {role}",
+                "role": role,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200, f"Failed to create {role}: {response.json()}"
+        return response.json()
+
+    def _get_user_flags_from_db(self, username: str) -> tuple:
+        """Get (is_active, must_change_password) from DB for a user."""
+        row = self.conn.execute(
+            "SELECT is_active, must_change_password FROM users WHERE username = ?",
+            (username,),
+        ).fetchone()
+        assert row is not None, f"User {username} not found in DB"
+        return (row[0], row[1])
+
+    def test_create_user_member_sets_both_flags(self):
+        """Member user gets is_active=1 AND must_change_password=1 atomically."""
+        self._create_user_via_api("test_member", "member")
+        is_active, must_change = self._get_user_flags_from_db("test_member")
+        assert is_active == 1, f"Expected is_active=1, got {is_active}"
+        assert must_change == 1, f"Expected must_change_password=1, got {must_change}"
+
+    def test_create_user_admin_sets_both_flags(self):
+        """Admin user gets is_active=1 AND must_change_password=1 atomically."""
+        self._create_user_via_api("test_admin", "admin")
+        is_active, must_change = self._get_user_flags_from_db("test_admin")
+        assert is_active == 1, f"Expected is_active=1, got {is_active}"
+        assert must_change == 1, f"Expected must_change_password=1, got {must_change}"
+
+    def test_create_user_superadmin_sets_both_flags(self):
+        """Superadmin user gets is_active=1 AND must_change_password=1 atomically."""
+        # Use superadmin token to create another superadmin
+        from app.security import csrf_protect
+
+        self.client.app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        token = get_token(self.superadmin_id, "superadmin", "superadmin")
+        response = self.client.post(
+            "/users/",
+            json={
+                "username": "test_superadmin2",
+                "password": "SecurePass123!",
+                "full_name": "Test Superadmin 2",
+                "role": "superadmin",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200, f"Failed to create superadmin: {response.json()}"
+
+        is_active, must_change = self._get_user_flags_from_db("test_superadmin2")
+        assert is_active == 1, f"Expected is_active=1, got {is_active}"
+        assert must_change == 1, f"Expected must_change_password=1, got {must_change}"
+
+    def test_create_user_viewer_sets_both_flags(self):
+        """Viewer user gets is_active=1 AND must_change_password=1 atomically."""
+        self._create_user_via_api("test_viewer", "viewer")
+        is_active, must_change = self._get_user_flags_from_db("test_viewer")
+        assert is_active == 1, f"Expected is_active=1, got {is_active}"
+        assert must_change == 1, f"Expected must_change_password=1, got {must_change}"
+
+    def test_insert_statement_has_hardcoded_flags(self):
+        """Source inspection: INSERT uses hardcoded 1,1 for is_active and must_change_password.
+
+        This is a source-inspection test that verifies the INSERT statement in the source
+        code has the literal VALUES (?, ?, ?, ?, 1, 1) with hardcoded 1s for the flags.
+        This prevents accidental parameterization of these security-critical flags.
+        """
+        import inspect
+        from app.api.routes import users
+
+        # Get the source code of the create_user function
+        source = inspect.getsource(users.create_user)
+
+        # The INSERT statement spans multiple lines:
+        #   INSERT INTO users (username, hashed_password, full_name, role, is_active, must_change_password)
+        #   VALUES (?, ?, ?, ?, 1, 1)
+        #
+        # We verify:
+        # 1. The INSERT lists is_active and must_change_password columns
+        # 2. The VALUES clause has hardcoded 1, 1 for these columns (not ? placeholders)
+
+        # Verify INSERT lists both flag columns in the column list
+        assert "is_active" in source and "must_change_password" in source, (
+            "INSERT should list both is_active and must_change_password columns"
+        )
+
+        # Verify VALUES has the hardcoded 1, 1 pattern
+        # The actual source is: VALUES (?, ?, ?, ?, 1, 1)
+        values_pattern = r'VALUES\s*\(\s*\?\s*,\s*\?\s*,\s*\?\s*,\s*\?\s*,\s*1\s*,\s*1\s*\)'
+        match = re.search(values_pattern, source, re.IGNORECASE | re.DOTALL)
+
+        assert match is not None, (
+            "INSERT VALUES clause does not have hardcoded '1, 1' for is_active and must_change_password. "
+            "These flags must be hardcoded to 1 in the VALUES clause, not parameterized."
+        )
+
+    def test_insert_values_order_matches_columns(self):
+        """Source inspection: VALUES count matches column count in INSERT.
+
+        Verifies the INSERT has exactly 6 columns and 6 values:
+        (username, hashed_password, full_name, role, is_active, must_change_password)
+        VALUES (?, ?, ?, ?, 1, 1)
+        """
+        import inspect
+        from app.api.routes import users
+
+        source = inspect.getsource(users.create_user)
+
+        # Count columns in INSERT
+        columns_match = re.search(
+            r'INSERT\s+INTO\s+users\s*\(([^)]+)\)\s*VALUES',
+            source,
+            re.IGNORECASE | re.DOTALL,
+        )
+        assert columns_match is not None, "Could not find INSERT columns in source"
+
+        columns = [c.strip() for c in columns_match.group(1).split(",")]
+        assert len(columns) == 6, f"Expected 6 columns, got {len(columns)}: {columns}"
+        assert columns[4] == "is_active", f"Column 5 should be is_active, got {columns[4]}"
+        assert columns[5] == "must_change_password", f"Column 6 should be must_change_password, got {columns[5]}"
+
+        # Count VALUES placeholders
+        values_match = re.search(
+            r'VALUES\s*\(([^)]+)\)',
+            source,
+            re.IGNORECASE | re.DOTALL,
+        )
+        assert values_match is not None, "Could not find VALUES in source"
+
+        values = [v.strip() for v in values_match.group(1).split(",")]
+        assert len(values) == 6, f"Expected 6 VALUES, got {len(values)}: {values}"
+
+        # The last two values should be hardcoded 1s
+        assert values[4] == "1", f"VALUES[4] (is_active) should be '1', got {values[4]}"
+        assert values[5] == "1", f"VALUES[5] (must_change_password) should be '1', got {values[5]}"
+
+
+class TestMustChangePasswordBehaviorVsAdminReset:
+    """Verify create_user sets same flags as admin_reset_password endpoint."""
+
+    def test_create_user_and_admin_reset_produce_same_flags(self):
+        """Both create_user and admin_reset_password set must_change_password=1.
+
+        This verifies consistency: a newly created user has the same must_change_password
+        flag as one whose password was admin-reset.
+        """
+        tmpdir = tempfile.mkdtemp()
+        db_path = os.path.join(tmpdir, "test.db")
+
+        from app.models.database import _pool_cache
+
+        _pool_cache.clear()
+
+        conn = setup_test_db(db_path)
+        superadmin_id = create_user(conn, "superadmin", "pass123", "superadmin", "Super Admin")
+        admin_id = create_user(conn, "admin", "pass123", "admin", "Admin User")
+        member_id = create_user(conn, "member", "pass123", "member", "Regular Member")
+
+        from app.api.routes.users import router as users_router
+
+        app = FastAPI()
+        app.include_router(users_router)
+
+        from app.api import deps
+        from app.models.database import SQLiteConnectionPool
+
+        test_pool = SQLiteConnectionPool(db_path, max_size=3)
+
+        def override_get_db():
+            conn = test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                test_pool.release_connection(conn)
+
+        from app.api.routes import users
+
+        original_get_pool = users.get_pool
+        users.get_pool = lambda path: test_pool
+
+        app.dependency_overrides[deps.get_db] = override_get_db
+
+        from app.security import csrf_protect
+
+        app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+
+        from app.config import settings
+
+        _orig_users_enabled = settings.users_enabled
+        _orig_jwt_secret = settings.jwt_secret_key
+        settings.users_enabled = True
+        settings.jwt_secret_key = os.environ["JWT_SECRET_KEY"]
+
+        client = TestClient(app)
+        client.headers["user-agent"] = ""
+
+        try:
+            # Create a user via API
+            token = get_token(admin_id, "admin", "admin")
+            response = client.post(
+                "/users/",
+                json={
+                    "username": "newuser",
+                    "password": "SecurePass123!",
+                    "full_name": "New User",
+                    "role": "member",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status_code == 200
+
+            # Check flags after create_user
+            row = conn.execute(
+                "SELECT is_active, must_change_password FROM users WHERE username = ?",
+                ("newuser",),
+            ).fetchone()
+            create_is_active, create_must_change = row[0], row[1]
+
+            # Now admin-reset password on member_id
+            token = get_token(admin_id, "admin", "admin")
+            response = client.patch(
+                f"/users/{member_id}/password",
+                json={"new_password": "AnotherSecurePass123!"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status_code == 200
+
+            # Check flags after admin_reset_password
+            row = conn.execute(
+                "SELECT is_active, must_change_password FROM users WHERE id = ?",
+                (member_id,),
+            ).fetchone()
+            reset_is_active, reset_must_change = row[0], row[1]
+
+            # Both should have must_change_password=1
+            assert create_must_change == 1, f"create_user: must_change_password should be 1, got {create_must_change}"
+            assert reset_must_change == 1, f"admin_reset_password: must_change_password should be 1, got {reset_must_change}"
+
+            # Both should have is_active=1
+            assert create_is_active == 1, f"create_user: is_active should be 1, got {create_is_active}"
+            assert reset_is_active == 1, f"admin_reset_password: is_active should remain 1, got {reset_is_active}"
+
+        finally:
+            client.close()
+            _pool_cache.clear()
+            conn.close()
+            users.get_pool = original_get_pool
+            test_pool.close_all()
+            settings.users_enabled = _orig_users_enabled
+            settings.jwt_secret_key = _orig_jwt_secret
+
+            import shutil
+
+            try:
+                shutil.rmtree(tmpdir, ignore_errors=True)
+            except Exception:
+                pass

--- a/backend/tests/test_users_routes_must_change_password.py
+++ b/backend/tests/test_users_routes_must_change_password.py
@@ -11,8 +11,8 @@ These are source-inspection + behavioral tests that verify the INSERT statement 
 """
 
 import os
-import tempfile
 import re
+import tempfile
 
 import pytest
 from fastapi import FastAPI
@@ -213,6 +213,7 @@ class TestMustChangePasswordInCreateUserInsert:
         This prevents accidental parameterization of these security-critical flags.
         """
         import inspect
+
         from app.api.routes import users
 
         # Get the source code of the create_user function
@@ -249,6 +250,7 @@ class TestMustChangePasswordInCreateUserInsert:
         VALUES (?, ?, ?, ?, 1, 1)
         """
         import inspect
+
         from app.api.routes import users
 
         source = inspect.getsource(users.create_user)


### PR DESCRIPTION
Closes #300

## Summary

Three onboarding security hardening fixes from a focused audit:

**Finding 1 — Register endpoint locked in single-admin mode**
Added settings.users_enabled guard to POST /api/auth/register so it returns 403 with "Registration disabled" when user registration is disabled. Prevents planting latent superadmin rows that could become live if users_enabled is later flipped.

**Finding 2 — Admin-created users forced to rotate password**
Added must_change_password=1 to the create_user INSERT column list so admin-provisioned accounts are prompted to rotate on first login, matching existing dmin_reset_password behavior.

**Finding 3 — Org invite creation rejects viewer-role users**
Added a global role check in create_org_invite that rejects invites addressed to users with global role "viewer" at creation time (HTTP 400), rather than letting them create unredeemable dead invites that fail confusingly at the accept gate.

## Invariant audit
- N/A — This project (RAGAPPv3) does not use opencode-swarm engineering invariants. Backend only, no plugin or subprocess changes.

## Test plan
- [x] Auth route tests: 31/31 pass (1 new test for users_enabled guard)
- [x] User route tests: 73/73 pass (1 new DB assertion, 7 new dedicated tests)
- [x] Org invite tests: 62/62 pass (3 new tests for viewer rejection, member acceptance, nonexistent user acceptance)
- [x] No regressions in any existing tests
- [x] Adversarial tests: 41 attack-vector tests pass for register endpoint
- [x] All 9 SAST findings are pre-existing LOW-severity (test assertions, password hashing calls)
- [x] secretscan findings are pre-existing (password hashing code, not related to changes)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

