### PR TITLE
fix: Fix structured citation contract: wiki/KMS citations silently dropped from answer_contract (#284)

### DIFF
--- a/backend/app/services/answer_contract.py
+++ b/backend/app/services/answer_contract.py
@@ -19,7 +19,7 @@ class StructuredAnswer(BaseModel):
     abstained: bool = False
 
 
-_CITATION_RE = re.compile(r"\[(S\d+|M\d+|W\d+|KMS\d+)\]")
+_CITATION_RE = re.compile(r"\[(S\d+|M\d+|W\d+|K\d+)\]")
 
 
 def build_answer_contract(
@@ -32,8 +32,8 @@ def build_answer_contract(
 ) -> Dict[str, Any]:
     source_labels = {s.get("source_label") for s in sources}
     memory_labels = {m.get("memory_label") for m in memories_used}
-    wiki_labels = {w.get("label_placeholder") for w in wiki_used}
-    kms_labels = {k.get("label_placeholder") for k in kms_used}
+    wiki_labels = {w.get("wiki_label") for w in wiki_used}
+    kms_labels = {k.get("kms_label") for k in kms_used}
     citations: List[AnswerCitation] = []
     for label in dict.fromkeys(_CITATION_RE.findall(content)):
         if label in source_labels:

--- a/backend/tests/test_issue_249_runtime_contracts.py
+++ b/backend/tests/test_issue_249_runtime_contracts.py
@@ -146,6 +146,25 @@ def test_answer_contract_preserves_answer_and_typed_citations():
     assert contract["abstained"] is False
 
 
+def test_answer_contract_includes_wiki_and_kms_citations():
+    """Regression for issue #284: wiki/KMS citations were silently dropped
+    due to (1) regex matching [KMS#] instead of real [K#] labels, and
+    (2) label sets built from nonexistent 'label_placeholder' key instead
+    of 'wiki_label'/'kms_label'."""
+    contract = build_answer_contract(
+        "Wiki says [W1] and KMS says [K1].",
+        sources=[],
+        memories_used=[],
+        wiki_used=[{"wiki_label": "W1"}],
+        kms_used=[{"kms_label": "K1"}],
+    )
+
+    assert contract["citations"] == [
+        {"label": "W1", "evidence_type": "wiki"},
+        {"label": "K1", "evidence_type": "kms"},
+    ]
+
+
 class DummyLLMClient:
     def __init__(self, name, *, fail=False, content=""):
         self.base_url = name


### PR DESCRIPTION
Closes #284

---
🤖 This PR was opened by `auto-fix-easy` cron. The fix was attempted autonomously by the `auto-fix-issue` Hermes skill, pre-validated by a local reproduction tier and a pre-PR reviewer. Review carefully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

