### PR TITLE
fix: Fix email ingestion shutdown/lifecycle defects (#280)

### DIFF
--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -606,7 +606,7 @@ async def lifespan(app: FastAPI):
     # Shutdown: Cancel keepalive, stop file watcher, and close services
     # Stop email ingestion service
     if app.state.email_service:
-        app.state.email_service.stop_polling()
+        await app.state.email_service.stop_polling()
     for kt in (keepalive_task_thinking, keepalive_task_instant):
         if kt:
             kt.cancel()

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -105,6 +105,7 @@ class EmailIngestionService:
         """Callback invoked when the polling task finishes — logs unhandled exceptions."""
         if task.cancelled():
             logger.info("Email polling task was cancelled")
+            self._running = False
             return
         exc = task.exception()
         if exc is not None:
@@ -115,12 +116,16 @@ class EmailIngestionService:
             )
             self._running = False
 
-    def stop_polling(self) -> None:
+    async def stop_polling(self) -> None:
         """
         Stop the email ingestion service gracefully.
 
-        Signals the service to shut down. The actual stop is handled
-        asynchronously in the polling loop.
+        Signals the service to shut down and waits for the polling task
+        to complete. If the task does not stop within the timeout, it
+        is cancelled. This mirrors the FileWatcher.stop() pattern so
+        that callers (e.g. lifespan shutdown) can be certain the poller
+        is no longer active before tearing down shared resources (pool,
+        background_processor). The timeout is bounded at 5.0 seconds.
         """
         if not self._running:
             logger.warning("Email ingestion service is not running")
@@ -128,6 +133,24 @@ class EmailIngestionService:
 
         logger.info("Stopping email ingestion service...")
         self._stop_event.set()
+
+        if self._polling_task is not None:
+            try:
+                await asyncio.wait_for(self._polling_task, timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Email polling task did not stop gracefully, cancelling..."
+                )
+                self._polling_task.cancel()
+                try:
+                    await self._polling_task
+                except asyncio.CancelledError:
+                    pass
+            except asyncio.CancelledError:
+                # Propagation from an outer cancellation — let it through.
+                raise
+
+        logger.info("Email ingestion service stopped")
 
     def is_healthy(self) -> bool:
         """
@@ -370,6 +393,25 @@ class EmailIngestionService:
                 logger.warning(
                     f"Email UID {uid} too large ({size_mb:.2f}MB > {max_mb:.2f}MB), skipping"
                 )
+                # Mark the oversized email as \Seen so it is excluded from
+                # subsequent UNSEEN searches. The normal processing path gets
+                # an implicit \Seen from the (RFC822) body fetch (RFC 3501),
+                # but we return before that fetch, so we must set the flag
+                # explicitly here -- otherwise the poller re-selects and
+                # re-skips this email on every cycle indefinitely.
+                for attempt in range(3):
+                    try:
+                        await imap_client.store(uid, '+FLAGS', '\\Seen')
+                        break
+                    except Exception as e:
+                        if attempt < 2:
+                            continue
+                        logger.warning(
+                            f"Failed to mark oversized email UID {self._sanitize_log_value(uid)} as Seen: {e}"
+                        )
+                        raise OSError(
+                            f"Failed to mark oversized email UID {uid} as Seen after retries"
+                        ) from e
                 return
 
         # Fetch email content

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -98,6 +98,7 @@ class FakeIMAPClient:
         self.fetched_uids = []
         self.logged_out = False
         self.emails = {}  # uid -> email data
+        self.stored_flags = {}  # uid -> list of store calls
 
     async def wait_hello_from_server(self):
         return 'OK'
@@ -118,13 +119,18 @@ class FakeIMAPClient:
         if uid in self.emails:
             email_data = self.emails[uid]
             if 'RFC822.SIZE' in parts:
-                len(email_data['content'])
-                return ('OK', [(b'1 (RFC822.SIZE {size})',)])
+                size = len(email_data['content'])
+                return ('OK', [(f'{uid} (RFC822.SIZE {size})'.encode(),)])
             elif 'RFC822' in parts:
                 # Real aioimaplib returns: [(b'uid (RFC822 {size})', b'...email content...')]
                 # where data[0][0] is the response string and data[0][1] is the email bytes
                 return ('OK', [(b'1 (RFC822)', email_data['content'])])
         return ('OK', [])
+
+    async def store(self, uid, *args):
+        """Record a STORE command (e.g. +FLAGS \\Seen) for test assertions."""
+        self.stored_flags.setdefault(uid, []).append(args)
+        return ('OK', None)
 
     async def logout(self):
         self.logged_out = True
@@ -676,7 +682,7 @@ class TestEmailServiceIntegration(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(self.service._polling_task)
 
             # Stop the service
-            self.service.stop_polling()
+            await self.service.stop_polling()
             # Wait a bit for stop to propagate
             await asyncio.sleep(0.1)
 
@@ -695,7 +701,7 @@ class TestEmailServiceIntegration(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(first_task, second_task)
 
             # Stop the service
-            self.service.stop_polling()
+            await self.service.stop_polling()
             await asyncio.sleep(0.1)
 
     async def test_start_polling_when_disabled(self):
@@ -714,7 +720,7 @@ class TestEmailServiceIntegration(unittest.IsolatedAsyncioTestCase):
     async def test_stop_polling_when_not_running(self):
         """Test stop_polling handles not running gracefully."""
         # Should not raise exception
-        self.service.stop_polling()
+        await self.service.stop_polling()
         self.assertFalse(self.service._running)
 
     async def test_stop_polling_sets_stop_event(self):
@@ -725,7 +731,7 @@ class TestEmailServiceIntegration(unittest.IsolatedAsyncioTestCase):
             await self.service.start_polling()
             self.assertFalse(self.service._stop_event.is_set())
 
-            self.service.stop_polling()
+            await self.service.stop_polling()
             self.assertTrue(self.service._stop_event.is_set())
 
             # Wait a bit for stop to propagate
@@ -837,6 +843,146 @@ class TestEmailServiceIntegration(unittest.IsolatedAsyncioTestCase):
 
             # Check nothing was enqueued
             self.assertEqual(len(self.background_processor.enqueued), 0)
+
+    async def test_oversized_email_marked_seen(self):
+        """Regression for issue #280 A9-5: oversized email must be marked
+        \\Seen so it is excluded from subsequent UNSEEN searches.
+
+        Before the fix, _process_email returned early after the RFC822.SIZE
+        fetch without setting \\Seen. Since the SIZE fetch does not set the
+        flag (RFC 3501), the poller re-selected and re-skipped the same
+        oversized email on every cycle indefinitely.
+        """
+        from app.services.email_service import MAX_EMAIL_SIZE
+
+        fake_imap = FakeIMAPClient()
+
+        # Build an email whose raw bytes exceed MAX_EMAIL_SIZE
+        large_content = b'x' * (MAX_EMAIL_SIZE + 1024)
+        msg = EmailMessage()
+        msg['Subject'] = 'Big Doc [Vault1]'
+        msg['From'] = 'sender@example.com'
+        msg.set_content('body')
+        msg.add_attachment(
+            large_content,
+            maintype='application',
+            subtype='pdf',
+            filename='huge.pdf',
+        )
+
+        fake_imap.emails = {'1': {'content': msg.as_bytes()}}
+
+        with patch('app.services.email_service.aioimaplib.IMAP4_SSL', return_value=fake_imap):
+            await self.service._process_email(fake_imap, '1')
+
+            # Nothing should have been enqueued
+            self.assertEqual(len(self.background_processor.enqueued), 0)
+
+            # The oversized email MUST have been marked \\Seen
+            self.assertIn('1', fake_imap.stored_flags,
+                          "Oversized email was not marked \\Seen — "
+                          "it will be re-polled indefinitely")
+            store_args = fake_imap.stored_flags['1'][0]
+            self.assertIn('\\Seen', store_args)
+
+    async def test_stop_polling_awaits_task_completion(self):
+        """Regression for issue #280 E2-1: stop_polling must await the
+        polling task (or cancel it on timeout) before returning.
+
+        Before the fix, stop_polling was synchronous and only set the stop
+        event. The polling task could still be mid-poll when the caller
+        proceeded to tear down shared resources (pool, background_processor).
+        """
+        fake_imap = FakeIMAPClient()
+
+        with patch('app.services.email_service.aioimaplib.IMAP4_SSL', return_value=fake_imap):
+            await self.service.start_polling()
+            self.assertTrue(self.service._running)
+            task = self.service._polling_task
+            self.assertIsNotNone(task)
+
+            await self.service.stop_polling()
+
+            # After stop_polling returns, the polling task MUST be done
+            self.assertTrue(task.done(),
+                            "stop_polling returned before the polling task finished")
+            self.assertFalse(self.service._running)
+
+    async def test_oversized_email_store_failure_is_handled(self):
+        """Regression for issue #280 follow-up: if marking an oversized
+        email as \\Seen fails after retries, _process_email must raise
+        OSError so _poll_once can log the failure and continue without
+        getting stuck on the same message.
+        """
+        from app.services.email_service import MAX_EMAIL_SIZE
+
+        fake_imap = FakeIMAPClient()
+        call_count = 0
+
+        async def failing_store(uid, *args):
+            nonlocal call_count
+            call_count += 1
+            raise OSError("IMAP store failed")
+
+        fake_imap.store = failing_store
+
+        large_content = b'x' * (MAX_EMAIL_SIZE + 1024)
+        msg = EmailMessage()
+        msg['Subject'] = 'Big Doc [Vault1]'
+        msg['From'] = 'sender@example.com'
+        msg.set_content('body')
+        msg.add_attachment(
+            large_content,
+            maintype='application',
+            subtype='pdf',
+            filename='huge.pdf',
+        )
+
+        fake_imap.emails = {'1': {'content': msg.as_bytes()}}
+
+        with patch('app.services.email_service.aioimaplib.IMAP4_SSL', return_value=fake_imap):
+            with self.assertRaises(OSError) as ctx:
+                await self.service._process_email(fake_imap, '1')
+
+            self.assertIn("Failed to mark oversized email UID 1 as Seen", str(ctx.exception))
+
+            # store() should have been attempted 3 times
+            self.assertEqual(call_count, 3)
+
+            # Nothing should have been enqueued
+            self.assertEqual(len(self.background_processor.enqueued), 0)
+
+    async def test_stop_polling_timeout_cancels_task(self):
+        """Regression for issue #280 E2-1 follow-up: if the polling task
+        does not stop within the 5s timeout, stop_polling must cancel it
+        and await its completion.
+        """
+        fake_imap = FakeIMAPClient()
+
+        async def hang_forever():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                raise
+
+        with patch('app.services.email_service.aioimaplib.IMAP4_SSL', return_value=fake_imap):
+            await self.service.start_polling()
+            self.assertTrue(self.service._running)
+            task = self.service._polling_task
+            self.assertIsNotNone(task)
+
+            # Replace the polling task with one that hangs forever
+            task.cancel()
+            await asyncio.sleep(0)
+            self.service._polling_task = asyncio.create_task(hang_forever())
+            self.service._polling_task.add_done_callback(self.service._on_polling_task_done)
+
+            await self.service.stop_polling()
+
+            # After stop_polling returns, the polling task MUST be done
+            self.assertTrue(self.service._polling_task.done(),
+                            "stop_polling did not cancel/complete the polling task")
+            self.assertFalse(self.service._running)
 
     async def test_process_email_multiple_attachments(self):
         """Test processing email with multiple attachments."""


### PR DESCRIPTION
Closes #280

## Review follow-up

**F-001 — ACCEPTED** (store() failure leaves oversized email UNSEEN)
The store() call for oversized emails now retries up to 3 times before raising OSError, which _poll_once catches and logs. This prevents a bounded re-poll loop when the IMAP store transiently fails.

**F-002 — ACCEPTED** (Redundant _running=False assignment)
Removed the redundant `self._running = False` from stop_polling(). The flag is already managed by _polling_loop and _on_polling_task_done.

**F-003 — ACCEPTED** (Log injection — unsanitized uid)
The new exception log at line 406 now uses `self._sanitize_log_value(uid)` to prevent log injection via malicious IMAP UIDs.

**F-004 — NOTED** (5s shutdown latency)
This is an intentional design trade-off mirroring FileWatcher.stop(). The 5s bound is now documented in the stop_polling() docstring.

**F-005 — ACCEPTED** (Missing negative-path test for store() failure)
Added `test_oversized_email_store_failure_is_handled` which verifies that store() failures are retried and eventually raise OSError.

**F-006 — ACCEPTED** (Missing timeout+cancel path test)
Added `test_stop_polling_timeout_cancels_task` which verifies that a hung polling task is cancelled after the 5s timeout.

**PR author findings:**
- Shutdown ordering: Already mitigated by the 5s timeout+cancel in stop_polling().
- File descriptor leak in _save_attachment(): Pre-existing concern; the current sentinel pattern (fd=None) is correct.
- Redundant _running=False: Same as F-002, now fixed.
- RFC822.SIZE regex parsing: Reviewer verified the existing `if size_match:` guard prevents AttributeError.

---

🤖 This PR was opened by `auto-fix-easy` cron. The fix was attempted autonomously by the `auto-fix-issue` Hermes skill, pre-validated by a local reproduction tier and a pre-PR reviewer. Review carefully.

<!-- This is an auto-generated description by cubic. --><a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a><!-- End of auto-generated description by cubic. -->