### PR TITLE
feat(documents): failed-chunk retry, ranked /documents/search, PDF chunk_bbox, configurable context window

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -338,6 +338,91 @@ async def retry_document(
         raise HTTPException(status_code=500, detail=f"Retry failed: {exc}")
 
 
+@router.post("/{file_id}/retry-chunks")
+@limiter.limit(settings.admin_rate_limit)
+async def retry_failed_chunks(
+    file_id: int,
+    request: Request,
+    conn: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(require_admin_role),
+    csrf_token: str = Depends(csrf_protect),
+    vector_store: VectorStore = Depends(get_vector_store),
+    embedding_service: EmbeddingService = Depends(get_embedding_service),
+    db_pool: SQLiteConnectionPool = Depends(get_db_pool),
+    secret_manager: SecretManager = Depends(get_secret_manager),
+    current_user: dict | None = Depends(_optional_current_user),
+) -> dict:
+    """Re-embed and re-index only the chunks that failed during ingest (Issue #396).
+
+    Unlike the whole-document retry above, this targets only the chunks recorded
+    in ``failed_chunks`` for a file whose status is ``indexed`` (partial-failure
+    case). Returns 409 when the file is not in a retryable state.
+    """
+    # Verify the file exists and is retryable before constructing the processor.
+    cursor = await asyncio.to_thread(
+        conn.execute,
+        "SELECT status FROM files WHERE id = ?",
+        (file_id,),
+    )
+    file_row = await asyncio.to_thread(cursor.fetchone)
+    if file_row is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    processor = DocumentProcessor(
+        chunk_size_chars=settings.chunk_size_chars,
+        chunk_overlap_chars=settings.chunk_overlap_chars,
+        vector_store=vector_store,
+        embedding_service=embedding_service,
+        pool=db_pool,
+    )
+
+    user_id = (
+        str(current_user["id"])
+        if current_user and current_user.get("id")
+        else user.get("id", "unknown")
+    )
+    try:
+        result = await processor.retry_failed_chunks(file_id)
+    except ValueError as exc:
+        # Not retryable (status != 'indexed' or file missing) → 409.
+        await asyncio.to_thread(
+            _record_document_action,
+            file_id,
+            "retry-chunks",
+            "rejected",
+            user_id,
+            secret_manager,
+            conn,
+        )
+        await asyncio.to_thread(conn.commit)
+        raise HTTPException(status_code=409, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Error retrying failed chunks for document %d", file_id)
+        await asyncio.to_thread(
+            _record_document_action,
+            file_id,
+            "retry-chunks",
+            "error",
+            user_id,
+            secret_manager,
+            conn,
+        )
+        await asyncio.to_thread(conn.commit)
+        raise HTTPException(status_code=500, detail=f"Retry-chunks failed: {exc}")
+
+    await asyncio.to_thread(
+        _record_document_action,
+        file_id,
+        "retry-chunks",
+        "ok",
+        user_id,
+        secret_manager,
+        conn,
+    )
+    await asyncio.to_thread(conn.commit)
+    return {"file_id": file_id, **result}
+
+
 class DocumentResponse(BaseModel):
     """Response model for a document record - frontend compatible."""
 
@@ -349,6 +434,8 @@ class DocumentResponse(BaseModel):
     status: str
     chunk_count: int
     chunks_failed: int = 0  # Chunks dropped due to embedding failures (Issue #221)
+    failed_chunks: int = 0  # Count of failed chunks eligible for retry (Issue #396)
+    failed_chunk_ids: List[int] = Field(default_factory=list)  # Chunk indices (Issue #396)
     size: Optional[int] = None  # Frontend expects size
     created_at: Optional[str]
     processed_at: Optional[str]
@@ -526,6 +613,28 @@ def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
     file_name = row["file_name"]
     chunk_count = row["chunk_count"] or 0
     chunks_failed = (row["chunks_failed"] if "chunks_failed" in keys else 0) or 0
+    failed_chunks_count = (
+        row["failed_chunks"] if "failed_chunks" in keys else None
+    )
+    failed_chunk_ids_raw = (
+        row["failed_chunk_ids"] if "failed_chunk_ids" in keys else None
+    )
+    # Parse failed_chunk_ids: may come from json_group_array (JSON string like
+    # "[0,3]" or sqlite json_group_array output "[0,3]"), or be None.
+    failed_chunk_ids: List[int] = []
+    if failed_chunk_ids_raw is not None:
+        try:
+            import json as _json
+
+            parsed = _json.loads(failed_chunk_ids_raw)
+            if isinstance(parsed, list):
+                failed_chunk_ids = [int(x) for x in parsed]
+        except (ValueError, TypeError):
+            failed_chunk_ids = []
+    # Fallback: count derived from ids list when the correlated subquery wasn't
+    # included in the SELECT.
+    if failed_chunks_count is None:
+        failed_chunks_count = len(failed_chunk_ids)
     status = row["status"]
     error_message = row["error_message"] if "error_message" in keys else None
     phase = row["phase"] if "phase" in keys else None
@@ -569,6 +678,8 @@ def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
         status=status,
         chunk_count=chunk_count,
         chunks_failed=chunks_failed,
+        failed_chunks=failed_chunks_count,
+        failed_chunk_ids=failed_chunk_ids,
         size=row["file_size"]
         if "file_size" in row.keys() and row["file_size"] is not None
         else None,
@@ -593,6 +704,8 @@ def _row_to_document_response(row: sqlite3.Row) -> DocumentResponse:
             "chunk_count": chunk_count,
             "chunks": chunk_count,  # Backward compatibility
             "chunks_failed": chunks_failed,
+            "failed_chunks": failed_chunks_count,
+            "failed_chunk_ids": failed_chunk_ids,
             # Keep progress fields mirrored for legacy metadata-based clients.
             "error_message": error_message,
             "phase": phase,
@@ -745,7 +858,10 @@ async def list_documents(
                    created_at, processed_at, error_message, phase, phase_message,
                    progress_percent, processed_units, total_units, unit_label,
                    phase_started_at, processing_started_at, enrichment_status,
-                   enrichment_error, vault_id, folder_id
+                   enrichment_error, vault_id, folder_id,
+                   (SELECT COUNT(*) FROM failed_chunks WHERE file_id = files.id) AS failed_chunks,
+                   (SELECT COALESCE(json_group_array(chunk_index), '[]')
+                    FROM failed_chunks WHERE file_id = files.id) AS failed_chunk_ids
             FROM files
             WHERE vault_id = ?{_extra_clause()}
             {order_clause}
@@ -775,7 +891,10 @@ async def list_documents(
                        created_at, processed_at, error_message, phase, phase_message,
                        progress_percent, processed_units, total_units, unit_label,
                        phase_started_at, processing_started_at, enrichment_status,
-                       enrichment_error, vault_id, folder_id
+                       enrichment_error, vault_id, folder_id,
+                       (SELECT COUNT(*) FROM failed_chunks WHERE file_id = files.id) AS failed_chunks,
+                       (SELECT COALESCE(json_group_array(chunk_index), '[]')
+                        FROM failed_chunks WHERE file_id = files.id) AS failed_chunk_ids
                 FROM files
                 WHERE vault_id IN ({placeholders}){_extra_clause()}
                 {order_clause}
@@ -799,7 +918,10 @@ async def list_documents(
                        created_at, processed_at, error_message, phase, phase_message,
                        progress_percent, processed_units, total_units, unit_label,
                        phase_started_at, processing_started_at, enrichment_status,
-                       enrichment_error, vault_id, folder_id
+                       enrichment_error, vault_id, folder_id,
+                       (SELECT COUNT(*) FROM failed_chunks WHERE file_id = files.id) AS failed_chunks,
+                       (SELECT COALESCE(json_group_array(chunk_index), '[]')
+                        FROM failed_chunks WHERE file_id = files.id) AS failed_chunk_ids
                 FROM files{base_where}
                 {order_clause}
                 LIMIT ? OFFSET ?
@@ -839,6 +961,9 @@ class DocumentStatusResponse(BaseModel):
     filename: str
     status: str
     chunk_count: int
+    chunks_failed: int = 0  # Aggregate counter (Issue #221)
+    failed_chunks: int = 0  # Count eligible for chunk-scoped retry (Issue #396)
+    failed_chunk_ids: List[int] = Field(default_factory=list)  # Chunk indices (Issue #396)
     error_message: Optional[str] = None
     processed_at: Optional[str] = None
     # Phase-aware progress
@@ -875,7 +1000,8 @@ async def get_document_status(
     cursor = await asyncio.to_thread(
         conn.execute,
         """
-        SELECT id, vault_id, file_name, status, chunk_count, error_message,
+        SELECT id, vault_id, file_name, status, chunk_count, chunks_failed,
+               error_message,
                processed_at, phase, phase_message, progress_percent,
                processed_units, total_units, unit_label, phase_started_at,
                processing_started_at, wiki_pending, enrichment_status,
@@ -938,11 +1064,28 @@ async def get_document_status(
         except (ValueError, TypeError):
             elapsed_seconds = None
 
+    # Failed-chunk accounting for chunk-scoped retry (Issue #396).
+    failed_chunk_ids: List[int] = []
+    try:
+        fc_cursor = await asyncio.to_thread(
+            conn.execute,
+            "SELECT chunk_index FROM failed_chunks WHERE file_id = ? ORDER BY chunk_index",
+            (file_id,),
+        )
+        fc_rows = await asyncio.to_thread(fc_cursor.fetchall)
+        failed_chunk_ids = [int(r["chunk_index"]) for r in fc_rows]
+    except sqlite3.Error:
+        # failed_chunks table may not exist on very old test fixtures.
+        pass
+
     return DocumentStatusResponse(
         id=row["id"],
         filename=row["file_name"],
         status=row["status"],
         chunk_count=row["chunk_count"] or 0,
+        chunks_failed=row["chunks_failed"] or 0,
+        failed_chunks=len(failed_chunk_ids),
+        failed_chunk_ids=failed_chunk_ids,
         error_message=_safe_get(row, "error_message"),
         processed_at=_safe_get(row, "processed_at"),
         phase=_safe_get(row, "phase"),
@@ -1041,6 +1184,178 @@ def _safe_get(row, key: str, default=None):
         return row[key]  # tuple/dict
     except (KeyError, IndexError, TypeError):
         return default
+
+
+class DocumentSearchResult(BaseModel):
+    """A single ranked document-search hit (Issue #396)."""
+
+    id: int
+    file_name: str
+    vault_id: int
+    status: str
+    score: float  # Normalized bm25 relevance (lower bm25 = better; negated for display)
+    excerpt: str  # Matched snippet with <mark> highlights (or fallback window)
+    match_type: str  # "body" | "metadata" | "filename"
+
+
+class DocumentSearchResponse(BaseModel):
+    """Ranked document-search response with excerpts (Issue #396)."""
+
+    results: List[DocumentSearchResult]
+    total: int
+    query: str
+
+
+@router.get("/search", response_model=DocumentSearchResponse)
+async def search_documents(
+    q: str = Query(..., min_length=1, max_length=200, description="Search query"),
+    vault_id: Optional[int] = Query(None, description="Restrict to a vault"),
+    limit: int = Query(20, ge=1, le=50),
+    offset: int = Query(0, ge=0),
+    conn: sqlite3.Connection = Depends(get_db),
+    user: dict = Depends(get_current_user_or_service_account),
+    evaluate: Callable = Depends(get_evaluate_policy),
+):
+    """Ranked document search returning matching excerpts (Issue #396).
+
+    Ranks by ``bm25()`` over ``files_content_fts`` (document body) and
+    ``files_search_fts`` (metadata), with a filename LIKE fallback. Returns one
+    row per document (de-duplicated in SQL before pagination) with a highlighted
+    excerpt. Authz mirrors ``GET /documents``: vault read check when
+    ``vault_id`` is given, accessible-vault filter for non-admins without one.
+    """
+    query_text = q.strip()
+    if not query_text:
+        raise HTTPException(status_code=400, detail="Query must not be empty")
+
+    fts_query = _build_files_fts_query(query_text)
+    if not fts_query:
+        raise HTTPException(status_code=400, detail="Query has no searchable tokens")
+    like_query = f"%{query_text.lower()}%"
+
+    # Resolve the vault scope (mirrors list_documents).
+    accessible_vaults: Optional[List[int]] = None
+    if vault_id is not None:
+        if not await evaluate(user, "vault", vault_id, "read"):
+            raise HTTPException(status_code=403, detail="Access denied to vault")
+        scope_vaults: List[int] = [vault_id]
+    else:
+        if user.get("role") not in ("admin", "superadmin"):
+            accessible_vaults = await get_user_accessible_vault_ids(user, conn)
+            if not accessible_vaults:
+                return DocumentSearchResponse(results=[], total=0, query=q)
+            scope_vaults = accessible_vaults
+        else:
+            scope_vaults = []  # admin: no vault restriction
+
+    if scope_vaults:
+        placeholders = ",".join("?" * len(scope_vaults))
+        vault_clause_body = f"f.vault_id IN ({placeholders})"
+        vault_clause_meta = vault_clause_body
+        vault_clause_name = vault_clause_body
+        vault_params = list(scope_vaults)
+    else:
+        vault_clause_body = "1=1"
+        vault_clause_meta = "1=1"
+        vault_clause_name = "1=1"
+        vault_params = []
+
+    # CTE + ROW_NUMBER dedup: keep one row per doc (body > metadata > filename).
+    # bm25() returns negative values (more negative = better); ORDER BY rank ASC.
+    ranked_sql = f"""
+    WITH raw_matches AS (
+        SELECT f.id, f.file_name, f.vault_id, f.status, f.parsed_text,
+               bm25(files_content_fts) AS rank,
+               highlight(files_content_fts, 0, '<mark>', '</mark>') AS excerpt_raw,
+               1 AS type_priority
+        FROM files_content_fts
+        JOIN files f ON f.id = files_content_fts.rowid
+        WHERE files_content_fts MATCH ?
+          AND {vault_clause_body}
+        UNION ALL
+        SELECT f.id, f.file_name, f.vault_id, f.status, f.parsed_text,
+               bm25(files_search_fts) AS rank,
+               highlight(files_search_fts, 0, '<mark>', '</mark>') AS excerpt_raw,
+               2 AS type_priority
+        FROM files_search_fts
+        JOIN files f ON f.id = files_search_fts.rowid
+        WHERE files_search_fts MATCH ?
+          AND {vault_clause_meta}
+        UNION ALL
+        SELECT f.id, f.file_name, f.vault_id, f.status, f.parsed_text,
+               0.0 AS rank, NULL AS excerpt_raw,
+               3 AS type_priority
+        FROM files f
+        WHERE LOWER(f.file_name) LIKE ?
+          AND {vault_clause_name}
+    ),
+    ranked AS (
+        SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY type_priority ASC, rank ASC) AS rn
+        FROM raw_matches
+    )
+    SELECT id, file_name, vault_id, status, rank, excerpt_raw, parsed_text, type_priority
+    FROM ranked WHERE rn = 1
+    ORDER BY type_priority ASC, rank ASC
+    LIMIT ? OFFSET ?
+    """
+
+    count_sql = f"""
+    WITH raw_matches AS (
+        SELECT f.id FROM files_content_fts
+        JOIN files f ON f.id = files_content_fts.rowid
+        WHERE files_content_fts MATCH ? AND {vault_clause_body}
+        UNION
+        SELECT f.id FROM files_search_fts
+        JOIN files f ON f.id = files_search_fts.rowid
+        WHERE files_search_fts MATCH ? AND {vault_clause_meta}
+        UNION
+        SELECT f.id FROM files f
+        WHERE LOWER(f.file_name) LIKE ? AND {vault_clause_name}
+    )
+    SELECT COUNT(*) AS total FROM raw_matches
+    """
+
+    base_params = [fts_query, *vault_params, fts_query, *vault_params, like_query, *vault_params]
+    cursor = await asyncio.to_thread(
+        conn.execute,
+        ranked_sql,
+        [*base_params, limit, offset],
+    )
+    rows = await asyncio.to_thread(cursor.fetchall)
+
+    count_cursor = await asyncio.to_thread(
+        conn.execute, count_sql, base_params
+    )
+    total = (await asyncio.to_thread(count_cursor.fetchone))[0]
+
+    results: List[DocumentSearchResult] = []
+    for row in rows:
+        match_type = {1: "body", 2: "metadata", 3: "filename"}.get(
+            int(row["type_priority"]), "body"
+        )
+        excerpt_raw = row["excerpt_raw"]
+        # Excerpt finalization: FTS highlight → parsed_text window → filename.
+        if isinstance(excerpt_raw, str) and excerpt_raw.strip():
+            excerpt = excerpt_raw[:300]
+        elif row["parsed_text"]:
+            excerpt = str(row["parsed_text"])[:200]
+        else:
+            excerpt = row["file_name"]
+        # Normalize score: negate bm25 so higher = better for display.
+        score = -float(row["rank"]) if row["rank"] is not None else 0.0
+        results.append(
+            DocumentSearchResult(
+                id=int(row["id"]),
+                file_name=row["file_name"],
+                vault_id=int(row["vault_id"]),
+                status=row["status"],
+                score=score,
+                excerpt=excerpt,
+                match_type=match_type,
+            )
+        )
+
+    return DocumentSearchResponse(results=results, total=int(total), query=q)
 
 
 @router.get("/stats", response_model=DocumentStatsResponse)
@@ -1150,7 +1465,10 @@ async def get_document(
                created_at, processed_at, error_message, phase, phase_message,
                progress_percent, processed_units, total_units, unit_label,
                phase_started_at, processing_started_at, enrichment_status,
-               enrichment_error
+               enrichment_error,
+               (SELECT COUNT(*) FROM failed_chunks WHERE file_id = files.id) AS failed_chunks,
+               (SELECT COALESCE(json_group_array(chunk_index), '[]')
+                FROM failed_chunks WHERE file_id = files.id) AS failed_chunk_ids
         FROM files WHERE id = ?
         """,
         (file_id,),

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -345,6 +345,7 @@ async def retry_failed_chunks(
     request: Request,
     conn: sqlite3.Connection = Depends(get_db),
     user: dict = Depends(require_admin_role),
+    evaluate: Callable = Depends(get_evaluate_policy),
     csrf_token: str = Depends(csrf_protect),
     vector_store: VectorStore = Depends(get_vector_store),
     embedding_service: EmbeddingService = Depends(get_embedding_service),
@@ -358,15 +359,23 @@ async def retry_failed_chunks(
     in ``failed_chunks`` for a file whose status is ``indexed`` (partial-failure
     case). Returns 409 when the file is not in a retryable state.
     """
-    # Verify the file exists and is retryable before constructing the processor.
+    # Verify the file exists and retryable; fetch vault_id for the per-file
+    # admin authz check. require_admin_role is only a coarse pre-filter
+    # ("admin of any vault") — a scoped vault admin must still be admin of the
+    # vault that owns this file, matching toggle_file_enrichment / delete_document.
     cursor = await asyncio.to_thread(
         conn.execute,
-        "SELECT status FROM files WHERE id = ?",
+        "SELECT status, vault_id FROM files WHERE id = ?",
         (file_id,),
     )
     file_row = await asyncio.to_thread(cursor.fetchone)
     if file_row is None:
         raise HTTPException(status_code=404, detail="Document not found")
+
+    if not await evaluate(user, "vault", file_row["vault_id"], "admin"):
+        raise HTTPException(
+            status_code=403, detail="Insufficient vault permissions"
+        )
 
     processor = DocumentProcessor(
         chunk_size_chars=settings.chunk_size_chars,
@@ -1262,6 +1271,9 @@ async def search_documents(
 
     # CTE + ROW_NUMBER dedup: keep one row per doc (body > metadata > filename).
     # bm25() returns negative values (more negative = better); ORDER BY rank ASC.
+    # A single statement computes both the page and the total over the
+    # de-duplicated set: a full-count CTE (no LIMIT) is joined to the paginated
+    # page, so the non-sargable filename LIKE runs once, not twice (NF3).
     ranked_sql = f"""
     WITH raw_matches AS (
         SELECT f.id, f.file_name, f.vault_id, f.status, f.parsed_text,
@@ -1275,7 +1287,14 @@ async def search_documents(
         UNION ALL
         SELECT f.id, f.file_name, f.vault_id, f.status, f.parsed_text,
                bm25(files_search_fts) AS rank,
-               highlight(files_search_fts, 0, '<mark>', '</mark>') AS excerpt_raw,
+               COALESCE(
+                   NULLIF(highlight(files_search_fts, 4, '<mark>', '</mark>'), ''),
+                   NULLIF(highlight(files_search_fts, 5, '<mark>', '</mark>'), ''),
+                   NULLIF(highlight(files_search_fts, 1, '<mark>', '</mark>'), ''),
+                   NULLIF(highlight(files_search_fts, 3, '<mark>', '</mark>'), ''),
+                   NULLIF(highlight(files_search_fts, 6, '<mark>', '</mark>'), ''),
+                   highlight(files_search_fts, 0, '<mark>', '</mark>')
+               ) AS excerpt_raw,
                2 AS type_priority
         FROM files_search_fts
         JOIN files f ON f.id = files_search_fts.rowid
@@ -1290,29 +1309,22 @@ async def search_documents(
           AND {vault_clause_name}
     ),
     ranked AS (
-        SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY type_priority ASC, rank ASC) AS rn
+        SELECT id, file_name, vault_id, status, rank, excerpt_raw, parsed_text, type_priority,
+               ROW_NUMBER() OVER (PARTITION BY id ORDER BY type_priority ASC, rank ASC) AS rn
         FROM raw_matches
+    ),
+    deduped AS (
+        SELECT id, file_name, vault_id, status, rank, excerpt_raw, parsed_text, type_priority
+        FROM ranked WHERE rn = 1
+    ),
+    full_count AS (
+        SELECT COUNT(*) AS n FROM deduped
     )
-    SELECT id, file_name, vault_id, status, rank, excerpt_raw, parsed_text, type_priority
-    FROM ranked WHERE rn = 1
-    ORDER BY type_priority ASC, rank ASC
+    SELECT d.id, d.file_name, d.vault_id, d.status, d.rank, d.excerpt_raw,
+           d.parsed_text, d.type_priority, fc.n AS total_count
+    FROM deduped d, full_count fc
+    ORDER BY d.type_priority ASC, d.rank ASC
     LIMIT ? OFFSET ?
-    """
-
-    count_sql = f"""
-    WITH raw_matches AS (
-        SELECT f.id FROM files_content_fts
-        JOIN files f ON f.id = files_content_fts.rowid
-        WHERE files_content_fts MATCH ? AND {vault_clause_body}
-        UNION
-        SELECT f.id FROM files_search_fts
-        JOIN files f ON f.id = files_search_fts.rowid
-        WHERE files_search_fts MATCH ? AND {vault_clause_meta}
-        UNION
-        SELECT f.id FROM files f
-        WHERE LOWER(f.file_name) LIKE ? AND {vault_clause_name}
-    )
-    SELECT COUNT(*) AS total FROM raw_matches
     """
 
     base_params = [fts_query, *vault_params, fts_query, *vault_params, like_query, *vault_params]
@@ -1323,10 +1335,33 @@ async def search_documents(
     )
     rows = await asyncio.to_thread(cursor.fetchall)
 
-    count_cursor = await asyncio.to_thread(
-        conn.execute, count_sql, base_params
-    )
-    total = (await asyncio.to_thread(count_cursor.fetchone))[0]
+    # total_count comes from the cross-joined full_count CTE; it is identical
+    # on every row, so read it from the first row (or 0 when the page is empty
+    # but matches exist — handle the empty-page case below).
+    total = int(rows[0]["total_count"]) if rows else 0
+    if total == 0 and offset > 0:
+        # Page beyond the result set: re-derive total without pagination so the
+        # caller still gets an accurate count (the LIMIT returned nothing but
+        # matches exist). Single cheap count over the deduped CTE.
+        count_only_sql = f"""
+        WITH raw_matches AS (
+            SELECT f.id FROM files_content_fts
+            JOIN files f ON f.id = files_content_fts.rowid
+            WHERE files_content_fts MATCH ? AND {vault_clause_body}
+            UNION
+            SELECT f.id FROM files_search_fts
+            JOIN files f ON f.id = files_search_fts.rowid
+            WHERE files_search_fts MATCH ? AND {vault_clause_meta}
+            UNION
+            SELECT f.id FROM files f
+            WHERE LOWER(f.file_name) LIKE ? AND {vault_clause_name}
+        )
+        SELECT COUNT(*) FROM raw_matches
+        """
+        count_cursor = await asyncio.to_thread(
+            conn.execute, count_only_sql, base_params
+        )
+        total = int((await asyncio.to_thread(count_cursor.fetchone))[0])
 
     results: List[DocumentSearchResult] = []
     for row in rows:

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -11,7 +11,7 @@ import sqlite3
 from collections.abc import Callable
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app.api.deps import (
@@ -68,7 +68,14 @@ class SearchResponse(BaseModel):
 
 
 class ChunkContextResponse(BaseModel):
-    """Expanded context for a retrieved chunk."""
+    """Expanded context for a retrieved chunk.
+
+    Backward-compatible: ``context_text``/``context_source`` remain the opaque
+    window used by existing clients. New structured fields (Issue #396):
+    ``matched_text`` is the chunk itself; ``before``/``after`` are ordered lists
+    of neighbor chunk texts selected by the ``context_before``/``context_after``
+    query params (empty when the params are 0, the default).
+    """
 
     id: str
     file_id: str
@@ -77,6 +84,9 @@ class ChunkContextResponse(BaseModel):
     chunk_text: str
     context_text: str
     context_source: str
+    matched_text: str = ""
+    before: List[str] = []
+    after: List[str] = []
 
 
 def _record_get(record: Any, key: str, default: Any = None) -> Any:
@@ -218,6 +228,8 @@ async def search(
 @router.get("/search/chunks/{chunk_id}/context", response_model=ChunkContextResponse)
 async def get_chunk_context(
     chunk_id: str,
+    context_before: int = Query(0, ge=0, le=10, description="Neighbor chunks before the match"),
+    context_after: int = Query(0, ge=0, le=10, description="Neighbor chunks after the match"),
     user: dict = Depends(get_current_user_or_service_account),
     db: sqlite3.Connection = Depends(get_db),
     vector_store: VectorStore = Depends(get_vector_store),
@@ -284,6 +296,38 @@ async def get_chunk_context(
         context_text = chunk_text
         context_source = "chunk"
 
+    # Configurable neighbor context (Issue #396). Fetch chunks before/after by
+    # file_id + chunk_index range and split into ordered before/after lists.
+    before_texts: List[str] = []
+    after_texts: List[str] = []
+    if context_before > 0 or context_after > 0:
+        center_idx = _record_get(chunk, "chunk_index", metadata.get("chunk_index", 0))
+        try:
+            center_idx_int = int(center_idx)
+        except (TypeError, ValueError):
+            center_idx_int = 0
+        get_range = getattr(vector_store, "get_chunks_by_file_range", None)
+        if get_range is not None:
+            try:
+                neighbors = await get_range(
+                    file_id, center_idx_int, context_before, context_after
+                )
+            except (OSError, RuntimeError, ValueError):
+                neighbors = []
+            for nbr in neighbors:
+                nbr_idx = _record_get(nbr, "chunk_index", None)
+                nbr_text = str(_record_get(nbr, "text", "") or "")
+                try:
+                    nbr_idx_int = int(nbr_idx) if nbr_idx is not None else None
+                except (TypeError, ValueError):
+                    continue
+                if nbr_idx_int is None or nbr_idx_int == center_idx_int:
+                    continue
+                if nbr_idx_int < center_idx_int:
+                    before_texts.append(nbr_text)
+                else:
+                    after_texts.append(nbr_text)
+
     return ChunkContextResponse(
         id=str(_record_get(chunk, "id", chunk_id) or chunk_id),
         file_id=file_id,
@@ -292,4 +336,7 @@ async def get_chunk_context(
         chunk_text=chunk_text,
         context_text=context_text,
         context_source=context_source,
+        matched_text=chunk_text,
+        before=before_texts,
+        after=after_texts,
     )

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -74,6 +74,22 @@ CREATE TABLE IF NOT EXISTS files (
     FOREIGN KEY (vault_id) REFERENCES vaults(id)
 );
 
+-- Per-chunk failure records for partial-embedding retry (Issue #396).
+-- Unlike files.chunks_failed (an aggregate counter), this table stores the
+-- identity + rebuild metadata of each chunk that failed to embed so a
+-- chunk-scoped retry can re-embed only the failures without re-parsing.
+CREATE TABLE IF NOT EXISTS failed_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL,
+    chunk_text TEXT NOT NULL,
+    chunk_metadata TEXT NOT NULL,  -- JSON: raw_text, parent_window_*, chunk_position, page_number, chunk_bbox, chunk_scale, chunk_uid, parent_window_text
+    error_reason TEXT,
+    attempts INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_failed_chunks_file_id ON failed_chunks(file_id);
+
 -- Full-text search index for document list metadata search
 CREATE VIRTUAL TABLE IF NOT EXISTS files_search_fts USING fts5(
     file_name,
@@ -1005,6 +1021,7 @@ def run_migrations(sqlite_path: str) -> None:
     migrate_add_files_processing_progress(sqlite_path)
     migrate_add_files_enrichment_status(sqlite_path)
     migrate_add_chunks_failed_column(sqlite_path)
+    migrate_add_failed_chunks_table(sqlite_path)
     migrate_add_vector_delete_pending(sqlite_path)
     migrate_add_security_audit_log(sqlite_path)
     migrate_add_files_search_fts(sqlite_path)
@@ -2363,6 +2380,46 @@ def migrate_add_vector_delete_pending(sqlite_path: str) -> None:
             CREATE INDEX IF NOT EXISTS idx_vector_delete_pending_file_id
             ON vector_delete_pending(file_id)
         """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def migrate_add_failed_chunks_table(sqlite_path: str) -> None:
+    """Migration: add failed_chunks table for chunk-scoped retry (Issue #396).
+
+    Stores per-chunk identity + rebuild metadata for chunks that failed to
+    embed, so ``DocumentProcessor.retry_failed_chunks`` can re-embed only the
+    failures without re-parsing the source file. ``files.chunks_failed`` (added
+    by migrate_add_chunks_failed_column) remains the aggregate counter; this
+    table is the durable identity store.
+
+    CASCADE on files.id delete keeps the table clean when a document is removed.
+
+    Idempotent — safe to run multiple times.
+    """
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS failed_chunks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                chunk_index INTEGER NOT NULL,
+                chunk_text TEXT NOT NULL,
+                chunk_metadata TEXT NOT NULL,
+                error_reason TEXT,
+                attempts INTEGER NOT NULL DEFAULT 1,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_failed_chunks_file_id
+            ON failed_chunks(file_id)
+            """
+        )
         conn.commit()
     finally:
         conn.close()

--- a/backend/app/services/chunking.py
+++ b/backend/app/services/chunking.py
@@ -132,6 +132,33 @@ class SemanticChunker:
 
         return metadata
 
+    @staticmethod
+    def _capture_bbox(element_metadata: Any) -> Optional[dict]:
+        """Reduce unstructured ``coordinates.points`` to an axis-aligned bbox.
+
+        ``coordinates.points`` is a tuple of ``(x, y)`` corner pairs; this
+        returns ``{"left","top","right","bottom"}`` or ``None`` when coordinates
+        are absent/malformed (merged CompositeElement chunks frequently drop
+        them, and unstructured is stubbed in CI). Issue #396.
+        """
+        coords = getattr(element_metadata, "coordinates", None)
+        if coords is None:
+            return None
+        points = getattr(coords, "points", None)
+        if not points or len(points) < 2:
+            return None
+        try:
+            xs = [float(p[0]) for p in points]
+            ys = [float(p[1]) for p in points]
+        except (TypeError, ValueError, IndexError):
+            return None
+        return {
+            "left": min(xs),
+            "top": min(ys),
+            "right": max(xs),
+            "bottom": max(ys),
+        }
+
     def _is_preserve_element(self, element: Element) -> bool:
         """
         Check if an element should be preserved intact (not split).
@@ -189,6 +216,13 @@ class SemanticChunker:
                     metadata["page_number"] = orig_meta.page_number
                 if hasattr(orig_meta, "filename") and orig_meta.filename:
                     metadata["source_file"] = orig_meta.filename
+                # Capture page-highlight bounding box from unstructured layout
+                # coordinates when available (Issue #396). Defensive: unstructured
+                # is stubbed in CI, and merged CompositeElement chunks frequently
+                # drop coordinates, so the key is simply absent when unavailable.
+                bbox = SemanticChunker._capture_bbox(orig_meta)
+                if bbox is not None:
+                    metadata["chunk_bbox"] = bbox
 
             processed_chunk = ProcessedChunk(
                 text=chunk_text, metadata=metadata, chunk_index=idx

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -1039,6 +1039,303 @@ class DocumentProcessor:
                 record["sparse_embedding"] = None
         return record
 
+    @staticmethod
+    def _build_failed_chunk_metadata(
+        chunk: ProcessedChunk, document_text: str
+    ) -> Dict[str, Any]:
+        """Build the rebuild metadata JSON for a failed chunk (Issue #396).
+
+        Captures everything ``_rebuild_vector_record_from_stored`` needs to
+        reconstruct a valid vector record later without re-parsing the source:
+        raw_text, parent_window offsets + text, chunk_position, page_number,
+        chunk_bbox, chunk_scale, chunk_uid. Enrichment is intentionally omitted
+        (a chunk that failed embedding never reached the enrichment stage).
+        """
+        meta = {
+            "raw_text": chunk.raw_text or chunk.text,
+            "chunk_index": chunk.chunk_index,
+            "chunk_scale": chunk.metadata.get("chunk_scale", "default"),
+            "chunk_uid": chunk.chunk_uid,
+            "chunk_position": chunk.chunk_position,
+            "parent_window_start": chunk.parent_window_start,
+            "parent_window_end": chunk.parent_window_end,
+            "page_number": chunk.metadata.get("page_number"),
+            "chunk_bbox": chunk.metadata.get("chunk_bbox"),
+            "total_chunks": chunk.metadata.get("total_chunks"),
+        }
+        if (
+            chunk.parent_window_start is not None
+            and chunk.parent_window_end is not None
+            and document_text
+        ):
+            meta["parent_window_text"] = document_text[
+                chunk.parent_window_start : chunk.parent_window_end
+            ]
+        return meta
+
+    def _persist_failed_chunks(
+        self,
+        file_id: int,
+        chunks: List[ProcessedChunk],
+        failed_indices: set,
+        document_text: str,
+        conn: sqlite3.Connection,
+        error_reason: Optional[str] = None,
+    ) -> None:
+        """Persist failed-chunk identity + rebuild metadata (Issue #396).
+
+        Clears any prior ``failed_chunks`` rows for this file first (idempotent
+        re-ingest), then inserts one row per failed chunk. Called inside the
+        caller's transaction; does not commit.
+        """
+        conn.execute(
+            "DELETE FROM failed_chunks WHERE file_id = ?", (file_id,)
+        )
+        for idx in sorted(failed_indices):
+            if idx >= len(chunks):
+                continue
+            chunk = chunks[idx]
+            meta_json = json.dumps(
+                self._build_failed_chunk_metadata(chunk, document_text)
+            )
+            conn.execute(
+                "INSERT INTO failed_chunks "
+                "(file_id, chunk_index, chunk_text, chunk_metadata, error_reason) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    file_id,
+                    chunk.chunk_index,
+                    chunk.text,
+                    meta_json,
+                    error_reason,
+                ),
+            )
+
+    @staticmethod
+    def _rebuild_chunk_from_stored(
+        stored_row: Any,
+    ) -> tuple[ProcessedChunk, Dict[str, Any]]:
+        """Reconstruct a ProcessedChunk + its metadata dict from a failed_chunks row.
+
+        Returns (chunk, stored_meta) so the caller can read parent_window_text
+        and other rebuild-only fields from stored_meta separately. [N4]
+        """
+        stored_meta: Dict[str, Any] = json.loads(stored_row["chunk_metadata"])
+        chunk_meta = {
+            "chunk_scale": stored_meta.get("chunk_scale", "default"),
+            "chunk_index": stored_meta.get("chunk_index", stored_row["chunk_index"]),
+            "total_chunks": stored_meta.get("total_chunks") or 1,
+            "raw_text": stored_meta.get("raw_text"),
+            "page_number": stored_meta.get("page_number"),
+            "chunk_bbox": stored_meta.get("chunk_bbox"),
+            "chunk_uid": stored_meta.get("chunk_uid"),
+        }
+        chunk = ProcessedChunk(
+            text=stored_row["chunk_text"],
+            metadata=chunk_meta,
+            chunk_index=stored_row["chunk_index"],
+            chunk_uid=stored_meta.get("chunk_uid"),
+            raw_text=stored_meta.get("raw_text"),
+            parent_window_start=stored_meta.get("parent_window_start"),
+            parent_window_end=stored_meta.get("parent_window_end"),
+            chunk_position=stored_meta.get("chunk_position"),
+        )
+        return chunk, stored_meta
+
+    def _rebuild_vector_record_from_stored(
+        self,
+        *,
+        file_id: int,
+        vault_id: int,
+        file_hash: str,
+        stored_row: Any,
+        stored_meta: Dict[str, Any],
+        chunk: ProcessedChunk,
+        embedding: List[float],
+    ) -> Dict[str, Any]:
+        """Rebuild a vector record for a previously-failed chunk (Issue #396).
+
+        Unlike ``_build_vector_record``, this does NOT require ``document_text``
+        or an ``enrichment`` object — ``parent_window_text`` is read from the
+        stored JSON, and enrichment is omitted (retried chunks re-enter the
+        enrichment queue separately). [C1.1, N4]
+        """
+        chunk_scale = chunk.metadata.get("chunk_scale", "default")
+        chunk_metadata = chunk.metadata.copy()
+        chunk_metadata["chunk_uid"] = chunk.chunk_uid or self._build_chunk_uid(
+            file_id, chunk
+        )
+        chunk_metadata["file_id"] = str(file_id)
+        chunk_metadata["chunk_count"] = chunk.metadata.get("total_chunks") or 1
+        chunk_metadata["chunk_scale"] = chunk_scale
+        chunk_metadata["raw_text"] = chunk.raw_text or chunk.text
+        if chunk.parent_window_start is not None:
+            chunk_metadata["parent_window_start"] = chunk.parent_window_start
+        if chunk.parent_window_end is not None:
+            chunk_metadata["parent_window_end"] = chunk.parent_window_end
+        if chunk.chunk_position is not None:
+            chunk_metadata["chunk_position"] = chunk.chunk_position
+        parent_window_text = stored_meta.get("parent_window_text")
+        if isinstance(parent_window_text, str) and parent_window_text.strip():
+            chunk_metadata["parent_window_text"] = parent_window_text
+
+        # Mirror the reupload_safe_order id branch from _build_vector_record. [N4]
+        if settings.reupload_safe_order:
+            record_id = (
+                f"{file_id}_{file_hash[:8]}_{chunk_scale}_{chunk.chunk_index}"
+            )
+        else:
+            record_id = chunk_metadata["chunk_uid"]
+
+        return {
+            "id": record_id,
+            "text": chunk.text,  # no enrichment on retry
+            "file_id": str(file_id),
+            "chunk_index": chunk.chunk_index,
+            "vault_id": str(vault_id),
+            "chunk_scale": chunk_scale,
+            "parent_doc_id": str(file_id),
+            "parent_window_start": chunk.parent_window_start,
+            "parent_window_end": chunk.parent_window_end,
+            "chunk_position": chunk.chunk_position,
+            "metadata": json.dumps(chunk_metadata),
+            "embedding": embedding,
+        }
+
+    async def retry_failed_chunks(self, file_id: int) -> Dict[str, Any]:
+        """Re-embed and re-index only the failed chunks for an indexed file.
+
+        Returns a summary dict: {retried, succeeded, still_failing,
+        failed_chunk_indices}. Raises ``ValueError`` when the file is not in a
+        retryable state (status != 'indexed') so the caller can map to 409.
+        [C1.2, C1.3, C1.4, N1, N3]
+        """
+        if self.embedding_service is None or self.vector_store is None:
+            raise RuntimeError("Embedding service or vector store unavailable")
+
+        conn = self.pool.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id, vault_id, file_hash, status, chunks_failed FROM files WHERE id = ?",
+                (file_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"File {file_id} not found")
+            if row["status"] != "indexed":
+                raise ValueError(
+                    f"File {file_id} status is '{row['status']}', must be 'indexed'"
+                )
+            vault_id = int(row["vault_id"])
+            file_hash = str(row["file_hash"] or "")
+
+            stored_rows = conn.execute(
+                "SELECT id, chunk_index, chunk_text, chunk_metadata, attempts "
+                "FROM failed_chunks WHERE file_id = ? ORDER BY chunk_index",
+                (file_id,),
+            ).fetchall()
+        finally:
+            self.pool.release_connection(conn)
+
+        if not stored_rows:
+            return {
+                "retried": 0,
+                "succeeded": 0,
+                "still_failing": 0,
+                "failed_chunk_indices": [],
+            }
+
+        # [N3] Pre-check: skip chunks already in LanceDB (reconcile a prior
+        # partial success where LanceDB write succeeded but SQLite DELETE failed).
+        to_embed: list[tuple[Any, ProcessedChunk, Dict[str, Any]]] = []
+        already_indexed_ids: list[int] = []  # failed_chunks row ids to clear
+        for srow in stored_rows:
+            chunk, stored_meta = self._rebuild_chunk_from_stored(srow)
+            chunk_scale = chunk.metadata.get("chunk_scale", "default")
+            if settings.reupload_safe_order:
+                record_id = (
+                    f"{file_id}_{file_hash[:8]}_{chunk_scale}_{chunk.chunk_index}"
+                )
+            else:
+                record_id = chunk.chunk_uid or self._build_chunk_uid(file_id, chunk)
+            existing = await self.vector_store.get_chunks_by_uid([record_id])
+            if existing:
+                already_indexed_ids.append(int(srow["id"]))
+                continue
+            to_embed.append((srow, chunk, stored_meta))
+
+        # Embed + build records per chunk. [N1] embed_batch(fail_fast=False)
+        # returns None placeholders on failure rather than raising.
+        records: list[Dict[str, Any]] = []
+        succeeded_row_ids: list[int] = []
+        still_failing: list[tuple[int, str, int]] = []  # (chunk_index, reason, row_id)
+        for srow, chunk, stored_meta in to_embed:
+            embs, failed = await self.embedding_service.embed_batch(
+                [chunk.text], fail_fast=False
+            )
+            if failed or not embs or embs[0] is None:
+                reason = "embedding returned None"
+                still_failing.append(
+                    (int(srow["chunk_index"]), reason, int(srow["id"]))
+                )
+                continue
+            record = self._rebuild_vector_record_from_stored(
+                file_id=file_id,
+                vault_id=vault_id,
+                file_hash=file_hash,
+                stored_row=srow,
+                stored_meta=stored_meta,
+                chunk=chunk,
+                embedding=embs[0],
+            )
+            records.append(record)
+            succeeded_row_ids.append(int(srow["id"]))
+
+        # [N3] LanceDB write FIRST (not transactional with SQLite), then SQLite
+        # cleanup in its own try/except. On SQLite failure the next retry's
+        # pre-check reconciles already-indexed chunks.
+        if records:
+            await self.vector_store.add_chunks(records)
+
+        conn = self.pool.get_connection()
+        try:
+            clear_ids = already_indexed_ids + succeeded_row_ids
+            if clear_ids:
+                placeholders = ",".join("?" * len(clear_ids))
+                conn.execute(
+                    f"DELETE FROM failed_chunks WHERE id IN ({placeholders})",
+                    clear_ids,
+                )
+            for _chunk_index, reason, row_id in still_failing:
+                conn.execute(
+                    "UPDATE failed_chunks SET attempts = attempts + 1, error_reason = ? "
+                    "WHERE id = ?",
+                    (reason, row_id),
+                )
+            conn.execute(
+                "UPDATE files SET chunks_failed = "
+                "(SELECT COUNT(*) FROM failed_chunks WHERE file_id = ?) "
+                "WHERE id = ?",
+                (file_id, file_id),
+            )
+            conn.commit()
+        except sqlite3.Error:
+            conn.rollback()
+            logger.warning(
+                "SQLite cleanup after retry of file %d failed; LanceDB already "
+                "updated. Next retry will reconcile.",
+                file_id,
+                exc_info=True,
+            )
+        finally:
+            self.pool.release_connection(conn)
+
+        return {
+            "retried": len(to_embed),
+            "succeeded": len(records),
+            "still_failing": len(still_failing),
+            "failed_chunk_indices": [ci for ci, _r, _rid in still_failing],
+        }
+
     async def _swap_in_enriched_vector_records(
         self, records: List[Dict[str, Any]], old_ids: List[str]
     ) -> None:
@@ -1747,6 +2044,9 @@ class DocumentProcessor:
 
             # Update status to processing
             self._update_status(file_id, "processing", conn)
+            # Clear stale failed-chunk records from a prior partial-failure ingest
+            # (Issue #396). Idempotent re-ingest must not accumulate stale rows.
+            conn.execute("DELETE FROM failed_chunks WHERE file_id = ?", (file_id,))
             conn.commit()
         finally:
             # Release connection before long-running operations
@@ -1950,6 +2250,30 @@ class DocumentProcessor:
                             len(failed_chunk_indices), len(chunks), failure_pct,
                             failed_batch_indices,
                         )
+
+                        # Persist failed-chunk identity for chunk-scoped retry
+                        # (Issue #396) BEFORE dropping them from the kept list.
+                        # Uses the ORIGINAL chunks list (indices are into it).
+                        try:
+                            _fc_conn = self.pool.get_connection()
+                            try:
+                                self._persist_failed_chunks(
+                                    file_id,
+                                    chunks,
+                                    failed_chunk_indices,
+                                    document_text,
+                                    _fc_conn,
+                                )
+                                _fc_conn.commit()
+                            finally:
+                                self.pool.release_connection(_fc_conn)
+                        except sqlite3.Error:
+                            logger.warning(
+                                "Failed to persist failed-chunk identity for file %d "
+                                "(retry-chunks endpoint will be unavailable for this ingest).",
+                                file_id,
+                                exc_info=True,
+                            )
 
                         original_chunk_count = len(chunks)
                         chunks = kept_chunks
@@ -2268,6 +2592,9 @@ class DocumentProcessor:
         conn = self.pool.get_connection()
         try:
             self._update_status(file_id, "processing", conn)
+            # Clear stale failed-chunk records from a prior partial-failure ingest
+            # (Issue #396). Idempotent re-ingest must not accumulate stale rows.
+            conn.execute("DELETE FROM failed_chunks WHERE file_id = ?", (file_id,))
             conn.commit()
         finally:
             self.pool.release_connection(conn)
@@ -2439,6 +2766,30 @@ class DocumentProcessor:
                             len(failed_chunk_indices), len(chunks), failure_pct,
                             failed_batch_indices,
                         )
+
+                        # Persist failed-chunk identity for chunk-scoped retry
+                        # (Issue #396) BEFORE dropping them from the kept list.
+                        # Uses the ORIGINAL chunks list (indices are into it).
+                        try:
+                            _fc_conn = self.pool.get_connection()
+                            try:
+                                self._persist_failed_chunks(
+                                    file_id,
+                                    chunks,
+                                    failed_chunk_indices,
+                                    document_text,
+                                    _fc_conn,
+                                )
+                                _fc_conn.commit()
+                            finally:
+                                self.pool.release_connection(_fc_conn)
+                        except sqlite3.Error:
+                            logger.warning(
+                                "Failed to persist failed-chunk identity for file %d "
+                                "(retry-chunks endpoint will be unavailable for this ingest).",
+                                file_id,
+                                exc_info=True,
+                            )
 
                         original_chunk_count = len(chunks)
                         chunks = kept_chunks

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -1313,9 +1313,10 @@ class DocumentProcessor:
                 )
             conn.execute(
                 "UPDATE files SET chunks_failed = "
-                "(SELECT COUNT(*) FROM failed_chunks WHERE file_id = ?) "
+                "(SELECT COUNT(*) FROM failed_chunks WHERE file_id = ?), "
+                "chunk_count = chunk_count + ? "
                 "WHERE id = ?",
-                (file_id, file_id),
+                (file_id, len(records), file_id),
             )
             conn.commit()
         except sqlite3.Error:
@@ -2281,6 +2282,31 @@ class DocumentProcessor:
                         chunks_failed_count = len(failed_chunk_indices)
 
                         if failure_pct > 50:
+                            # The file is about to land in status='error', which
+                            # the chunk-scoped retry endpoint rejects (409). The
+                            # failed_chunks rows persisted above are therefore
+                            # unreachable for chunk retry and would desync from
+                            # files.chunks_failed (which stays 0 on the error
+                            # path). Clear them so the only recovery is the
+                            # whole-document retry, which re-ingests from scratch.
+                            try:
+                                _abort_conn = self.pool.get_connection()
+                                try:
+                                    _abort_conn.execute(
+                                        "DELETE FROM failed_chunks WHERE file_id = ?",
+                                        (file_id,),
+                                    )
+                                    _abort_conn.commit()
+                                finally:
+                                    self.pool.release_connection(_abort_conn)
+                            except sqlite3.Error:
+                                logger.warning(
+                                    "Could not clear failed_chunks rows before "
+                                    ">50%% abort for file %d; rows will be cleared "
+                                    "on next re-ingest.",
+                                    file_id,
+                                    exc_info=True,
+                                )
                             raise DocumentProcessingError(
                                 "Too many embedding failures: %d/%d chunks failed (%.0f%%). "
                                 "Aborting document ingest." % (len(failed_chunk_indices), original_chunk_count, failure_pct),
@@ -2797,6 +2823,31 @@ class DocumentProcessor:
                         chunks_failed_count = len(failed_chunk_indices)
 
                         if failure_pct > 50:
+                            # The file is about to land in status='error', which
+                            # the chunk-scoped retry endpoint rejects (409). The
+                            # failed_chunks rows persisted above are therefore
+                            # unreachable for chunk retry and would desync from
+                            # files.chunks_failed (which stays 0 on the error
+                            # path). Clear them so the only recovery is the
+                            # whole-document retry, which re-ingests from scratch.
+                            try:
+                                _abort_conn = self.pool.get_connection()
+                                try:
+                                    _abort_conn.execute(
+                                        "DELETE FROM failed_chunks WHERE file_id = ?",
+                                        (file_id,),
+                                    )
+                                    _abort_conn.commit()
+                                finally:
+                                    self.pool.release_connection(_abort_conn)
+                            except sqlite3.Error:
+                                logger.warning(
+                                    "Could not clear failed_chunks rows before "
+                                    ">50%% abort for file %d; rows will be cleared "
+                                    "on next re-ingest.",
+                                    file_id,
+                                    exc_info=True,
+                                )
                             raise DocumentProcessingError(
                                 "Too many embedding failures: %d/%d chunks failed (%.0f%%). "
                                 "Aborting document ingest." % (len(failed_chunk_indices), original_chunk_count, failure_pct),

--- a/backend/app/services/document_retrieval.py
+++ b/backend/app/services/document_retrieval.py
@@ -559,6 +559,7 @@ class DocumentRetrievalService:
             "section": section,
             "source_label": source_label,
             "page_number": chunk.metadata.get("page_number"),
+            "chunk_bbox": chunk.metadata.get("chunk_bbox"),
             "snippet": snippet,
             "score": chunk.score,
             "metadata": chunk.metadata,

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -2200,6 +2200,43 @@ class VectorStore:
             logger.warning(f"Failed to fetch chunks by UID: {e}")
             return []
 
+    async def get_chunks_by_file_range(
+        self,
+        file_id: str,
+        chunk_index: int,
+        before: int,
+        after: int,
+    ) -> List[Dict[str, Any]]:
+        """Fetch neighbor chunks of a target chunk within the same file (Issue #396).
+
+        Used by the configurable context-window endpoint to build structured
+        before/match/after context. ``file_id`` is the LanceDB string column
+        (escaped via ``_lance_escape``); ``chunk_index`` selects the center; the
+        range ``[chunk_index - before, chunk_index + after]`` is fetched and
+        returned sorted by ``chunk_index`` (client-side — LanceDB ``orderby`` is
+        not relied on elsewhere in this codebase). Non-contiguous indices (gaps
+        from failed-chunk retries) are handled naturally: only existing rows
+        return.
+        """
+        if self.table is None:
+            return []
+        if before <= 0 and after <= 0:
+            return []
+        lo = int(chunk_index) - max(0, before)
+        hi = int(chunk_index) + max(0, after)
+        esc_file = _lance_escape(str(file_id))
+        query = (
+            f"file_id = '{esc_file}' "
+            f"AND chunk_index BETWEEN {int(lo)} AND {int(hi)}"
+        )
+        try:
+            rows = await self.table.query().where(query).to_list()
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.warning(f"Failed to fetch neighbor chunks: {e}")
+            return []
+        rows.sort(key=lambda r: r.get("chunk_index", 0) if isinstance(r, dict) else 0)
+        return rows
+
     async def get_stats(self) -> Dict[str, Any]:
         """
         Get statistics about the vector store.

--- a/backend/tests/test_chunk_bbox.py
+++ b/backend/tests/test_chunk_bbox.py
@@ -1,0 +1,150 @@
+"""Tests for chunk_bbox page-highlight metadata capture (Issue #396).
+
+unstructured is stubbed in CI, so these tests exercise the capture logic
+directly against synthetic element metadata objects. They verify the defensive
+behavior: bbox is captured when coordinates are present and well-formed, and
+absent (no exception) otherwise.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies (mirrors test_documents_auth.py).
+for _mod in ("lancedb", "pyarrow"):
+    try:
+        __import__(_mod)
+    except ImportError:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *a, **k: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *a, **k: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType(
+        "unstructured.documents.elements"
+    )
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    for _name, _sub in (
+        ("unstructured", _unstructured),
+        ("unstructured.partition", _unstructured.partition),
+        ("unstructured.partition.auto", _unstructured.partition.auto),
+        ("unstructured.chunking", _unstructured.chunking),
+        ("unstructured.chunking.title", _unstructured.chunking.title),
+        ("unstructured.documents", _unstructured.documents),
+        ("unstructured.documents.elements", _unstructured.documents.elements),
+    ):
+        sys.modules[_name] = _sub
+
+from app.services.chunking import ProcessedChunk, SemanticChunker  # noqa: E402
+
+
+class _FakeCoord:
+    """Mimics unstructured's coordinates object."""
+
+    def __init__(self, points):
+        self.points = points
+
+
+class _FakeMetadata:
+    """Mimics unstructured element metadata."""
+
+    def __init__(self, page_number=None, filename=None, coordinates=None):
+        self.page_number = page_number
+        self.filename = filename
+        self.coordinates = coordinates
+
+
+class TestChunkBboxCapture(unittest.TestCase):
+    """Verify chunk_bbox capture from unstructured coordinates metadata.
+
+    These tests call the REAL ``SemanticChunker._capture_bbox`` static method
+    (the production code path used by ``chunk_elements``) — not a duplicate —
+    so a regression in the capture logic is caught directly.
+    """
+
+    def test_bbox_captured_from_well_formed_points(self):
+        """Four corner points → axis-aligned bbox."""
+        meta = _FakeMetadata(
+            page_number=2,
+            coordinates=_FakeCoord(
+                points=((1.0, 2.0), (3.0, 2.0), (3.0, 4.0), (1.0, 4.0))
+            ),
+        )
+        bbox = SemanticChunker._capture_bbox(meta)
+        self.assertEqual(
+            bbox,
+            {"left": 1.0, "top": 2.0, "right": 3.0, "bottom": 4.0},
+        )
+
+    def test_no_coordinates_key_absent_no_exception(self):
+        """When coordinates is None, _capture_bbox returns None (no error)."""
+        meta = _FakeMetadata(page_number=1)
+        self.assertIsNone(SemanticChunker._capture_bbox(meta))
+
+    def test_malformed_points_skipped_silently(self):
+        """Malformed points must not raise; returns None."""
+        meta = _FakeMetadata(
+            coordinates=_FakeCoord(points=(("not", "numbers"), ("x", "y")))
+        )
+        self.assertIsNone(SemanticChunker._capture_bbox(meta))
+
+    def test_merged_composite_element_drops_coordinates(self):
+        """Common case: merged CompositeElement has coordinates=None."""
+        meta = _FakeMetadata(page_number=1, coordinates=None)
+        self.assertIsNone(SemanticChunker._capture_bbox(meta))
+
+    def test_metadata_without_coordinates_attr_returns_none(self):
+        """A bare metadata object with no coordinates attr → None (defensive)."""
+        meta = _FakeMetadata(page_number=1)
+        # _FakeMetadata initializes coordinates=None by default; verify the
+        # getattr fallback handles a metadata object lacking the attribute too.
+        self.assertIsNone(SemanticChunker._capture_bbox(meta))
+
+    def test_chunker_handles_empty_element_list(self):
+        """chunk_elements with empty list returns [] without touching metadata."""
+        chunker = SemanticChunker(chunk_size_chars=500, chunk_overlap_chars=0)
+        self.assertEqual(chunker.chunk_elements([]), [])
+
+    def test_processedchunk_metadata_roundtrip_preserves_bbox(self):
+        """Stored chunk metadata JSON round-trips bbox correctly (rebuild path)."""
+        import json
+
+        chunk = ProcessedChunk(
+            text="hello",
+            metadata={
+                "chunk_index": 0,
+                "chunk_bbox": {"left": 1.0, "top": 2.0, "right": 3.0, "bottom": 4.0},
+                "page_number": 5,
+            },
+            chunk_index=0,
+        )
+        meta_json = json.dumps(
+            {
+                "chunk_bbox": chunk.metadata["chunk_bbox"],
+                "page_number": chunk.metadata["page_number"],
+            }
+        )
+        restored = json.loads(meta_json)
+        self.assertEqual(
+            restored["chunk_bbox"],
+            {"left": 1.0, "top": 2.0, "right": 3.0, "bottom": 4.0},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_chunk_context_window.py
+++ b/backend/tests/test_chunk_context_window.py
@@ -1,0 +1,294 @@
+"""Tests for configurable context window on chunk context endpoint (Issue #396).
+
+Extends the existing /search/chunks/{id}/context tests to cover the new
+``context_before``/``context_after`` query params and the structured
+``before``/``matched_text``/``after`` response fields, plus backward
+compatibility (defaults yield empty lists, context_text still present).
+"""
+
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies.
+for _mod in ("lancedb", "pyarrow"):
+    try:
+        __import__(_mod)
+    except ImportError:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *a, **k: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *a, **k: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType(
+        "unstructured.documents.elements"
+    )
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    for _name, _sub in (
+        ("unstructured", _unstructured),
+        ("unstructured.partition", _unstructured.partition),
+        ("unstructured.partition.auto", _unstructured.partition.auto),
+        ("unstructured.chunking", _unstructured.chunking),
+        ("unstructured.chunking.title", _unstructured.chunking.title),
+        ("unstructured.documents", _unstructured.documents),
+        ("unstructured.documents.elements", _unstructured.documents.elements),
+    ):
+        sys.modules[_name] = _sub
+
+import jwt  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.config import settings  # noqa: E402
+from app.models.database import (  # noqa: E402
+    SQLiteConnectionPool,
+    init_db,
+    run_migrations,
+)
+
+
+class _RangeAwareVectorStore:
+    """Fake vector store supporting get_chunks_by_uid + get_chunks_by_file_range."""
+
+    def __init__(self):
+        self.chunk_records = []
+
+    async def get_chunks_by_uid(self, chunk_uids):
+        wanted = set(chunk_uids)
+        return [c for c in self.chunk_records if c.get("id") in wanted]
+
+    async def get_chunks_by_file_range(
+        self, file_id, chunk_index, before, after
+    ):
+        lo = chunk_index - max(0, before)
+        hi = chunk_index + max(0, after)
+        out = [
+            c
+            for c in self.chunk_records
+            if c.get("file_id") == file_id
+            and lo <= c.get("chunk_index", -1) <= hi
+        ]
+        out.sort(key=lambda r: r.get("chunk_index", 0))
+        return out
+
+
+class TestChunkContextWindow(unittest.TestCase):
+    """GET /search/chunks/{id}/context with context_before/context_after."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+
+        self._orig_jwt = settings.jwt_secret_key
+        self._orig_users = settings.users_enabled
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+
+        self.test_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+        self._seed_users_and_vaults()
+
+        from app.api.deps import get_db, get_vector_store
+        from app.main import app as main_app
+
+        def get_test_db():
+            conn = self.test_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.test_pool.release_connection(conn)
+
+        self.fake_vector_store = _RangeAwareVectorStore()
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[get_vector_store] = lambda: (
+            self.fake_vector_store
+        )
+        self.client = TestClient(main_app)
+        self.app = main_app
+
+    def tearDown(self):
+        settings.jwt_secret_key = self._orig_jwt
+        settings.users_enabled = self._orig_users
+        self.app.dependency_overrides.clear()
+        self.test_pool.close_all()
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _seed_users_and_vaults(self):
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO users (username, hashed_password, full_name, role, is_active, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("member_user", "pw", "Member", "member", 1, datetime.now(timezone.utc).isoformat()),
+            )
+            self.member_id = conn.execute(
+                "SELECT id FROM users WHERE username='member_user'"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO vaults (name, description, visibility, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("Accessible", "v", "private", "2026-01-01", "2026-01-01"),
+            )
+            self.vault_id = conn.execute("SELECT id FROM vaults WHERE name='Accessible'").fetchone()[0]
+            conn.execute(
+                "INSERT INTO vault_members (vault_id, user_id, permission, granted_at) "
+                "VALUES (?, ?, ?, ?)",
+                (self.vault_id, self.member_id, "read", "2026-01-01"),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+    def _token(self):
+        payload = {
+            "sub": str(self.member_id),
+            "username": "member_user",
+            "role": "member",
+            "exp": datetime.now(timezone.utc).timestamp() + 3600,
+            "type": "access",
+        }
+        return jwt.encode(payload, settings.jwt_secret_key, algorithm="HS256")
+
+    def _seed_chunks(self):
+        """Seed a file + 5 ordered chunks (indices 0-4); center on index 2."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (50, "ctx.md", "/uploads/ctx.md", 100, "indexed", 5, self.vault_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+
+        self.fake_vector_store.chunk_records = [
+            {
+                "id": f"50_{i}",
+                "text": f"chunk text {i}",
+                "file_id": "50",
+                "vault_id": str(self.vault_id),
+                "chunk_index": i,
+                "metadata": json.dumps({"raw_text": f"chunk text {i}"}),
+            }
+            for i in range(5)
+        ]
+        return "50_2"  # center chunk id
+
+    def test_before_after_return_ordered_neighbors(self):
+        center_id = self._seed_chunks()
+        resp = self.client.get(
+            f"/api/search/chunks/{center_id}/context?context_before=2&context_after=1",
+            headers={"Authorization": f"Bearer {self._token()}"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        # before: chunks 0, 1 (in order); after: chunk 3.
+        self.assertEqual(data["before"], ["chunk text 0", "chunk text 1"])
+        self.assertEqual(data["after"], ["chunk text 3"])
+        self.assertEqual(data["matched_text"], "chunk text 2")
+
+    def test_defaults_backward_compatible(self):
+        """With no params (default 0,0), before/after are empty; context_text present."""
+        center_id = self._seed_chunks()
+        resp = self.client.get(
+            f"/api/search/chunks/{center_id}/context",
+            headers={"Authorization": f"Bearer {self._token()}"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["before"], [])
+        self.assertEqual(data["after"], [])
+        self.assertIn("context_text", data)
+        self.assertEqual(data["matched_text"], "chunk text 2")
+
+    def test_non_contiguous_indices_returns_only_existing(self):
+        """Gap in indices (e.g. a missing index 3): only existing neighbors return."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (51, "gap.md", "/uploads/gap.md", 100, "indexed", 4, self.vault_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+        # Indices 0, 1, 2, 4 — index 3 missing (simulates a failed-chunk gap).
+        self.fake_vector_store.chunk_records = [
+            {
+                "id": f"51_{i}",
+                "text": f"g text {i}",
+                "file_id": "51",
+                "vault_id": str(self.vault_id),
+                "chunk_index": i,
+                "metadata": json.dumps({"raw_text": f"g text {i}"}),
+            }
+            for i in (0, 1, 2, 4)
+        ]
+        resp = self.client.get(
+            "/api/search/chunks/51_2/context?context_before=0&context_after=2",
+            headers={"Authorization": f"Bearer {self._token()}"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        # Only index 4 exists after 2 (index 3 is gone).
+        self.assertEqual(data["after"], ["g text 4"])
+
+    def test_inaccessible_vault_returns_404(self):
+        """Chunk in a vault the user cannot read → 404 (not 403)."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO vaults (name, description, visibility, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("Other", "v", "private", "2026-01-01", "2026-01-01"),
+            )
+            other_vault = conn.execute("SELECT id FROM vaults WHERE name='Other'").fetchone()[0]
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (60, "secret.md", "/uploads/secret.md", 100, "indexed", 1, other_vault),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+        self.fake_vector_store.chunk_records = [
+            {
+                "id": "60_0",
+                "text": "secret",
+                "file_id": "60",
+                "vault_id": "999",
+                "chunk_index": 0,
+                "metadata": "{}",
+            }
+        ]
+        resp = self.client.get(
+            "/api/search/chunks/60_0/context?context_before=1",
+            headers={"Authorization": f"Bearer {self._token()}"},
+        )
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_chunk_context_window.py
+++ b/backend/tests/test_chunk_context_window.py
@@ -255,6 +255,42 @@ class TestChunkContextWindow(unittest.TestCase):
         # Only index 4 exists after 2 (index 3 is gone).
         self.assertEqual(data["after"], ["g text 4"])
 
+    def test_before_exceeds_center_at_index_zero(self):
+        """[PRR-020] context_before larger than the center chunk_index (here 0)
+        yields a negative lower BETWEEN bound — must not error, and must return
+        only existing neighbors (the single 'after' chunk)."""
+        conn = self.test_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (52, "edge.md", "/uploads/edge.md", 100, "indexed", 3, self.vault_id),
+            )
+            conn.commit()
+        finally:
+            self.test_pool.release_connection(conn)
+        self.fake_vector_store.chunk_records = [
+            {
+                "id": f"52_{i}",
+                "text": f"e text {i}",
+                "file_id": "52",
+                "vault_id": str(self.vault_id),
+                "chunk_index": i,
+                "metadata": json.dumps({"raw_text": f"e text {i}"}),
+            }
+            for i in range(3)
+        ]
+        # Center on index 0; ask for 5 before (negative lo) and 1 after.
+        resp = self.client.get(
+            "/api/search/chunks/52_0/context?context_before=5&context_after=1",
+            headers={"Authorization": f"Bearer {self._token()}"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["before"], [])  # nothing before index 0
+        self.assertEqual(data["after"], ["e text 1"])
+        self.assertEqual(data["matched_text"], "e text 0")
+
     def test_inaccessible_vault_returns_404(self):
         """Chunk in a vault the user cannot read → 404 (not 403)."""
         conn = self.test_pool.get_connection()

--- a/backend/tests/test_document_processor.py
+++ b/backend/tests/test_document_processor.py
@@ -405,6 +405,82 @@ CREATE TABLE posts (
         self.assertEqual(row["chunk_count"], 1)
         self.assertEqual(row["chunks_failed"], 1)
 
+        # [PRR-008] Verify the failed chunk was also persisted to the
+        # failed_chunks table (the chunk-scoped retry data source).
+        conn = sqlite3.connect(self.temp_db_path)
+        conn.row_factory = sqlite3.Row
+        fc_rows = conn.execute(
+            "SELECT chunk_index, chunk_text FROM failed_chunks WHERE file_id = ?",
+            (result.file_id,),
+        ).fetchall()
+        conn.close()
+        self.assertEqual(len(fc_rows), 1, "failed_chunks must hold the dropped chunk")
+        self.assertEqual(fc_rows[0]["chunk_index"], 1)
+
+    def test_process_file_above_50pct_failure_clears_failed_chunks(self):
+        """[PRR-001] On >50% embedding failure the document aborts to status
+        'error' and the failed_chunks rows persisted before the abort are
+        cleared (they're unreachable for chunk-retry since status != 'indexed').
+        No desync: chunks_failed stays 0 and failed_chunks is empty."""
+
+        class AllFailEmbeddingService:
+            MAX_TEXT_LENGTH = 8192
+            embedding_doc_prefix = ""
+
+            async def embed_batch(self, texts, batch_size=None, fail_fast=True):
+                # Every batch fails → 100% failure → >50% abort.
+                # With batch_size=1, each text is its own batch; return every
+                # batch index as failed.
+                n_batches = max(1, (len(texts) + max(1, batch_size or 1) - 1) // max(1, batch_size or 1))
+                embeddings = [None for _ in texts]
+                return (embeddings, list(range(n_batches)))
+
+        class FakeVectorStore:
+            def __init__(self):
+                self.records = []
+
+            async def init_table(self, embedding_dim):
+                self.embedding_dim = embedding_dim
+
+            async def add_chunks(self, records):
+                self.records.extend(records)
+
+            async def delete_old_generation_by_file(self, file_id, new_hash_short):
+                return 0
+
+            async def delete_by_file(self, file_id):
+                return 0
+
+            async def count_by_file(self, file_id):
+                return 1
+
+        original_batch_size = settings.embedding_batch_size
+        settings.embedding_batch_size = 1
+        self.processor.embedding_service = AllFailEmbeddingService()
+        self.processor.vector_store = FakeVectorStore()
+
+        try:
+            with self.assertRaises(DocumentProcessingError):
+                asyncio.run(
+                    self.processor.process_file(self.sql_file_path, vault_id=1)
+                )
+        finally:
+            settings.embedding_batch_size = original_batch_size
+
+        conn = sqlite3.connect(self.temp_db_path)
+        conn.row_factory = sqlite3.Row
+        file_row = conn.execute(
+            "SELECT status, chunks_failed FROM files ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        fc_count = conn.execute("SELECT COUNT(*) FROM failed_chunks").fetchone()[0]
+        conn.close()
+
+        self.assertIsNotNone(file_row)
+        self.assertEqual(file_row["status"], "error")
+        # No desync: chunks_failed is 0 AND failed_chunks table is empty.
+        self.assertEqual(file_row["chunks_failed"], 0)
+        self.assertEqual(fc_count, 0, "failed_chunks must be cleared on >50% abort")
+
     def test_base_vector_record_preserves_raw_text_without_enrichment(self):
         """Initial indexing stores raw evidence and does not add synthetic search text."""
         chunk = ProcessedChunk(

--- a/backend/tests/test_documents_search_ranked.py
+++ b/backend/tests/test_documents_search_ranked.py
@@ -10,12 +10,14 @@ from test_documents_auth import TestDocumentAuthBase
 class TestDocumentsSearchRanked(TestDocumentAuthBase):
     """GET /documents/search returns ranked docs with excerpts."""
 
-    def _seed_doc(self, file_id, vault_id, file_name, parsed_text, status="indexed"):
+    def _seed_doc(self, file_id, vault_id, file_name, parsed_text, status="indexed",
+                  email_subject=None, email_sender=None):
         conn = self._connection_pool.get_connection()
         try:
             conn.execute(
                 "INSERT INTO files (id, file_name, file_path, file_size, status, "
-                "chunk_count, vault_id, parsed_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "chunk_count, vault_id, parsed_text, email_subject, email_sender) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     file_id,
                     file_name,
@@ -25,6 +27,8 @@ class TestDocumentsSearchRanked(TestDocumentAuthBase):
                     1,
                     vault_id,
                     parsed_text,
+                    email_subject,
+                    email_sender,
                 ),
             )
             conn.commit()
@@ -156,6 +160,41 @@ class TestDocumentsSearchRanked(TestDocumentAuthBase):
         ids2 = {r["id"] for r in page2["results"]}
         self.assertEqual(len(page2["results"]), 2)
         self.assertEqual(ids1.isdisjoint(ids2), True, "pages must not overlap")
+
+    def test_metadata_match_highlights_matched_column_not_filename(self):
+        """[NF2] A match in email_subject must produce an excerpt from that
+        column (with <mark>), not the filename."""
+        # Unique token in email_subject; absent from filename + body.
+        self._seed_doc(
+            230, 2, "plain_report.txt", "Unrelated body content without the token.",
+            email_subject="Q3 zorbulator revenue review",
+        )
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=zorbulator&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["total"], 1)
+        result = data["results"][0]
+        self.assertEqual(result["match_type"], "metadata")
+        # The excerpt must come from the matched metadata column and contain
+        # the highlight marker, NOT be the bare filename.
+        self.assertIn("<mark>zorbulator</mark>", result["excerpt"])
+
+    def test_fts_special_chars_hyphen_does_not_error(self):
+        """[PRR-019] Hyphens in the query are normalized by _build_files_fts_query
+        (FTS5 treats them as column-filter prefix otherwise → OperationalError).
+        The search must not 500."""
+        self._seed_doc(231, 2, "hyphen-test.pdf", "model-x specification details")
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=model-x&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        self.assertIn(resp.status_code, (200,))
+        self.assertEqual(resp.json()["total"], 1)
 
     def test_empty_query_rejected(self):
         token = self._member_token()

--- a/backend/tests/test_documents_search_ranked.py
+++ b/backend/tests/test_documents_search_ranked.py
@@ -1,0 +1,171 @@
+"""Tests for ranked ``GET /documents/search`` (Issue #396).
+
+Verifies bm25 ranking, excerpt highlighting, deduplication before pagination,
+and cross-vault isolation against a real SQLite FTS5 index.
+"""
+
+from test_documents_auth import TestDocumentAuthBase
+
+
+class TestDocumentsSearchRanked(TestDocumentAuthBase):
+    """GET /documents/search returns ranked docs with excerpts."""
+
+    def _seed_doc(self, file_id, vault_id, file_name, parsed_text, status="indexed"):
+        conn = self._connection_pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, file_size, status, "
+                "chunk_count, vault_id, parsed_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    file_id,
+                    file_name,
+                    f"/uploads/{file_name}",
+                    100,
+                    status,
+                    1,
+                    vault_id,
+                    parsed_text,
+                ),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+    def test_body_match_returns_ranked_result_with_excerpt(self):
+        self._seed_doc(
+            200, 2, "fox_report.txt", "The quick brown fox jumps over the lazy dog."
+        )
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=fox&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["total"], 1)
+        result = data["results"][0]
+        self.assertEqual(result["id"], 200)
+        self.assertEqual(result["match_type"], "body")
+        self.assertIn("fox", result["excerpt"].lower())
+
+    def test_filename_match_returns_metadata_match_type(self):
+        # Body does not contain the search token; filename does. files_search_fts
+        # indexes file_name, so a filename hit surfaces as match_type=metadata
+        # (the LIKE arm is a fallback only for tokens FTS won't tokenize).
+        self._seed_doc(
+            201, 2, "unique_budget_file.txt", "Completely unrelated body text here."
+        )
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=budget&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["total"], 1)
+        result = data["results"][0]
+        self.assertEqual(result["match_type"], "metadata")
+        self.assertEqual(result["id"], 201)
+
+    def test_doc_matching_body_and_metadata_appears_once(self):
+        """Dedup: a doc matching both body and metadata FTS appears once, and
+        ``total`` counts unique docs, not union rows."""
+        # Filename + body both contain the token.
+        self._seed_doc(
+            202, 2, "alpha_token.txt", "The alpha_token appears in the body too."
+        )
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=alpha_token&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        ids = [r["id"] for r in data["results"]]
+        self.assertEqual(ids.count(202), 1, "doc must appear exactly once after dedup")
+        self.assertEqual(data["total"], 1, "total must count unique docs")
+
+    def test_bm25_ranking_order_differs_from_insertion(self):
+        """A doc with more/frequent matches ranks above one with a single mention."""
+        # Strong match: token repeated.
+        self._seed_doc(
+            203, 2, "strong.txt", "flux flux flux flux flux the primary topic"
+        )
+        # Weak match: token once, in a longer document.
+        self._seed_doc(
+            204,
+            2,
+            "weak.txt",
+            "flux " + "filler " * 200 + " only mentioned once at the end flux",
+        )
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=flux&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(len(data["results"]), 2)
+        # The strong-match doc (id 203) should rank first.
+        self.assertEqual(data["results"][0]["id"], 203)
+
+    def test_cross_vault_isolation_member_without_vault_id(self):
+        """Member without an explicit vault_id must not see other-vault docs."""
+        # Vault 3 doc — member1 has NO access to vault 3.
+        self._seed_doc(
+            205, 3, "vault3_secret.txt", "isolation_probe_token_xyz body"
+        )
+        token = self._member_token()  # member1 has access to vault 2 only
+        resp = self.client.get(
+            "/api/documents/search?q=isolation_probe_token_xyz",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        ids = [r["id"] for r in data["results"]]
+        self.assertNotIn(
+            205, ids, "cross-vault leak: vault 3 doc visible to vault 2 member"
+        )
+
+    def test_pagination_honored_post_dedup(self):
+        """limit + offset operate on de-duplicated unique docs."""
+        for i in range(5):
+            self._seed_doc(
+                210 + i,
+                2,
+                f"paginated_{i}.txt",
+                f"pagination_probe token number {i}",
+            )
+        token = self._member_token()
+        # Page 1
+        resp1 = self.client.get(
+            "/api/documents/search?q=pagination_probe&vault_id=2&limit=2&offset=0",
+            headers=self._auth_headers(token),
+        )
+        self.assertEqual(resp1.status_code, 200, resp1.text)
+        page1 = resp1.json()
+        self.assertEqual(len(page1["results"]), 2)
+        self.assertEqual(page1["total"], 5)
+        # Page 2 must not overlap page 1.
+        resp2 = self.client.get(
+            "/api/documents/search?q=pagination_probe&vault_id=2&limit=2&offset=2",
+            headers=self._auth_headers(token),
+        )
+        page2 = resp2.json()
+        ids1 = {r["id"] for r in page1["results"]}
+        ids2 = {r["id"] for r in page2["results"]}
+        self.assertEqual(len(page2["results"]), 2)
+        self.assertEqual(ids1.isdisjoint(ids2), True, "pages must not overlap")
+
+    def test_empty_query_rejected(self):
+        token = self._member_token()
+        resp = self.client.get(
+            "/api/documents/search?q=&vault_id=2",
+            headers=self._auth_headers(token),
+        )
+        # Pydantic min_length=1 → 422, or endpoint 400.
+        self.assertIn(resp.status_code, (400, 422))
+
+    def test_unauthenticated_returns_401(self):
+        resp = self.client.get("/api/documents/search?q=test")
+        self.assertEqual(resp.status_code, 401)

--- a/backend/tests/test_failed_chunks_retry.py
+++ b/backend/tests/test_failed_chunks_retry.py
@@ -1,0 +1,519 @@
+"""Tests for failed-chunk accounting + chunk-scoped retry (Issue #396).
+
+Covers:
+- ``failed_chunks`` table existence + migration.
+- ``_persist_failed_chunks`` / ``_build_failed_chunk_metadata`` correctness.
+- ``retry_failed_chunks`` service method: success path (LanceDB write, DELETE
+  rows, decrement count), None-embedding failure path (attempts+1, no write),
+  reconciliation pre-check, and the status-not-indexed 409 path.
+- HTTP endpoint authz (admin only) + 409 mapping.
+- Status/detail response surfacing of failed_chunks/failed_chunk_ids.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies.
+for _mod in ("lancedb", "pyarrow"):
+    try:
+        __import__(_mod)
+    except ImportError:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *a, **k: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *a, **k: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType(
+        "unstructured.documents.elements"
+    )
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    for _name, _sub in (
+        ("unstructured", _unstructured),
+        ("unstructured.partition", _unstructured.partition),
+        ("unstructured.partition.auto", _unstructured.partition.auto),
+        ("unstructured.chunking", _unstructured.chunking),
+        ("unstructured.chunking.title", _unstructured.chunking.title),
+        ("unstructured.documents", _unstructured.documents),
+        ("unstructured.documents.elements", _unstructured.documents.elements),
+    ):
+        sys.modules[_name] = _sub
+
+import jwt  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.config import settings  # noqa: E402
+from app.models.database import (  # noqa: E402
+    SQLiteConnectionPool,
+    init_db,
+    run_migrations,
+)
+from app.services.chunking import ProcessedChunk  # noqa: E402
+from app.services.document_processor import DocumentProcessor  # noqa: E402
+
+
+class _FakeEmbeddingService:
+    """Fake embedding service matching embed_batch(fail_fast=False) contract."""
+
+    def __init__(self, fail_indices=None):
+        self._fail = set(fail_indices or [])
+        self._call_count = 0
+
+    async def embed_batch(self, texts, fail_fast=False):
+        self._call_count += 1
+        idx = self._call_count - 1
+        if idx in self._fail:
+            return ([None], [0])
+        return ([[0.1, 0.2, 0.3]], [])
+
+
+class _FakeVectorStore:
+    """Fake vector store capturing add_chunks + supporting get_chunks_by_uid."""
+
+    def __init__(self):
+        self.added_records = []
+        self._existing_ids = set()
+
+    async def add_chunks(self, records):
+        for r in records:
+            self.added_records.append(r)
+            self._existing_ids.add(r["id"])
+
+    async def get_chunks_by_uid(self, chunk_uids):
+        return [
+            {"id": uid, "text": "existing"}
+            for uid in chunk_uids
+            if uid in self._existing_ids
+        ]
+
+
+def _make_pool(db_path):
+    return SQLiteConnectionPool(db_path, max_size=5)
+
+
+class TestFailedChunksRetry(unittest.TestCase):
+    """Service-layer + HTTP tests for chunk-scoped retry."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.db")
+        init_db(self.db_path)
+        run_migrations(self.db_path)
+        self.pool = _make_pool(self.db_path)
+
+        self._orig_jwt = settings.jwt_secret_key
+        self._orig_users = settings.users_enabled
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+
+        self._seed_users_vaults_file()
+
+    def tearDown(self):
+        settings.jwt_secret_key = self._orig_jwt
+        settings.users_enabled = self._orig_users
+        self.pool.close_all()
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _seed_users_vaults_file(self):
+        conn = self.pool.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO users (username, hashed_password, full_name, role, is_active, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("admin_user", "pw", "Admin", "admin", 1, datetime.now(timezone.utc).isoformat()),
+            )
+            self.admin_id = conn.execute(
+                "SELECT id FROM users WHERE username='admin_user'"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO users (username, hashed_password, full_name, role, is_active, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("member_user", "pw", "Member", "member", 1, datetime.now(timezone.utc).isoformat()),
+            )
+            self.member_id = conn.execute(
+                "SELECT id FROM users WHERE username='member_user'"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO vaults (name, description, visibility, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("V", "v", "private", "2026-01-01", "2026-01-01"),
+            )
+            self.vault_id = conn.execute("SELECT id FROM vaults WHERE name='V'").fetchone()[0]
+            conn.execute(
+                "INSERT INTO vault_members (vault_id, user_id, permission, granted_at) "
+                "VALUES (?, ?, ?, ?)",
+                (self.vault_id, self.member_id, "read", "2026-01-01"),
+            )
+            # An indexed file with chunks_failed=2.
+            conn.execute(
+                "INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, "
+                "chunks_failed, vault_id, file_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (70, "f.txt", "/uploads/f.txt", 100, "indexed", 3, 2, self.vault_id, "abc12345"),
+            )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+    def _seed_failed_chunks(self, file_id=70):
+        conn = self.pool.get_connection()
+        try:
+            for idx in (1, 3):
+                meta = json.dumps({
+                    "raw_text": f"failed chunk {idx}",
+                    "chunk_index": idx,
+                    "chunk_scale": "default",
+                    "chunk_uid": f"{file_id}_{idx}",
+                    "chunk_position": idx,
+                    "parent_window_start": None,
+                    "parent_window_end": None,
+                    "page_number": None,
+                    "chunk_bbox": None,
+                    "total_chunks": 4,
+                })
+                conn.execute(
+                    "INSERT INTO failed_chunks (file_id, chunk_index, chunk_text, chunk_metadata) "
+                    "VALUES (?, ?, ?, ?)",
+                    (file_id, idx, f"failed chunk {idx}", meta),
+                )
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+
+    def _make_processor(self, embedding_service, vector_store):
+        return DocumentProcessor(
+            chunk_size_chars=500,
+            chunk_overlap_chars=0,
+            vector_store=vector_store,
+            embedding_service=embedding_service,
+            pool=self.pool,
+        )
+
+    # ── Schema / migration ──────────────────────────────────────────────
+
+    def test_failed_chunks_table_exists_after_migration(self):
+        conn = self.pool.get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='failed_chunks'"
+            ).fetchall()
+            self.assertEqual(len(rows), 1)
+            cols = {
+                r[1] for r in conn.execute("PRAGMA table_info(failed_chunks)").fetchall()
+            }
+            for expected in (
+                "id",
+                "file_id",
+                "chunk_index",
+                "chunk_text",
+                "chunk_metadata",
+                "error_reason",
+                "attempts",
+                "created_at",
+            ):
+                self.assertIn(expected, cols)
+        finally:
+            self.pool.release_connection(conn)
+
+    # ── Service: retry_failed_chunks success path ───────────────────────
+
+    def test_retry_succeeds_writes_lancedb_deletes_rows(self):
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()  # no failures
+        vs = _FakeVectorStore()
+        proc = self._make_processor(emb, vs)
+
+        # reupload_safe_order=True (default) → id = {file_id}_{hash[:8]}_{scale}_{idx}
+        expected_ids = {"70_abc12345_default_1", "70_abc12345_default_3"}
+
+        result = proc.loop.run_until_complete if hasattr(proc, "loop") else None
+        import asyncio
+
+        result = asyncio.run(proc.retry_failed_chunks(70))
+
+        self.assertEqual(result["retried"], 2)
+        self.assertEqual(result["succeeded"], 2)
+        self.assertEqual(result["still_failing"], 0)
+        # LanceDB received 2 rebuilt records.
+        self.assertEqual(len(vs.added_records), 2)
+        rebuilt_ids = {r["id"] for r in vs.added_records}
+        self.assertEqual(rebuilt_ids, expected_ids)
+        # failed_chunks rows deleted; chunks_failed decremented to 0.
+        conn = self.pool.get_connection()
+        try:
+            remaining = conn.execute(
+                "SELECT COUNT(*) FROM failed_chunks WHERE file_id = 70"
+            ).fetchone()[0]
+            self.assertEqual(remaining, 0)
+            cf = conn.execute(
+                "SELECT chunks_failed FROM files WHERE id = 70"
+            ).fetchone()[0]
+            self.assertEqual(cf, 0)
+        finally:
+            self.pool.release_connection(conn)
+
+    def test_retry_none_embedding_keeps_row_increments_attempts(self):
+        """[N1] embed_batch returning None → chunk stays, attempts+1, no write."""
+        self._seed_failed_chunks()
+        # Both calls fail (call indices 0, 1).
+        emb = _FakeEmbeddingService(fail_indices=[0, 1])
+        vs = _FakeVectorStore()
+        proc = self._make_processor(emb, vs)
+
+        import asyncio
+
+        result = asyncio.run(proc.retry_failed_chunks(70))
+
+        self.assertEqual(result["succeeded"], 0)
+        self.assertEqual(result["still_failing"], 2)
+        self.assertEqual(len(vs.added_records), 0)  # no LanceDB write
+        conn = self.pool.get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT attempts FROM failed_chunks WHERE file_id = 70 ORDER BY chunk_index"
+            ).fetchall()
+            self.assertEqual([r[0] for r in rows], [2, 2])  # 1 → 2
+            cf = conn.execute(
+                "SELECT chunks_failed FROM files WHERE id = 70"
+            ).fetchone()[0]
+            self.assertEqual(cf, 2)  # unchanged
+        finally:
+            self.pool.release_connection(conn)
+
+    def test_retry_reconciles_already_indexed_chunks(self):
+        """[N3] Chunks already in LanceDB are skipped + rows cleared."""
+        self._seed_failed_chunks()
+        vs = _FakeVectorStore()
+        # Pretend chunk index 1 is already in LanceDB (reupload_safe_order id format).
+        vs._existing_ids.add("70_abc12345_default_1")
+        emb = _FakeEmbeddingService()
+        proc = self._make_processor(emb, vs)
+
+        import asyncio
+
+        result = asyncio.run(proc.retry_failed_chunks(70))
+
+        # Only chunk 3 needed re-embedding (chunk 1 pre-check skipped it).
+        self.assertEqual(result["retried"], 1)
+        self.assertEqual(result["succeeded"], 1)
+        self.assertEqual(len(vs.added_records), 1)
+        conn = self.pool.get_connection()
+        try:
+            remaining = conn.execute(
+                "SELECT COUNT(*) FROM failed_chunks WHERE file_id = 70"
+            ).fetchone()[0]
+            self.assertEqual(remaining, 0)  # both rows cleared
+        finally:
+            self.pool.release_connection(conn)
+
+    def test_retry_rejects_non_indexed_status(self):
+        """[C1.2] status != indexed → ValueError (caller maps to 409)."""
+        conn = self.pool.get_connection()
+        try:
+            conn.execute("UPDATE files SET status = 'error' WHERE id = 70")
+            conn.commit()
+        finally:
+            self.pool.release_connection(conn)
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        proc = self._make_processor(emb, vs)
+
+        import asyncio
+
+        with self.assertRaises(ValueError):
+            asyncio.run(proc.retry_failed_chunks(70))
+
+    def test_retry_no_failed_chunks_returns_zero_summary(self):
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        proc = self._make_processor(emb, vs)
+        import asyncio
+
+        result = asyncio.run(proc.retry_failed_chunks(70))
+        self.assertEqual(result, {
+            "retried": 0,
+            "succeeded": 0,
+            "still_failing": 0,
+            "failed_chunk_indices": [],
+        })
+
+    # ── List/status surfacing ───────────────────────────────────────────
+
+    def test_list_surfaces_failed_chunks_non_admin_without_vault_id(self):
+        """The non-admin (vault_id IN accessible) list branch must surface
+        failed_chunks/failed_chunk_ids — regression guard for the branch that
+        originally omitted the correlated subqueries."""
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.get(
+                "/api/documents",
+                headers={"Authorization": f"Bearer {self._member_token()}"},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            docs = resp.json()["documents"]
+            target = [d for d in docs if d["id"] == 70]
+            self.assertTrue(target, "seeded file 70 must appear in list")
+            self.assertEqual(target[0]["failed_chunks"], 2)
+            self.assertEqual(sorted(target[0]["failed_chunk_ids"]), [1, 3])
+        finally:
+            main_app.dependency_overrides.clear()
+
+    def test_list_surfaces_failed_chunks_admin_all_docs(self):
+        """The admin (all-docs) list branch must also surface failed_chunks."""
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.get(
+                "/api/documents",
+                headers={"Authorization": f"Bearer {self._admin_token()}"},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            docs = resp.json()["documents"]
+            target = [d for d in docs if d["id"] == 70]
+            self.assertTrue(target, "seeded file 70 must appear in list")
+            self.assertEqual(target[0]["failed_chunks"], 2)
+            self.assertEqual(sorted(target[0]["failed_chunk_ids"]), [1, 3])
+        finally:
+            main_app.dependency_overrides.clear()
+
+    def test_status_surfaces_failed_chunks(self):
+        """GET /documents/{id}/status surfaces failed_chunks/failed_chunk_ids."""
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.get(
+                "/api/documents/70/status",
+                headers={"Authorization": f"Bearer {self._member_token()}"},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            data = resp.json()
+            self.assertEqual(data["failed_chunks"], 2)
+            self.assertEqual(sorted(data["failed_chunk_ids"]), [1, 3])
+            self.assertEqual(data["chunks_failed"], 2)
+        finally:
+            main_app.dependency_overrides.clear()
+
+    # ── HTTP endpoint ───────────────────────────────────────────────────
+
+    def _setup_client(self, embedding_service, vector_store):
+        from app.api.deps import (
+            get_db,
+            get_db_pool,
+            get_embedding_service,
+            get_secret_manager,
+            get_vector_store,
+        )
+        from app.main import app as main_app
+
+        def get_test_db():
+            conn = self.pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self.pool.release_connection(conn)
+
+        main_app.dependency_overrides[get_db] = get_test_db
+        main_app.dependency_overrides[get_db_pool] = lambda: self.pool
+        main_app.dependency_overrides[get_vector_store] = lambda: vector_store
+        main_app.dependency_overrides[get_embedding_service] = lambda: (
+            embedding_service
+        )
+        _sm = MagicMock()
+        _sm.get_hmac_key.return_value = (b"test-hmac-key-32bytes-padding!!", "v1")
+        main_app.dependency_overrides[get_secret_manager] = lambda: _sm
+        client = TestClient(main_app)
+        client.headers["user-agent"] = ""
+        return client, main_app
+
+    def _admin_token(self):
+        payload = {
+            "sub": str(self.admin_id),
+            "username": "admin_user",
+            "role": "admin",
+            "exp": datetime.now(timezone.utc).timestamp() + 3600,
+            "type": "access",
+        }
+        return jwt.encode(payload, settings.jwt_secret_key, algorithm="HS256")
+
+    def _member_token(self):
+        payload = {
+            "sub": str(self.member_id),
+            "username": "member_user",
+            "role": "member",
+            "exp": datetime.now(timezone.utc).timestamp() + 3600,
+            "type": "access",
+        }
+        return jwt.encode(payload, settings.jwt_secret_key, algorithm="HS256")
+
+    def test_endpoint_admin_retry_succeeds(self):
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.post(
+                "/api/documents/70/retry-chunks",
+                headers={"Authorization": f"Bearer {self._admin_token()}"},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            data = resp.json()
+            self.assertEqual(data["succeeded"], 2)
+        finally:
+            main_app.dependency_overrides.clear()
+
+    def test_endpoint_member_forbidden(self):
+        """Non-admin cannot retry chunks → 403."""
+        self._seed_failed_chunks()
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.post(
+                "/api/documents/70/retry-chunks",
+                headers={"Authorization": f"Bearer {self._member_token()}"},
+            )
+            self.assertEqual(resp.status_code, 403)
+        finally:
+            main_app.dependency_overrides.clear()
+
+    def test_endpoint_unauthenticated_returns_401(self):
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.post("/api/documents/70/retry-chunks")
+            self.assertEqual(resp.status_code, 401)
+        finally:
+            main_app.dependency_overrides.clear()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_failed_chunks_retry.py
+++ b/backend/tests/test_failed_chunks_retry.py
@@ -165,6 +165,46 @@ class TestFailedChunksRetry(unittest.TestCase):
                 "VALUES (?, ?, ?, ?)",
                 (self.vault_id, self.member_id, "read", "2026-01-01"),
             )
+            # admin_user (role=admin) gets an explicit admin entry on vault A so
+            # the per-file vault-admin check (evaluate ... "admin") passes. The
+            # role=admin baseline alone only grants write, not admin.
+            conn.execute(
+                "INSERT INTO vault_members (vault_id, user_id, permission, granted_at) "
+                "VALUES (?, ?, ?, ?)",
+                (self.vault_id, self.admin_id, "admin", "2026-01-01"),
+            )
+            # A second vault (B) and a vault admin of B only — used to prove the
+            # cross-vault admin check on retry-chunks (NF1): admin-of-B must NOT
+            # be able to retry chunks of a file in vault A (self.vault_id).
+            conn.execute(
+                "INSERT INTO vaults (name, description, visibility, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("VB", "v", "private", "2026-01-01", "2026-01-01"),
+            )
+            self.vault_b_id = conn.execute(
+                "SELECT id FROM vaults WHERE name='VB'"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO users (username, hashed_password, full_name, role, is_active, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "vault_b_admin",
+                    "pw",
+                    "Vault B Admin",
+                    "admin",  # role=admin: passes require_admin_role pre-filter;
+                    #   per-vault gate must still deny (no admin perm on vault A)
+                    1,
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+            self.vault_b_admin_id = conn.execute(
+                "SELECT id FROM users WHERE username='vault_b_admin'"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO vault_members (vault_id, user_id, permission, granted_at) "
+                "VALUES (?, ?, ?, ?)",
+                (self.vault_b_id, self.vault_b_admin_id, "admin", "2026-01-01"),
+            )
             # An indexed file with chunks_failed=2.
             conn.execute(
                 "INSERT INTO files (id, file_name, file_path, file_size, status, chunk_count, "
@@ -258,7 +298,8 @@ class TestFailedChunksRetry(unittest.TestCase):
         self.assertEqual(len(vs.added_records), 2)
         rebuilt_ids = {r["id"] for r in vs.added_records}
         self.assertEqual(rebuilt_ids, expected_ids)
-        # failed_chunks rows deleted; chunks_failed decremented to 0.
+        # failed_chunks rows deleted; chunks_failed decremented to 0;
+        # chunk_count incremented by the 2 re-indexed chunks (PRR-003).
         conn = self.pool.get_connection()
         try:
             remaining = conn.execute(
@@ -269,6 +310,10 @@ class TestFailedChunksRetry(unittest.TestCase):
                 "SELECT chunks_failed FROM files WHERE id = 70"
             ).fetchone()[0]
             self.assertEqual(cf, 0)
+            cc = conn.execute(
+                "SELECT chunk_count FROM files WHERE id = 70"
+            ).fetchone()[0]
+            self.assertEqual(cc, 5)  # was 3, +2 retried
         finally:
             self.pool.release_connection(conn)
 
@@ -473,6 +518,22 @@ class TestFailedChunksRetry(unittest.TestCase):
         }
         return jwt.encode(payload, settings.jwt_secret_key, algorithm="HS256")
 
+    def _vault_b_admin_token(self):
+        """Token for a user who is admin of vault B but NOT vault A.
+
+        role=admin is deliberate: it clears the coarse require_admin_role
+        pre-filter so the request reaches the per-file vault-admin gate —
+        which is the actual threat model the test must exercise.
+        """
+        payload = {
+            "sub": str(self.vault_b_admin_id),
+            "username": "vault_b_admin",
+            "role": "admin",  # passes pre-filter; per-vault check must still deny
+            "exp": datetime.now(timezone.utc).timestamp() + 3600,
+            "type": "access",
+        }
+        return jwt.encode(payload, settings.jwt_secret_key, algorithm="HS256")
+
     def test_endpoint_admin_retry_succeeds(self):
         self._seed_failed_chunks()
         emb = _FakeEmbeddingService()
@@ -486,6 +547,27 @@ class TestFailedChunksRetry(unittest.TestCase):
             self.assertEqual(resp.status_code, 200, resp.text)
             data = resp.json()
             self.assertEqual(data["succeeded"], 2)
+        finally:
+            main_app.dependency_overrides.clear()
+
+    def test_endpoint_cross_vault_admin_forbidden(self):
+        """[NF1] A vault admin of vault B cannot retry chunks of a file in
+        vault A — require_admin_role is only a coarse pre-filter; the handler
+        must enforce per-file vault-admin authz."""
+        self._seed_failed_chunks()  # file 70 is in vault A (self.vault_id)
+        emb = _FakeEmbeddingService()
+        vs = _FakeVectorStore()
+        client, main_app = self._setup_client(emb, vs)
+        try:
+            resp = client.post(
+                "/api/documents/70/retry-chunks",
+                headers={
+                    "Authorization": f"Bearer {self._vault_b_admin_token()}"
+                },
+            )
+            self.assertEqual(resp.status_code, 403, resp.text)
+            # No LanceDB write should have occurred.
+            self.assertEqual(len(vs.added_records), 0)
         finally:
             main_app.dependency_overrides.clear()
 

--- a/backend/tests/test_schema_drift.py
+++ b/backend/tests/test_schema_drift.py
@@ -26,7 +26,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 # constant ONLY when an intentional schema change adds/removes a base table,
 # and document the change in the commit message.
 # 44 -> 45: master added `document_reindex_jobs` (reindex jobs table).
-EXPECTED_BASE_TABLE_COUNT = 45
+# 45 -> 46: PR #410 added `failed_chunks` (per-chunk retry identity, Issue #396).
+EXPECTED_BASE_TABLE_COUNT = 46
 
 # Curated set of critical application tables that must always exist. If any of
 # these disappears, the drift test fails with a clear message naming the table.


### PR DESCRIPTION
## Summary

Implements the four backend document features tracked by #396, closing #54 (the remaining backend-blocked UX items deferred from Round 4 / PR #53).

- **Failed-chunk accounting + chunk-scoped retry** — new `failed_chunks` table persists per-chunk identity + rebuild metadata at ingest; `POST /documents/{file_id}/retry-chunks` re-embeds only the failures without re-parsing. `failed_chunks` / `failed_chunk_ids` surfaced in status, list, and detail responses.
- **Ranked `/documents/search`** — browse-oriented ranked endpoint over `files_content_fts` (body) + `files_search_fts` (metadata) with `bm25()` ranking, highlighted excerpts, and a filename fallback. De-duplicated in SQL before pagination; vault-scoped.
- **`chunk_bbox` page-highlight metadata** — opportunistic capture of unstructured `coordinates.points` into chunk metadata (defensive; degrades to absent when unavailable, including in CI where unstructured is stubbed).
- **Configurable context window** — `/search/chunks/{chunk_id}/context` accepts `context_before` / `context_after` and returns structured `before` / `matched_text` / `after` via a new `get_chunks_by_file_range` LanceDB helper. Backward compatible (`context_text` / `context_source` retained).

## How it works

### Failed-chunk retry
Failed-chunk identity is captured at the embedding-failure point in both ingestion paths (`process_file`, `process_existing_file`) **before** the failed chunks are dropped, then persisted to `failed_chunks` (text + rebuild metadata incl. `parent_window_text`). On retry, `DocumentProcessor.retry_failed_chunks` re-embeds each chunk one at a time, checks `embed_batch`'s `None`-return contract (does not raise), writes rebuilt records to LanceDB **first** (not transactional with SQLite), then cleans up `failed_chunks` rows in its own try/except with a pre-check that reconciles chunks already indexed. Retry is restricted to `status == 'indexed'` (409 otherwise); the >50%-abort path clears `failed_chunks` rows (unreachable for chunk-retry) to avoid a counter desync.

### Ranked search
`bm25()` over both FTS5 tables with a `UNION ALL` + `ROW_NUMBER() OVER (PARTITION BY id ...)` CTE that keeps the best match per document (body > metadata > filename) **before** `LIMIT`/`OFFSET`. Excerpts come from `highlight()` on the actual matched column; `total` counts unique docs via a single full-count CTE (filename LIKE runs once, not twice). Vault scoping mirrors `GET /documents`; the retry-chunks endpoint enforces per-file vault-admin authz (`evaluate(user, vault, vault_id, "admin")`) in addition to the coarse `require_admin_role` pre-filter.

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `failed_chunks`/`failed_chunk_ids` + retry surfaced in document status | ✅ |
| 2 | Ranked `/documents/search` returns matching excerpts | ✅ |
| 3 | `chunk_bbox` page-highlight metadata where available | ✅ |
| 4 | `/search/chunks/{chunk_id}/context` accepts `context_before`/`context_after`, returns structured before/match/after | ✅ |

## Invariants preserved
- Existing `GET /documents?search=` lightweight filter unchanged.
- Existing `POST /documents/admin/retry/{file_id}` (whole-doc) unchanged.
- `ChunkContextResponse` extensions are additive (defaults keep old clients working).
- LanceDB schema unchanged (`chunk_bbox` lives in the existing metadata JSON column).
- Backend-only (issue subsystem: backend); no frontend changes.

## Test plan
37 new tests across 4 new files + 2 added to the existing `test_document_processor.py`, asserting real behavior (not just status codes):
- **Failed-chunk retry:** LanceDB write verification, None-embedding guard, reconciliation pre-check, 409 on non-indexed, admin/member/unauth authz, **cross-vault admin denial**, list + status surfacing across all 3 list branches, **chunk_count increment**, **>50% abort clears failed_chunks**.
- **Ranked search:** bm25 ranking order, **excerpt highlights the matched metadata column**, dedup (one row per doc), pagination non-overlap, cross-vault isolation, filename match, **FTS hyphen handling**.
- **chunk_bbox:** capture via real `_capture_bbox` method, malformed/absent coordinates, JSON round-trip.
- **Context window:** ordered before/after neighbors, backward-compatible defaults, non-contiguous indices, inaccessible-vault 404, **negative BETWEEN bound at index 0**.

**Validation run:**
- `ruff check .` → All checks passed
- `python scripts/check_config_contract.py` → passed
- `python scripts/check_pr_scope_drift.py` → passed
- 146 tests pass, 0 failures

Closes #396
Closes #54