### PR TITLE
docs(engineering): document zustand 5 useShallow and vite/vitest alignment

### DIFF
--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -122,8 +122,8 @@ Export shared types/interfaces (`Document`, `Tag`, `Vault`, `ChatSession`, etc.)
 - Styling: Tailwind classes + `cn()` from `lib/utils.ts`; use `formatFileSize`/`formatDate` from `lib/formatters.ts`.
 
 ### State selectors and zustand upgrades
-- Array/object selectors must be stable across renders. In **zustand 5** the `equalityFn` second argument to `useStore(selector, equalityFn)` is silently ignored; use `useStore(useShallow(selector))` from `zustand/shallow` instead. Add a regression test that fails when the broken pattern is present.
-- Verify dependency lockfiles with the CI Node/npm version (Node 20/npm 10). Lockfiles produced by newer npm may be rejected by CI's older npm.
+- Array/object selectors must be stable across renders. In **zustand 5** the `equalityFn` second argument to `useStore(selector, equalityFn)` is silently ignored; use `useStore(useShallow(selector))` from `zustand/shallow` instead. Existing selectors in `frontend/src/stores/` use `useShallow` to avoid unstable references.
+- CI pins Node 20.19.0; regenerate lockfiles with the same Node release so the bundled npm version matches CI. Lockfiles produced by newer npm may be rejected by CI's older npm.
 - Vitest 4.x requires Vite >= 6; keep the top-level `vite` dependency aligned with the `vitest` range.
 
 ### TypeScript & lint

--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -121,6 +121,11 @@ Export shared types/interfaces (`Document`, `Tag`, `Vault`, `ChatSession`, etc.)
 - Routes are lazy (`lazy(() => import(...))`) under `<Suspense>`, wrapped in `ProtectedRoute` + `MainAppShell` in `App.tsx`.
 - Styling: Tailwind classes + `cn()` from `lib/utils.ts`; use `formatFileSize`/`formatDate` from `lib/formatters.ts`.
 
+### State selectors and zustand upgrades
+- Array/object selectors must be stable across renders. In **zustand 5** the `equalityFn` second argument to `useStore(selector, equalityFn)` is silently ignored; use `useStore(useShallow(selector))` from `zustand/shallow` instead. Add a regression test that fails when the broken pattern is present.
+- Verify dependency lockfiles with the CI Node/npm version (Node 20/npm 10). Lockfiles produced by newer npm may be rejected by CI's older npm.
+- Vitest 4.x requires Vite >= 6; keep the top-level `vite` dependency aligned with the `vitest` range.
+
 ### TypeScript & lint
 - `tsconfig` is `strict` with `noUnusedLocals`/`noUnusedParameters`. Use `import type` for type-only imports.
 - Lint is **zero-warning**: `eslint src --max-warnings 0`. `react-hooks/exhaustive-deps` is enforced.

--- a/docs/releases/pending/zustand-vitest-conventions.md
+++ b/docs/releases/pending/zustand-vitest-conventions.md
@@ -1,0 +1,18 @@
+# docs: capture zustand 5 useShallow and vite/vitest lockfile conventions
+
+## What changed
+Added a "State selectors and zustand upgrades" section to `docs/engineering/conventions.md` documenting two hard-won lessons from the Phase 5 dependabot cleanup:
+
+- Zustand 5 silently ignores the `equalityFn` second argument to `useStore`; array/object selectors must use `useStore(useShallow(selector))` from `zustand/shallow` to avoid React "Maximum update depth exceeded" loops.
+- Dependency lockfiles must be regenerated with the CI Node/npm version (Node 20/npm 10); newer npm versions generate lockfile metadata that older CI npm rejects.
+- Vitest 4.x requires Vite >= 6; keep the top-level `vite` dependency aligned with the `vitest` range.
+
+## Why
+These patterns caused real CI failures on dependabot PRs #320 and #332. Capturing them in the engineering conventions prevents regressions when future dependency upgrades touch the frontend store or build toolchain.
+
+## Migration
+No migration required.
+
+## Caveats
+- This is a documentation-only change; no runtime behavior is affected.
+- The existing frontend code already follows these conventions.

--- a/docs/releases/pending/zustand-vitest-conventions.md
+++ b/docs/releases/pending/zustand-vitest-conventions.md
@@ -1,10 +1,10 @@
 # docs: capture zustand 5 useShallow and vite/vitest lockfile conventions
 
 ## What changed
-Added a "State selectors and zustand upgrades" section to `docs/engineering/conventions.md` documenting two hard-won lessons from the Phase 5 dependabot cleanup:
+Added a "State selectors and zustand upgrades" section to `docs/engineering/conventions.md` documenting three hard-won lessons from the Phase 5 dependabot cleanup:
 
 - Zustand 5 silently ignores the `equalityFn` second argument to `useStore`; array/object selectors must use `useStore(useShallow(selector))` from `zustand/shallow` to avoid React "Maximum update depth exceeded" loops.
-- Dependency lockfiles must be regenerated with the CI Node/npm version (Node 20/npm 10); newer npm versions generate lockfile metadata that older CI npm rejects.
+- Dependency lockfiles must be regenerated with the same Node release as CI (Node 20.19.0) so the bundled npm version matches CI; newer npm versions generate lockfile metadata that older CI npm rejects.
 - Vitest 4.x requires Vite >= 6; keep the top-level `vite` dependency aligned with the `vitest` range.
 
 ## Why


### PR DESCRIPTION
## Summary
Adds a new "State selectors and zustand upgrades" subsection to docs/engineering/conventions.md so the lessons learned from the Phase 5 dependabot cleanup are discoverable to future maintainers.

Documents:
- Zustand 5 silently ignores the equalityFn second argument to useStore; array/object selectors must use useStore(useShallow(selector)) from zustand/shallow.
- Regenerate frontend lockfiles with the CI Node/npm version (Node 20/npm 10) to avoid lockfile-format rejection.
- Vitest 4.x requires Vite >= 6; keep the top-level ite dependency aligned with the itest range.

Also adds a release-note fragment under docs/releases/pending/.

## Invariant audit
- 1 (plugin init): not touched - no plugin changes
- 2 (runtime portability): not touched - no runtime code
- 3 (subprocesses): not touched - no subprocess calls
- 4 (.swarm containment): not touched - no .swarm files committed
- 5 (plan durability): not touched - no plan changes
- 6 (test_runner safety): not touched - no test runner usage
- 7 (test writing): not touched - no test files
- 8 (session state): not touched - no session state files
- 9 (guardrails/retry): not touched - no guardrail changes
- 10 (chat/system msg): not touched - no prompt changes
- 11 (tool registration): not touched - no tool registration changes
- 12 (release/cache): not touched - no release/version files edited

## Test plan
- [x] git diff origin/master..HEAD shows only docs/engineering/conventions.md and docs/releases/pending/zustand-vitest-conventions.md.
- [x] Read the rendered Markdown to confirm the new subsection reads correctly.
- [x] Confirmed no source code, config, or test files were modified.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

