### PR TITLE
fix(admin): PR #337 follow-up — debounce, null-safety, error-handling tests, and CI fix

### DIFF
--- a/frontend/src/components/documents/DocumentStatsCards.test.tsx
+++ b/frontend/src/components/documents/DocumentStatsCards.test.tsx
@@ -122,7 +122,9 @@ describe("DocumentStatsCards", () => {
       };
       render(<DocumentStatsCards stats={stats} />);
       // Should fall back to 0 via `?.indexed || 0`
-      expect(screen.getByText("0")).toBeInTheDocument();
+      const indexedLabel = screen.getByText("Indexed");
+      const indexedValue = indexedLabel.closest("div")?.querySelector("h3");
+      expect(indexedValue?.textContent).toBe("0");
     });
   });
 

--- a/frontend/src/pages/AdminUsersPage.error-handling.test.tsx
+++ b/frontend/src/pages/AdminUsersPage.error-handling.test.tsx
@@ -150,14 +150,18 @@ vi.mock('lucide-react', () => ({
 }));
 
 // Helper to create an axios-like error with response.data.detail
-function makeApiError(detail: string) {
-  return {
+function makeApiError(detail: string, originalError?: any) {
+  const error: any = {
     response: {
       data: {
         detail,
       },
     },
   };
+  if (originalError) {
+    error.originalError = originalError;
+  }
+  return error;
 }
 
 // Helper to make a plain error without response (network error etc)
@@ -282,10 +286,32 @@ describe('AdminUsersPage error handling', () => {
     api.default.get.mockRejectedValueOnce(makeNetworkError());
 
     await act(async () => { render(<AdminUsersPage />); });
-    
+
     const toastError = await getToastError();
     await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
     expect(toastError).toHaveBeenCalledWith('Failed to load users');
+  });
+
+  it('fetchUsers: uses generic fallback when error detail is empty string', async () => {
+    const api = await import('@/lib/api');
+    api.default.get.mockRejectedValueOnce(makeApiError(''));
+
+    await act(async () => { render(<AdminUsersPage />); });
+
+    const toastError = await getToastError();
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastError).toHaveBeenCalledWith('Failed to load users');
+  });
+
+  it('fetchUsers: surfaces backend detail from originalError.response.data.detail when response.data.detail is empty string', async () => {
+    const api = await import('@/lib/api');
+    api.default.get.mockRejectedValueOnce(makeApiError('', { response: { data: { detail: 'Original error detail' } } }));
+
+    await act(async () => { render(<AdminUsersPage />); });
+
+    const toastError = await getToastError();
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastError).toHaveBeenCalledWith('Original error detail');
   });
 
   // ============================================================
@@ -783,6 +809,21 @@ describe('AdminUsersPage error handling', () => {
     await vi.waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to load user groups'));
   });
 
+  it('fetchUserGroups: renders empty groups when response.data.groups is missing', async () => {
+    registerUrlResponse('/groups', { data: {} });
+    registerUrlResponse(`/users/2/groups`, { data: {} });
+
+    await act(async () => { render(<AdminUsersPage />); });
+    await vi.waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+
+    const groupButton = document.querySelector('button[aria-label="Manage groups for bob"]');
+    await act(async () => {
+      fireEvent.click(groupButton!);
+    });
+
+    await vi.waitFor(() => expect(screen.getByText('No groups available')).toBeInTheDocument());
+  });
+
   // ============================================================
   // fetchAllOrgs — error in catch block at line 361
   // ============================================================
@@ -814,6 +855,20 @@ describe('AdminUsersPage error handling', () => {
 
     const toastError = await getToastError();
     await vi.waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to load organizations'));
+  });
+
+  it('fetchAllOrgs: renders empty organizations when response.data.organizations is missing', async () => {
+    registerUrlResponse('/organizations/', { data: {} });
+
+    await act(async () => { render(<AdminUsersPage />); });
+    await vi.waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+
+    const orgButton = document.querySelector('button[aria-label="Manage organizations for bob"]');
+    await act(async () => {
+      fireEvent.click(orgButton!);
+    });
+
+    await vi.waitFor(() => expect(screen.getByText('No organizations available')).toBeInTheDocument());
   });
 
   // ============================================================

--- a/frontend/src/pages/AdminUsersPage.pagination.test.tsx
+++ b/frontend/src/pages/AdminUsersPage.pagination.test.tsx
@@ -558,4 +558,27 @@ describe('AdminUsersPage pagination', () => {
       );
     });
   });
+
+  // 11. total=0 page-1 boundary: pagination disabled, page stays at 1, no users displayed
+  it('total=0 shows pagination disabled and no users displayed', async () => {
+    const api = await import('@/lib/api');
+    vi.mocked(api.default.get).mockClear();
+    vi.mocked(api.default.get).mockResolvedValue({ data: { users: [], total: 0 } });
+
+    await act(async () => { render(<AdminUsersPage />); });
+    await waitFor(() => expect(screen.getByTestId('pagination')).toBeInTheDocument());
+
+    // Pagination receives total=0
+    const calls = paginationProps.mock.calls;
+    const lastCall = calls[calls.length - 1][0];
+    expect(lastCall.total).toBe(0);
+
+    // Pagination receives page=1
+    expect(lastCall.page).toBe(1);
+
+    // No users are displayed (empty state)
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+    expect(screen.queryByText('bob')).not.toBeInTheDocument();
+    expect(screen.queryByText('carol')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from "@/stores/useAuthStore";
 import apiClient from "@/lib/api";
 import { useTestMode } from "@/fixtures/TestModeContext";
 import { mockAdminUsers } from "@/fixtures/users";
+import { useDebounce } from "@/hooks/useDebounce";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -60,6 +61,7 @@ function AdminUsersPageContent() {
   const [users, setUsers] = useState<User[]>(testMode ? mockAdminUsers : []);
   const [loading, setLoading] = useState(!testMode);
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery] = useDebounce(searchQuery, 300);
   const [updatingUserId, setUpdatingUserId] = useState<number | null>(null);
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(20);
@@ -110,7 +112,7 @@ function AdminUsersPageContent() {
     try {
       const skip = (page - 1) * limit;
       const response = await apiClient.get<{ users: User[]; total: number }>(
-        `/users/?skip=${skip}&limit=${limit}&q=${encodeURIComponent(searchQuery)}`
+        `/users/?skip=${skip}&limit=${limit}&q=${encodeURIComponent(debouncedSearchQuery)}`
       );
       setUsers(response.data.users);
       setTotalCount(response.data.total);
@@ -121,7 +123,7 @@ function AdminUsersPageContent() {
     } finally {
       setLoading(false);
     }
-  }, [testMode, page, limit, searchQuery]);
+  }, [testMode, page, limit, debouncedSearchQuery]);
 
   useEffect(() => {
     if (!testMode) fetchUsers();
@@ -227,7 +229,13 @@ function AdminUsersPageContent() {
   const fetchAllGroups = async () => {
     try {
       const response = await apiClient.get<{ groups: Group[] }>("/groups");
-      setAllGroups(response.data.groups);
+      setAllGroups((prev) => {
+        const next = response.data.groups ?? [];
+        if (prev.length === next.length && next.length > 0 && prev[0]?.id === next[0]?.id) {
+          return prev;
+        }
+        return next;
+      });
     } catch (err) {
       console.error("Failed to fetch groups:", err);
       const detail = (err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail;
@@ -238,7 +246,7 @@ function AdminUsersPageContent() {
   const fetchUserGroups = async (userId: number) => {
     try {
       const response = await apiClient.get<{ groups: Group[] }>(`/users/${userId}/groups`);
-      setSelectedGroupIds(response.data.groups.map((g) => g.id));
+      setSelectedGroupIds((response.data?.groups ?? []).map((g) => g.id));
     } catch (err) {
       console.error("Failed to fetch user groups:", err);
       const detail = (err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail;
@@ -290,8 +298,14 @@ function AdminUsersPageContent() {
 
   const fetchAllOrgs = async () => {
     try {
-      const response = await apiClient.get<{ organizations: OrgItem[]; total: number }>("/organizations/");
-      setAllOrgs(Array.isArray(response.data) ? response.data : response.data.organizations ?? []);
+      const response = await apiClient.get<{ organizations: OrgItem[]; total: number } | OrgItem[]>("/organizations/");
+      setAllOrgs((prev) => {
+        const next = Array.isArray(response.data) ? response.data : response.data?.organizations ?? [];
+        if (prev.length === next.length && prev[0]?.id === next[0]?.id) {
+          return prev;
+        }
+        return next;
+      });
     } catch (err) {
       console.error("Failed to fetch organizations:", err);
       const detail = (err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail;
@@ -303,7 +317,8 @@ function AdminUsersPageContent() {
     try {
       const response = await apiClient.get<{ organizations: OrgItem[] }>(`/users/${userId}/organizations`);
       const map = new Map<number, string>();
-      for (const o of response.data.organizations) {
+      const orgs = Array.isArray(response.data) ? response.data : response.data?.organizations ?? [];
+      for (const o of orgs) {
         map.set(o.id, o.role || "member");
       }
       setOrgMemberships(map);

--- a/frontend/src/pages/AdminUsersPage/ManageGroupsSheet.tsx
+++ b/frontend/src/pages/AdminUsersPage/ManageGroupsSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useMemo } from "react";
 import { Users, Loader2, Search } from "lucide-react";
 import {
   Sheet,
@@ -43,20 +43,13 @@ export function ManageGroupsSheet({
   onSave,
   onClose,
 }: ManageGroupsSheetProps) {
-  const toggleGroup = useCallback(
-    (groupId: number) => {
-      onToggleGroup(groupId);
-    },
-    [onToggleGroup]
-  );
-
-  const filteredGroups = allGroups.filter((group) => {
+  const filteredGroups = useMemo(() => {
     const searchLower = searchQuery.toLowerCase();
-    return (
+    return allGroups.filter((group) =>
       group.name.toLowerCase().includes(searchLower) ||
       (group.description && group.description.toLowerCase().includes(searchLower))
     );
-  });
+  }, [allGroups, searchQuery]);
 
   return (
     <Sheet open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
@@ -122,10 +115,10 @@ export function ManageGroupsSheet({
                     key={group.id}
                     className="flex items-start space-x-3 rounded-sm border p-3 hover:bg-muted/50 transition-colors"
                   >
-                    <Checkbox
+                      <Checkbox
                       id={`group-${group.id}`}
                       checked={selectedGroupIds.includes(group.id)}
-                      onCheckedChange={() => toggleGroup(group.id)}
+                      onCheckedChange={() => onToggleGroup(group.id)}
                       aria-label={`Select ${group.name}`}
                       disabled={isSaving}
                     />

--- a/frontend/src/pages/AdminUsersPage/ManageOrgsSheet.tsx
+++ b/frontend/src/pages/AdminUsersPage/ManageOrgsSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useMemo } from "react";
 import { Building2, Loader2, Search } from "lucide-react";
 import {
   Sheet,
@@ -52,20 +52,13 @@ export function ManageOrgsSheet({
   onSave,
   onClose,
 }: ManageOrgsSheetProps) {
-  const toggleOrg = useCallback(
-    (orgId: number) => {
-      onToggleOrg(orgId);
-    },
-    [onToggleOrg]
-  );
-
-  const filteredOrgs = allOrgs.filter((org) => {
+  const filteredOrgs = useMemo(() => {
     const searchLower = searchQuery.toLowerCase();
-    return (
+    return allOrgs.filter((org) =>
       org.name.toLowerCase().includes(searchLower) ||
       (org.description && org.description.toLowerCase().includes(searchLower))
     );
-  });
+  }, [allOrgs, searchQuery]);
 
   return (
     <Sheet open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
@@ -135,7 +128,7 @@ export function ManageOrgsSheet({
                       <Checkbox
                         id={`org-${org.id}`}
                         checked={isMember}
-                        onCheckedChange={() => toggleOrg(org.id)}
+                        onCheckedChange={() => onToggleOrg(org.id)}
                         aria-label={`Select ${org.name}`}
                         disabled={isSaving}
                         className="mt-0.5"

--- a/frontend/src/pages/OrgsPage.tsx
+++ b/frontend/src/pages/OrgsPage.tsx
@@ -21,6 +21,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { NATIVE_SELECT_CLASS_NAME } from "@/lib/utils";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { useTestMode } from "@/fixtures/TestModeContext";
+import { useDebounce } from "@/hooks/useDebounce";
 import { PageTitleHeader } from "@/components/layout/PageTitleHeader";
 import {
   Table,
@@ -90,11 +91,11 @@ function OrgsPageContent() {
   const [addingMember, setAddingMember] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserResult | null>(null);
   const [userSearchQuery, setUserSearchQuery] = useState("");
+  const [debouncedUserSearchQuery] = useDebounce(userSearchQuery, 300);
   const [userSearchResults, setUserSearchResults] = useState<UserResult[]>([]);
   const [showUserDropdown, setShowUserDropdown] = useState(false);
   const [searchingUsers, setSearchingUsers] = useState(false);
   const userSearchRef = useRef<HTMLDivElement>(null);
-  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const [newMemberRole, setNewMemberRole] = useState<OrgRole>("member");
   const [updatingMemberId, setUpdatingMemberId] = useState<number | null>(null);
   const [removeMemberDialogOpen, setRemoveMemberDialogOpen] = useState(false);
@@ -119,13 +120,6 @@ function OrgsPageContent() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  // Clean up search timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-    };
-  }, []);
-
   // Debounced user search
   const searchUsers = useCallback(async (query: string) => {
     if (!query.trim()) {
@@ -148,9 +142,11 @@ function OrgsPageContent() {
   const handleUserSearchChange = (value: string) => {
     setUserSearchQuery(value);
     setSelectedUser(null);
-    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-    searchTimeoutRef.current = setTimeout(() => searchUsers(value), 300);
   };
+
+  useEffect(() => {
+    searchUsers(debouncedUserSearchQuery);
+  }, [debouncedUserSearchQuery, searchUsers]);
 
   const selectUser = (user: UserResult) => {
     setSelectedUser(user);
@@ -171,7 +167,7 @@ function OrgsPageContent() {
       setOrgs(Array.isArray(response.data) ? response.data : response.data.organizations ?? []);
     } catch (err: any) {
       console.error("Failed to fetch organizations:", err);
-      toast.error(err?.response?.data?.detail || "Failed to load organizations");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to load organizations");
     } finally {
       setLoading(false);
     }
@@ -185,7 +181,7 @@ function OrgsPageContent() {
       setOrgs((prev) => prev.map((o) => o.id === orgId ? { ...o, members: response.data.members } : o));
     } catch (err: any) {
       console.error("Failed to fetch members:", err);
-      toast.error(err?.response?.data?.detail || "Failed to load members");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to load members");
     }
   }, []);
 
@@ -216,7 +212,7 @@ function OrgsPageContent() {
       setNewOrgName("");
       setNewOrgDescription("");
     } catch (err: any) {
-      toast.error(err?.response?.data?.detail || "Failed to create organization");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to create organization");
     } finally {
       setCreatingOrg(false);
     }
@@ -231,7 +227,7 @@ function OrgsPageContent() {
       setDeleteDialogOpen(false);
       setOrgToDelete(null);
     } catch (err: any) {
-      toast.error(err?.response?.data?.detail || "Failed to delete organization");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to delete organization");
     }
   };
 
@@ -250,7 +246,7 @@ function OrgsPageContent() {
       fetchOrgMembers(orgId);
       setOrgs((prev) => prev.map((o) => o.id === orgId ? { ...o, member_count: o.member_count + 1 } : o));
     } catch (err: any) {
-      const detail = err?.response?.data?.detail || "Failed to add member";
+      const detail = (err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to add member";
       toast.error(detail);
     } finally {
       setAddingMember(false);
@@ -271,7 +267,7 @@ function OrgsPageContent() {
       }));
       toast.success("Role updated successfully");
     } catch (err: any) {
-      toast.error(err?.response?.data?.detail || "Failed to update role");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to update role");
     } finally {
       setUpdatingMemberId(null);
     }
@@ -294,7 +290,7 @@ function OrgsPageContent() {
       setMemberToRemove(null);
       setOrgForMemberAction(null);
     } catch (err: any) {
-      toast.error(err?.response?.data?.detail || "Failed to remove member");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to remove member");
     }
   };
 
@@ -309,7 +305,7 @@ function OrgsPageContent() {
       setTransferTargetId(null);
       fetchOrgMembers(transferOrgId);
     } catch (err: any) {
-      toast.error(err?.response?.data?.detail || "Failed to transfer ownership");
+      toast.error((err as any)?.originalError?.response?.data?.detail || (err as any)?.response?.data?.detail || "Failed to transfer ownership");
     } finally {
       setTransferring(false);
     }


### PR DESCRIPTION
## Summary
- Added useDebounce to AdminUsersPage search to prevent API call cascade on every keystroke
- Added null-safety guards in fetchUserGroups and fetchAllOrgs for malformed API responses
- Updated OrgsPage error handling to include originalError fallback for consistency
- Expanded error-handling test coverage for empty-string detail and originalError chain
- Fixed DocumentStatsCards test assertion to use robust selector
- Added pagination test for total=0 page-1 boundary
- Applied useMemo to filtered lists and removed redundant useCallback wrappers in sheet components

## Test plan
- [x] npm test -- --run src/components/documents/DocumentStatsCards.test.tsx src/pages/AdminUsersPage.error-handling.test.tsx src/pages/AdminUsersPage.pagination.test.tsx src/pages/OrgsPage.test.tsx — 75/75 passed
- [x] npm run typecheck — passes
- [x] git diff --check — no whitespace issues

## Review follow-up
- **F-004 / F-011 — ACCEPTED** (null-safety fallback tests)
  Added regression tests for malformed success responses missing `.groups` / `.organizations`.
- **F-009 — ACCEPTED** (OrgsPage debounce consistency)
  Replaced manual `setTimeout` search debounce with `useDebounce` hook.
- **F-012 / F-023 — ACCEPTED** (test description accuracy)
  Updated test description to match actual empty-string + `originalError` precondition.
- **F-016 / F-017 — ACCEPTED** (useMemo stability)
  Stabilized `allGroups` / `allOrgs` state updates in parent to avoid invalidating sheet `useMemo` on identical fetches.
- **F-018 — ACCEPTED** (null-safety pattern consistency)
  Unified `fetchUserOrgs` with the same `Array.isArray` + `?.organizations ?? []` pattern used in `fetchAllOrgs`.
- **F-021 — ACCEPTED** (type accuracy)
  Widened `fetchAllOrgs` response generic to include the array-or-object runtime contract.
- **F-006 — REJECTED** (docs)
  The PR body previously mentioned a `tsconfig.json` change that is not present in this branch; removed that claim from the description.
