### PR TITLE
test(auth): async-override regression test for get_current_user_or_service_account (#399)

### DIFF
--- a/backend/tests/test_auth_override_async_path.py
+++ b/backend/tests/test_auth_override_async_path.py
@@ -1,0 +1,386 @@
+"""
+Regression test for the auth dependency override branch in
+``get_current_user_or_service_account`` (``backend/app/api/deps.py``).
+
+History / why this file exists
+------------------------------
+Issue #312 asked for a regression test that sets
+``app.dependency_overrides[get_evaluate_policy]`` to an ``async def`` to guard
+against the historical anti-pattern where an override branch used
+``inspect.isawaitable()`` instead of ``inspect.iscoroutine()`` (documented in
+``.agents/skills/authz-bridging-exceptions/SKILL.md``).
+
+Verification of the current code (2026-07-15) shows:
+
+1. ``inspect.isawaitable`` appears NOWHERE in ``backend/`` — the bug is absent.
+2. There is NO override branch keyed on ``get_evaluate_policy`` anywhere in
+   application code. ``get_evaluate_policy`` is a plain factory returning a
+   closure; FastAPI's DI resolver handles overrides of it directly, with no
+   ``iscoroutine``/``isawaitable`` decision point. A test overriding
+   ``get_evaluate_policy`` with an ``async def`` would therefore be *vacuous*:
+   it would pass on both the buggy and the fixed code because there is no
+   branch to exercise.
+
+3. The ONE real override branch is in ``get_current_user_or_service_account``
+   (deps.py:550-557), keyed on ``get_current_active_user``::
+
+       _override = request.app.dependency_overrides.get(get_current_active_user)
+       if _override is not None:
+           _result = _override()
+           user = await _result if inspect.iscoroutine(_result) else _result
+           return user
+
+   It already uses the correct ``inspect.iscoroutine``.
+
+This file therefore ships the *meaningful* variant of #312: it exercises the
+REAL override branch with a module-scope ``async def`` override (not a sync
+lambda) that calls another ``async def`` (matching AC-2 of the skill), and it
+pins the literal ``isawaitable``-absence invariant via source inspection.
+
+What is falsified, and what is NOT
+----------------------------------
+Two distinct bug classes touch this branch; the tests below split them so each
+is guarded by the right kind of assertion:
+
+1. **Drop-the-await bug** (the coroutine is never awaited, so ``user`` is a raw
+   coroutine object). Falsified *behaviorally* by the 200/403 pair below: a raw
+   coroutine handed to ``_evaluate_policy`` raises ``AttributeError`` on
+   ``principal.get("id")`` and the route 500s instead of returning 200/403.
+   Verified by mutation: changing deps.py:556 to ``user = _result`` makes both
+   behavioral tests fail.
+
+2. **``isawaitable``-vs-``iscoroutine`` bug** (the literal #312 concern).
+   IMPORTANT: these two predicates return the SAME value on a coroutine object
+   (both True), because the override is *called* at deps.py:555 before the
+   check. So swapping ``iscoroutine`` → ``isawaitable`` leaves the behavioral
+   tests GREEN — it is NOT falsified by the 200/403 pair. This invariant is
+   guarded only by the source-inspection test
+   ``test_override_branch_uses_iscoroutine_not_isawaitable`` (a source-string
+   tripwire, not a behavioral test). That test catches a revert to
+   ``isawaitable``; it would also fail on a benign rename, so treat it as a
+   tripwire, not proof of behavior.
+
+A purely behavioral falsifier for bug class 2 would require a code path where
+``inspect.isawaitable`` is evaluated on an *uncalled* ``async def`` function
+(where the two predicates diverge) — such a path does not exist in current
+deps.py. So bug class 2 is pinned by source inspection; bug class 1 is pinned
+behaviorally. Both are documented honestly here.
+"""
+
+import inspect
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies (mirrors test_service_account_authenticates_to_routes.py)
+try:
+    import lancedb
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition
+except ImportError:
+    import types
+
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType("unstructured.documents.elements")
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _unstructured
+    sys.modules["unstructured.partition"] = _unstructured.partition
+    sys.modules["unstructured.partition.auto"] = _unstructured.partition.auto
+    sys.modules["unstructured.chunking"] = _unstructured.chunking
+    sys.modules["unstructured.chunking.title"] = _unstructured.chunking.title
+    sys.modules["unstructured.documents"] = _unstructured.documents
+    sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
+
+from _db_pool import SimpleConnectionPool
+from fastapi.testclient import TestClient
+
+from app.api.deps import (
+    get_background_processor,
+    get_current_active_user,
+    get_db,
+    get_db_pool,
+    get_embedding_service,
+    get_evaluate_policy,
+    get_secret_manager,
+    get_vector_store,
+)
+from app.config import settings
+from app.main import app
+from app.models.database import _pool_cache, _pool_cache_lock, init_db, run_migrations
+
+# ---------------------------------------------------------------------------
+# Module-scope async def overrides (the point of #312).
+#
+# These are `async def` functions defined at MODULE scope — NOT sync lambdas.
+# AC-2 of the authz-bridging-exceptions skill: "sets it to an `async def`
+# function that calls another `async def` function". The override calls
+# another async def (`_superadmin_user_coro`) to satisfy that wording.
+# ---------------------------------------------------------------------------
+
+
+async def _superadmin_user_coro():
+    """Inner async def — the 'another async def' that the override calls."""
+    return {
+        "id": 1,
+        "username": "superadmin",
+        "role": "superadmin",
+        "is_active": True,
+        "is_service_account": False,
+    }
+
+
+async def _override_authorized_user():
+    """Override value for get_current_active_user — an async def, not a lambda.
+
+    Calling this yields a coroutine; the deps.py override branch must
+    `inspect.iscoroutine`-detect it and await it to recover the dict below.
+    """
+    return await _superadmin_user_coro()
+
+
+async def _forbidden_member_coro():
+    """Inner async def returning a non-superadmin user with no vault access."""
+    return {
+        "id": 999,
+        "username": "outsider",
+        "role": "member",
+        "is_active": True,
+        "is_service_account": False,
+    }
+
+
+async def _override_unauthorized_user():
+    """Override value: async def returning a member with no vault 1 membership.
+
+    `_evaluate_policy` will look up vault_members for (user 999, vault 1),
+    find nothing, and return False → 403. This proves the resolved principal
+    flows into `evaluate` (it is not bypassed or replaced with None).
+    """
+    return await _forbidden_member_coro()
+
+
+class TestAuthOverrideAsyncPath(unittest.TestCase):
+    """Exercise the async-def override path on get_current_user_or_service_account."""
+
+    def setUp(self):
+        self._original_jwt_env = os.environ.get("JWT_SECRET_KEY")
+        os.environ["JWT_SECRET_KEY"] = "test-auth-override-async-key-32chars!"
+
+        self._temp_dir = tempfile.mkdtemp()
+        self._db_path = str(Path(self._temp_dir) / "app.db")
+
+        self._original_jwt_secret = settings.jwt_secret_key
+        self._original_users_enabled = settings.users_enabled
+        self._original_data_dir = settings.data_dir
+
+        settings.users_enabled = True
+        settings.data_dir = Path(self._temp_dir)
+        settings.jwt_secret_key = os.environ["JWT_SECRET_KEY"]
+
+        with _pool_cache_lock:
+            for _path, pool in list(_pool_cache.items()):
+                pool.close_all()
+            _pool_cache.clear()
+
+        init_db(self._db_path)
+        run_migrations(self._db_path)
+        self._connection_pool = SimpleConnectionPool(self._db_path)
+
+        def override_get_db():
+            conn = self._connection_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                self._connection_pool.release_connection(conn)
+
+        self._mock_vector_store = MagicMock()
+        self._mock_vector_store.db = None
+        self._mock_embedding_service = MagicMock()
+        self._mock_embedding_service.embed_single = AsyncMock(return_value=[0.0] * 384)
+        self._mock_db_pool = self._connection_pool
+        self._mock_background_processor = MagicMock()
+        self._mock_background_processor.is_running = True
+        self._mock_background_processor.enqueue = AsyncMock()
+
+        app.dependency_overrides[get_db] = override_get_db
+        app.dependency_overrides[get_vector_store] = lambda: self._mock_vector_store
+        app.dependency_overrides[get_embedding_service] = lambda: self._mock_embedding_service
+        app.dependency_overrides[get_db_pool] = lambda: self._mock_db_pool
+        app.dependency_overrides[get_background_processor] = lambda: self._mock_background_processor
+        _mock_sm = MagicMock()
+        _mock_sm.get_hmac_key.return_value = (b"test-hmac-key-32bytes-padding!!", "v1")
+        app.dependency_overrides[get_secret_manager] = lambda: _mock_sm
+
+        conn = self._connection_pool.get_connection()
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute("DELETE FROM files")
+            conn.execute("DELETE FROM vault_members")
+            conn.execute("DELETE FROM users WHERE id != 0")
+            conn.execute("DELETE FROM service_accounts")
+
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, username, hashed_password, full_name, role, is_active) "
+                "VALUES (?, ?, ?, ?, ?, 1)",
+                (1, "superadmin", "x", "Super Admin", "superadmin"),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO vaults (id, name, description) VALUES (?, ?, ?)",
+                (1, "Test Vault", "A test vault"),
+            )
+            # Document in vault 1 so list_document_tags can reach its body after the
+            # permission check passes.
+            conn.execute(
+                "INSERT OR IGNORE INTO files (id, file_name, file_path, file_size, status, chunk_count, vault_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (1, "doc.txt", "/uploads/doc.txt", 100, "indexed", 0, 1),
+            )
+            conn.commit()
+        finally:
+            self._connection_pool.release_connection(conn)
+
+        self.client = TestClient(app)
+        self.client.headers["user-agent"] = ""
+
+    def tearDown(self):
+        with _pool_cache_lock:
+            for _path, pool in list(_pool_cache.items()):
+                pool.close_all()
+            _pool_cache.clear()
+
+        settings.jwt_secret_key = self._original_jwt_secret
+        settings.users_enabled = self._original_users_enabled
+        settings.data_dir = self._original_data_dir
+
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_vector_store, None)
+        app.dependency_overrides.pop(get_embedding_service, None)
+        app.dependency_overrides.pop(get_db_pool, None)
+        app.dependency_overrides.pop(get_background_processor, None)
+        app.dependency_overrides.pop(get_secret_manager, None)
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+        self.client.close()
+        self._connection_pool.close_all()
+
+        if self._original_jwt_env is None:
+            os.environ.pop("JWT_SECRET_KEY", None)
+        else:
+            os.environ["JWT_SECRET_KEY"] = self._original_jwt_env
+
+        try:
+            shutil.rmtree(self._temp_dir)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Primary behavioral falsifier: the 200 / 403 pair.
+    # ------------------------------------------------------------------
+
+    def test_async_override_resolves_and_allows(self):
+        """An `async def` override (not a lambda) resolves to the dict and the
+        route returns 200.
+
+        This requires the deps.py override branch to detect the coroutine and
+        await it. If the await is dropped or `iscoroutine` no longer matches,
+        `user` is a coroutine and `_require_vault_read` breaks.
+        """
+        app.dependency_overrides[get_current_active_user] = _override_authorized_user
+
+        resp = self.client.get("/api/tags/documents/1", params={"vault_id": 1})
+        self.assertEqual(
+            resp.status_code, 200, f"expected 200, got {resp.status_code}: {resp.text}"
+        )
+        self.assertEqual(resp.json(), {"tags": []})
+
+    def test_async_override_unauthorized_denies(self):
+        """An `async def` override returning an unauthorized member yields 403.
+
+        Proves the RESOLVED principal dict flows into `evaluate` (which checks
+        vault_members and denies) — the auth path is not bypassed.
+        """
+        app.dependency_overrides[get_current_active_user] = _override_unauthorized_user
+
+        resp = self.client.get("/api/tags/documents/1", params={"vault_id": 1})
+        self.assertEqual(
+            resp.status_code, 403, f"expected 403, got {resp.status_code}: {resp.text}"
+        )
+
+    # ------------------------------------------------------------------
+    # Source-inspection tripwires: pin the invariants the literal #312 names.
+    #
+    # NOTE: these are source-STRING guards, NOT behavioral tests. They catch a
+    # revert to `isawaitable`, but they also fail on a benign rename (e.g.
+    # `from inspect import iscoroutine`). They exist because the
+    # isawaitable-vs-iscoroutine bug is NOT behaviorally falsifiable here — see
+    # the module docstring "What is falsified, and what is NOT".
+    # ------------------------------------------------------------------
+
+    def test_override_branch_uses_iscoroutine_not_isawaitable(self):
+        """Source-string tripwire: the override branch source contains
+        `iscoroutine` and the string `isawaitable` appears nowhere in deps.py.
+
+        This is the ONLY test that catches an `iscoroutine`→`isawaitable` revert
+        (verified by mutation: swapping the predicate leaves the behavioral
+        200/403 tests green because both predicates return True on a coroutine
+        object). It also fails on benign renames — treat as a tripwire.
+        """
+        from app.api import deps
+
+        src = inspect.getsource(deps.get_current_user_or_service_account)
+        self.assertIn("iscoroutine", src)
+        self.assertNotIn("isawaitable", src)
+
+        deps_file = Path(deps.__file__).read_text()
+        self.assertNotIn("isawaitable", deps_file)
+
+    def test_get_evaluate_policy_has_no_override_branch(self):
+        """Document that `get_evaluate_policy` has no `dependency_overrides`
+        read — i.e. #312's literal `dependency_overrides[get_evaluate_policy]`
+        surface does not exist in application code. FastAPI resolves such
+        overrides directly, with no iscoroutine/isawaitable decision point.
+
+        If a future change adds an override branch to get_evaluate_policy,
+        this test should be updated to cover it (and to assert it uses
+        iscoroutine).
+        """
+        from app.api import deps
+
+        src = inspect.getsource(deps.get_evaluate_policy)
+        self.assertNotIn("dependency_overrides", src)
+        self.assertNotIn("isawaitable", src)
+        self.assertNotIn("iscoroutine", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -47,6 +47,13 @@ Tests for concurrent permission queries live in `backend/tests/test_effective_va
 - The `_SQLITE_SERIALIZED` flag in `deps.py` controls whether the concurrent or sequential branch runs; tests may monkey-patch `deps._SQLITE_SERIALIZED` to force either path.
 - Seeds multiple vaults, groups, and memberships; asserts each vault returns the correct effective permission string.
 
+### Auth override async-path tests (`test_auth_override_async_path.py`)
+Tests for the `get_current_user_or_service_account` dependency-override branch (issue #312 / `authz-bridging-exceptions` skill) live in `backend/tests/test_auth_override_async_path.py`. Key patterns and policy:
+- The override branch in `deps.py` (`get_current_user_or_service_account`) reads `app.dependency_overrides[get_current_active_user]` and must `await` the result only when it is a coroutine: `user = await _result if inspect.iscoroutine(_result) else _result`. The check must use `inspect.iscoroutine` — never `inspect.isawaitable` (the historical anti-pattern the `authz-bridging-exceptions` skill documents).
+- The test overrides `get_current_active_user` with a **module-scope `async def`** (not a sync lambda) that calls another `async def`, matching AC-2 of the skill, then drives a real route (`GET /api/tags/documents/{id}`) through `TestClient`.
+- **Two bug classes are guarded, and the distinction matters:** (1) *drop-the-await* is falsified **behaviorally** by a 200 (authorized) / 403 (denied) pair — mutating the branch to skip the await makes both fail because the raw coroutine reaches `_evaluate_policy`. (2) *`isawaitable`-vs-`iscoroutine`* is **not** behaviorally falsifiable here (the override is *called* before the check, so `_result` is a coroutine on which both predicates return True); it is pinned only by a **source-string tripwire** (`test_override_branch_uses_iscoroutine_not_isawaitable`). A purely behavioral falsifier for class 2 would require an `isawaitable` check on an uncalled `async def`, which does not exist in `deps.py`.
+- `get_evaluate_policy` has no `dependency_overrides` read of its own; FastAPI resolves overrides of it directly. So a test overriding `get_evaluate_policy` with an `async def` would be vacuous — the override branch under test is on `get_current_active_user`.
+
 ---
 
 ## 3. Frontend testing (Vitest + React Testing Library + jsdom)


### PR DESCRIPTION
Closes #399
Closes #310
Closes #312

## Summary

Resolves the tracking issue #399, which bundled two sub-issues. Investigation
showed the bulk of the described work was already merged before #399 was
opened, and #312's literal request targets a code path that no longer exists.
This PR contributes the one genuinely-missing deliverable (the #312 regression
test) and closes all three with honest dispositions. **No production code
changes** — one new test file.

### #310 — DI conversion of route files: ALREADY DONE (no code needed)
The conversion of the 6 route files (`chat.py`, `folders.py`, `kms.py`,
`memories.py`, `tags.py`, `wiki.py`) plus `vault_members.py` from the standalone
`evaluate_policy` (which opens its own pool connection) to DI-injected
`Depends(get_evaluate_policy)` was **already merged** via:
- PR #384 — `fix(backend): eliminate evaluate_policy double-connection (#205 S-003)` (2026-07-14 05:13Z)
- PR #385 — `fix(backend): eliminate double db connections in route files` (2026-07-14 13:13Z)

Invariant verified: `git grep -nE 'await evaluate_policy\(' backend/app/api/routes/` → **zero matches**.

> Note on the grep: a broader `evaluate_policy\(` (no `await ` prefix) returns two hits — `chat.py:715` and `wiki.py:770` — but these are `_evaluate_policy(conn, ...)` (the underscore-prefixed connection-bound helper), called inside an intentional short-lived `with pool.connection()` auth block that is **released before the SSE stream begins**. This is the documented PR #301/#384 carve-out for streaming endpoints, NOT the anti-pattern. A request-scoped `Depends(get_evaluate_policy)` there would pin a pool slot across the entire stream — the exact regression #301 fixed.

`vault_members.py:332` (cited by #310) is also clean: the permission check is now `Depends(get_evaluate_policy)` at line 306.

### #310 AC test files — renamed, substance covered
#310's AC literally names three test files. Disposition:
- `test_chat_route_policy_di.py` — **exists**.
- `test_wiki_events_connection_lifetime.py` — **does not exist**; substance covered by `test_chat_stream_connection_release.py` (header: *"Issue #301 regression: the pooled SQLite connection used for /chat/stream auth must be RELEASED before the SSE stream begins"*).
- `test_route_policy_di_no_standalone.py` — **does not exist**; substance covered by `test_route_policy_no_double_connection.py` (header: *"Issue #205 (S-003): eliminate the double-connection … Target files: chat.py, memories.py, kms.py, wiki.py, tags.py, folders.py, vault_members.py"*).

Rather than ship empty stubs, the existing files (which cover all 7 files) are relied upon. Flagging here so the AC checklist can be reconciled.

### #312 — async-override regression test: literal AC is vacuous; ships meaningful variant
#312 asked for a regression test that sets `app.dependency_overrides[get_evaluate_policy]` to an `async def` to guard against an `inspect.isawaitable` vs `inspect.iscoroutine` bug. That literal target **no longer exists**:
- `inspect.isawaitable` appears **nowhere** in `backend/`.
- There is **no** override branch keyed on `get_evaluate_policy` anywhere in application code. `get_evaluate_policy` is a plain factory; FastAPI resolves overrides of it directly with no `iscoroutine`/`isawaitable` decision point. A test overriding `get_evaluate_policy` with an `async def` would be **vacuous** — it would pass on both buggy and fixed code.
- The `get_evaluate_policy`-keyed override branch was removed back in `3130c92` (`fix(api): reuse sqlite policy connections`).

The ONE surviving override branch is in `get_current_user_or_service_account` (`deps.py:550-557`), keyed on `get_current_active_user`, and already uses the correct `inspect.iscoroutine`. This PR ships the **meaningful variant** of #312: a new `backend/tests/test_auth_override_async_path.py` that exercises that real branch end-to-end with a module-scope `async def` override (not a sync lambda) that calls another `async def` — matching AC-2 of `.agents/skills/authz-bridging-exceptions/SKILL.md`.

## What the test guards (honestly labeled)

Two distinct bug classes; each is guarded by the right kind of assertion:

| Bug class | Falsifier | Honest note |
|---|---|---|
| **Drop-the-await** (coroutine never awaited → `user` is a raw coroutine) | **Behavioral** — the 200/403 pair. Mutation `deps.py:556 → user = _result` makes both fail with `AttributeError: 'coroutine' object has no attribute 'get'`. | Genuinely falsified. |
| **`isawaitable` vs `iscoroutine`** (the literal #312 concern) | **Source-string tripwire only** — `test_override_branch_uses_iscoroutine_not_isawaitable`. | NOT behaviorally falsifiable here: the override is *called* at `deps.py:555` before the check, so `_result` is a coroutine on which both predicates return True. An `iscoroutine`→`isawaitable` swap leaves the behavioral tests green (verified by mutation). The tripwire also fails on a benign rename — treat as a tripwire, not proof of behavior. |

No purely behavioral falsifier exists for bug class 2 because there is no code path where `isawaitable` is evaluated on an *uncalled* `async def` function. This is documented in the module docstring of the test file.

## Test plan
- [x] `cd backend && python -m pytest tests/test_auth_override_async_path.py -v` → **4 passed**
- [x] Falsifiability (drop-await): mutate `deps.py:556` → `user = _result`, both behavioral tests fail; revert → green
- [x] Falsifiability (isawaitable): mutate `deps.py:556` → `inspect.isawaitable`, only the source tripwire fails (behavioral stays green, as documented)
- [x] `cd backend && python -m pytest -q tests/test_deps_auth.py tests/test_deps_auth_adversarial.py tests/test_service_account_authenticates_to_routes.py tests/test_chat_route_policy_di.py tests/test_route_policy_no_double_connection.py tests/test_tags_routes.py` → **164 passed** (incl. new file)
- [x] `cd backend && python -m ruff check .` → clean
- [x] `python scripts/check_config_contract.py` → pass
- [x] `python scripts/check_pr_scope_drift.py` → pass
- [x] Invariant: `git grep -nE 'await evaluate_policy\(' backend/app/api/routes/` → empty

## Validation gates (swarm)
- Independent implementation reviewer (Phase 8b): **APPROVE** — re-ran all evidence, confirmed falsifiability load-bearing, teardown non-polluting (164-test combined run clean).
- Final critic (Phase 9): **NEEDS_REVISION** → fixed (docstring had overclaimed the behavioral pair falsifies the isawaitable bug; corrected after critic empirically disproved it). Re-reviewed on updated diff: **APPROVE**.

## Follow-up (not in scope)
- `.agents`/`.claude`/`.opencode` mirrors of `authz-bridging-exceptions/SKILL.md` reference functions `get_chat_stream_auth_context` and `get_wiki_events_auth_context` that **do not exist** (removed in `3130c92`, replaced by `get_stream_auth` / `wiki_events_stream`). This staleness contributed to the #312 confusion and should be corrected in a separate PR (mirrors required per `AGENTS.md`). Flagging here; not touched to avoid expanding scope.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/ragappv3/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

