### PR TITLE
fix: Fix LoginPage demo-credential bypass missing production DEV gate (#290)

### DIFF
--- a/frontend/src/pages/LoginPage.dev-gate.test.ts
+++ b/frontend/src/pages/LoginPage.dev-gate.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * Regression test for issue #290: LoginPage demo-credential bypass missing
+ * production DEV gate.
+ *
+ * The security property: `TEST_MODE` in LoginPage.tsx must be gated on
+ * `import.meta.env.DEV` so Vite statically replaces it with `false` during
+ * `vite build`, dead-code-eliminating the demo-credential login bypass
+ * (lines that call `useAuthStore.setState` with a synthetic superadmin user
+ * and `accessToken='demo-token'`).
+ *
+ * This invariant cannot be tested via component rendering because Vitest runs
+ * in DEV mode (`import.meta.env.DEV === true`), so both the buggy and fixed
+ * code behave identically in tests. The vulnerability only manifests at build
+ * time. Therefore we verify the source-level invariant directly.
+ */
+const source = readFileSync("src/pages/LoginPage.tsx", "utf-8");
+
+describe("LoginPage TEST_MODE DEV gate (issue #290)", () => {
+  it("gates TEST_MODE on import.meta.env.DEV, matching App.tsx", () => {
+    // Extract the TEST_MODE constant definition
+    const match = source.match(/const\s+TEST_MODE\s*=\s*(.+?);/s);
+    expect(match).not.toBeNull();
+    const testModeExpr = match![1];
+
+    // The expression MUST contain the import.meta.env.DEV guard
+    expect(testModeExpr).toContain("import.meta.env.DEV");
+    // The expression MUST contain the VITE_TEST_MODE check
+    expect(testModeExpr).toContain("import.meta.env.VITE_TEST_MODE");
+  });
+
+  it("does NOT define TEST_MODE without the DEV guard (the original bug)", () => {
+    // This regex matches the buggy pattern: TEST_MODE = import.meta.env.VITE_TEST_MODE === "true"
+    // WITHOUT the import.meta.env.DEV && prefix
+    const buggyPattern =
+      /const\s+TEST_MODE\s*=\s*import\.meta\.env\.VITE_TEST_MODE\s*===\s*"true"\s*;/;
+    expect(source).not.toMatch(buggyPattern);
+  });
+});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -17,7 +17,10 @@ import { MeridianLogo } from "@/components/icons/MeridianLogo";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { LockPasswordIcon, Login01Icon, User02Icon, ViewOffSlashIcon, ViewIcon } from "@hugeicons/core-free-icons";
 
-const TEST_MODE = import.meta.env.VITE_TEST_MODE === "true";
+// Gated on import.meta.env.DEV so it is statically false (and dead-code
+// eliminated) in any production build — the demo auth bypass can never ship
+// in `vite build` output regardless of VITE_TEST_MODE. Mirrors App.tsx.
+const TEST_MODE = import.meta.env.DEV && import.meta.env.VITE_TEST_MODE === "true";
 const DEMO_USERNAME = import.meta.env.VITE_DEMO_USERNAME || "demo";
 const DEMO_PASSWORD = import.meta.env.VITE_DEMO_PASSWORD || "demo123";
 


### PR DESCRIPTION
Closes #290

---
🤖 This PR was opened by `auto-fix-easy` cron. The fix was attempted autonomously by the `auto-fix-issue` Hermes skill, pre-validated by a local reproduction tier and a pre-PR reviewer. Review carefully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

