### PR TITLE
fix(security): single-transaction atomicity for register/change-password/lockout (#405, #393)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -50,27 +50,51 @@ REFRESH_TOKEN_COOKIE_NAME = "refresh_token"
 REFRESH_TOKEN_MAX_AGE_DAYS = 30
 
 
-def _record_failed_attempt_db(
-    db,
-    user_id: int,
-    failed_attempts: int,
-) -> None:
+def _record_failed_attempt_db(db, user_id: int) -> int:
     """Record a failed login attempt and lock out the account if threshold reached.
 
-    Executes in a single transaction with rollback on failure.
+    F-2.4 (#393): re-reads ``failed_attempts`` inside ``BEGIN IMMEDIATE`` after
+    the atomic UPDATE so concurrent incrementers cannot bypass the lockout
+    threshold on a stale snapshot. Executes in a single transaction with
+    rollback on failure.
+
+    Returns the fresh post-increment ``failed_attempts`` count so the caller
+    can choose an accurate HTTP status for the trip request (401 vs 423)
+    without re-reading — the stale caller-snapshotted value cannot be trusted
+    under concurrency.
     """
     try:
+        # Clear any dangling implicit transaction (e.g., from the login SELECT).
+        if db.in_transaction:
+            db.rollback()
+        db.execute("BEGIN IMMEDIATE")
         db.execute(
             "UPDATE users SET failed_attempts = failed_attempts + 1 WHERE id = ?",
             (user_id,),
         )
-        if failed_attempts + 1 >= 5:
+        # F-2.4: re-read the post-UPDATE value under the write lock before
+        # deciding whether to set locked_until. The stale caller-snapshotted
+        # value is intentionally ignored — concurrent failed logins can each
+        # observe a stale read of N and skip lockout even at >= 5 attempts.
+        # PRR-002: guard the None case — if the user row was deleted between
+        # the login SELECT and this re-read (concurrent superadmin delete),
+        # fetchone() returns None. Roll back the no-op UPDATE and return 0 so
+        # the caller issues a generic 401 rather than a TypeError → 500.
+        row = db.execute(
+            "SELECT failed_attempts FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+        if row is None:
+            db.rollback()
+            return 0
+        fresh = row[0]
+        if fresh >= 5:
             lockout_until = datetime.now(timezone.utc) + timedelta(minutes=15)
             db.execute(
                 "UPDATE users SET locked_until = ? WHERE id = ?",
                 (lockout_until.isoformat(), user_id),
             )
         db.commit()
+        return fresh
     except Exception:
         db.rollback()
         raise
@@ -251,34 +275,68 @@ async def register(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    # Check username uniqueness (case-insensitive)
-    existing = await asyncio.to_thread(
-        lambda: db.execute(
-            "SELECT id FROM users WHERE username = ? COLLATE NOCASE", (body.username,)
-        ).fetchone()
-    )
-    if existing:
-        raise HTTPException(status_code=409, detail="Username already exists")
+    # Check username uniqueness (case-insensitive) — performed INSIDE the
+    # BEGIN IMMEDIATE transaction below (F-2.1, #393) so concurrent
+    # registrations of the same username get a clean 409 instead of racing
+    # the pre-check SELECT and surfacing an IntegrityError as HTTP 500.
 
     hashed_pw = await async_hash_password(body.password)
+
+    # F-2.3 (#393): hoist refresh-token + cookie inputs above _register_db so
+    # they are in closure scope when the session INSERT is merged into the
+    # same transaction as the user INSERT. These are pure computations
+    # independent of the transaction; if the transaction rolls back, the
+    # generated hashes are simply discarded.
+    user_agent = request.headers.get("user-agent", "")
+    refresh_token_raw, refresh_token_hash = create_refresh_token()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_MAX_AGE_DAYS)
+    ip_address = _request_ip(request)
 
     try:
         def _register_db():
             try:
-                # Clear any dangling implicit transaction from the outer SELECT check
+                # Clear any dangling implicit transaction from a prior SELECT.
                 if db.in_transaction:
                     db.rollback()
                 db.execute("BEGIN IMMEDIATE")
+                # F-2.1: uniqueness check INSIDE the write lock so concurrent
+                # registrations cannot both pass the check before either
+                # acquires BEGIN IMMEDIATE.
+                existing = db.execute(
+                    "SELECT id FROM users WHERE username = ? COLLATE NOCASE",
+                    (body.username,),
+                ).fetchone()
+                if existing:
+                    db.rollback()
+                    raise HTTPException(status_code=409, detail="Username already exists")
                 # Atomic: count read and insert are in the same transaction
                 user_count = db.execute("SELECT COUNT(*) FROM users").fetchone()[0]
                 role = "superadmin" if user_count == 0 else "member"
-                user_id = db.execute(
-                    "INSERT INTO users (username, hashed_password, full_name, role, is_active) VALUES (?, ?, ?, ?, 1)",
-                    (body.username, hashed_pw, body.full_name, role),
-                ).lastrowid
+                try:
+                    user_id = db.execute(
+                        "INSERT INTO users (username, hashed_password, full_name, role, is_active) VALUES (?, ?, ?, ?, 1)",
+                        (body.username, hashed_pw, body.full_name, role),
+                    ).lastrowid
+                except sqlite3.IntegrityError:
+                    # F-2.1 defense-in-depth: a concurrent INSERT that landed
+                    # between our in-txn SELECT and INSERT (cannot happen
+                    # under a single BEGIN IMMEDIATE writer, but cheap
+                    # insurance). Narrow to the user INSERT only so vault /
+                    # session IntegrityErrors are not mislabeled.
+                    db.rollback()
+                    raise HTTPException(status_code=409, detail="Username already exists")
                 assign_user_to_default_vault(db, user_id)
+                # F-2.3: session INSERT in the SAME transaction as the user
+                # INSERT so a crash between cannot leave a registered user
+                # with no login session.
+                db.execute(
+                    "INSERT INTO user_sessions (user_id, refresh_token_hash, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)",
+                    (user_id, refresh_token_hash, expires_at.isoformat(), ip_address, user_agent),
+                )
                 db.commit()
                 return user_id, role
+            except HTTPException:
+                raise
             except Exception:
                 try:
                     db.rollback()
@@ -287,40 +345,19 @@ async def register(
                 raise
 
         user_id, role = await asyncio.to_thread(_register_db)
+    except HTTPException:
+        # F-2.1: let the 409 from _register_db propagate unchanged. Without
+        # this branch the broad `except Exception` below would convert the
+        # 409 into a 500 (HTTPException is a subclass of Exception).
+        raise
     except Exception:
         logger.error("Failed to create user with default assignments", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again later.")
 
-    # Create tokens for auto-login
-    user_agent = request.headers.get("user-agent", "")
+    # Create access token for auto-login (depends on user_id/role from above).
     access_token = create_access_token(
         user_id, body.username, role, client_fingerprint=compute_client_fingerprint(user_agent)
     )
-    refresh_token_raw, refresh_token_hash = create_refresh_token()
-
-    # Store refresh token session
-    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_MAX_AGE_DAYS)
-    ip_address = _request_ip(request)
-
-    try:
-        def _register_session_db():
-            try:
-                db.execute(
-                    "INSERT INTO user_sessions (user_id, refresh_token_hash, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)",
-                    (user_id, refresh_token_hash, expires_at.isoformat(), ip_address, user_agent),
-                )
-                db.commit()
-            except Exception:
-                try:
-                    db.rollback()
-                except Exception:
-                    pass
-                raise
-
-        await asyncio.to_thread(_register_session_db)
-    except Exception:
-        logger.error("Failed to create session", exc_info=True)
-        raise HTTPException(status_code=500, detail="An internal error occurred. Please try again later.")
 
     # Set refresh token cookie
     response.set_cookie(
@@ -434,7 +471,15 @@ async def login(
             )
 
     if not await async_verify_password(body.password, hashed_pw):
-        await asyncio.to_thread(_record_failed_attempt_db, db, user_id, failed_attempts)
+        # F-2.4: use the fresh post-increment count returned by
+        # _record_failed_attempt_db (re-read under BEGIN IMMEDIATE) for both
+        # the audit metadata and the trip-response status. The stale
+        # ``failed_attempts`` snapshot read before any lock cannot be trusted
+        # under concurrency — using it could return 401 for the very request
+        # that trips the lockout (DB counter already at 5).
+        fresh_failed_attempts = await asyncio.to_thread(
+            _record_failed_attempt_db, db, user_id
+        )
         await safe_record_security_event(
             db,
             event_type="auth.login_failed",
@@ -443,10 +488,10 @@ async def login(
             request=request,
             metadata={
                 "reason": "bad_password",
-                "failed_attempts": failed_attempts + 1,
+                "failed_attempts": fresh_failed_attempts,
             },
         )
-        if failed_attempts + 1 >= 5:
+        if fresh_failed_attempts >= 5:
             raise HTTPException(
                 status_code=423,
                 detail="Account locked due to too many failed attempts. Try again in 15 minutes.",
@@ -836,6 +881,16 @@ async def change_password(
     new_hashed_pw = await async_hash_password(body.new_password)
     new_epoch = datetime.now(timezone.utc).timestamp()
 
+    # F-2.2 (#393): hoist refresh-token + cookie inputs above _change_password_db
+    # so they are in closure scope when the new-session INSERT is merged into
+    # the same transaction as the password UPDATE + session DELETE. These are
+    # pure computations independent of the transaction; if the transaction
+    # rolls back, the generated hashes are simply discarded.
+    user_agent = request.headers.get("user-agent", "")
+    ip_address = _request_ip(request)
+    refresh_token_raw, refresh_token_hash = create_refresh_token()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_MAX_AGE_DAYS)
+
     # Update password, clear must_change_password, bump password_changed_at epoch (FR-007)
     # and revoke all sessions in a transaction
     try:
@@ -849,11 +904,19 @@ async def change_password(
                     "DELETE FROM user_sessions WHERE user_id = ?",
                     (user_id,),
                 )
+                # F-2.2: new-session INSERT in the SAME transaction as the
+                # password UPDATE + old-session DELETE, so a crash between
+                # cannot leave the user with a changed password and no valid
+                # session (old sessions deleted, new one never committed).
+                # Include ip_address/user_agent for audit-trail parity with
+                # the register and login session INSERTs (PRR-005).
                 db.execute(
-                    "UPDATE users SET must_change_password = 0 WHERE id = ?",
-                    (user_id,),
+                    "INSERT INTO user_sessions (user_id, refresh_token_hash, expires_at, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)",
+                    (user_id, refresh_token_hash, expires_at.isoformat(), ip_address, user_agent),
                 )
                 db.commit()
+            except HTTPException:
+                raise
             except Exception:
                 try:
                     db.rollback()
@@ -862,6 +925,12 @@ async def change_password(
                 raise
 
         await asyncio.to_thread(_change_password_db)
+    except HTTPException:
+        # PRR-003: let any HTTPException from inside _change_password_db
+        # propagate unchanged, mirroring the register handler's F-2.1 shim.
+        # Without this branch the broad `except Exception` below would
+        # convert it to 500 (HTTPException is a subclass of Exception).
+        raise
     except Exception:
         logger.error("Failed to change password", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again later.")
@@ -877,35 +946,10 @@ async def change_password(
         metadata={"sessions_revoked": True},
     )
 
-    # Generate new tokens
-    user_agent = request.headers.get("user-agent", "")
+    # Generate new access token (username/role/user_id already in scope).
     access_token = create_access_token(
         user_id, username, role, client_fingerprint=compute_client_fingerprint(user_agent)
     )
-    refresh_token_raw, refresh_token_hash = create_refresh_token()
-
-    # Store new refresh token session
-    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_MAX_AGE_DAYS)
-
-    try:
-        def _create_session_db():
-            try:
-                db.execute(
-                    "INSERT INTO user_sessions (user_id, refresh_token_hash, expires_at) VALUES (?, ?, ?)",
-                    (user_id, refresh_token_hash, expires_at.isoformat()),
-                )
-                db.commit()
-            except Exception:
-                try:
-                    db.rollback()
-                except Exception:
-                    pass
-                raise
-
-        await asyncio.to_thread(_create_session_db)
-    except Exception:
-        logger.error("Failed to create new session", exc_info=True)
-        raise HTTPException(status_code=500, detail="An internal error occurred. Please try again later.")
 
     # Set httpOnly refresh cookie
     response.set_cookie(

--- a/backend/security/bandit-baseline.json
+++ b/backend/security/bandit-baseline.json
@@ -2,15 +2,15 @@
   "errors": [],
   "metrics": {
     "_totals": {
-      "CONFIDENCE.HIGH": 48,
+      "CONFIDENCE.HIGH": 46,
       "CONFIDENCE.LOW": 28,
       "CONFIDENCE.MEDIUM": 64,
       "CONFIDENCE.UNDEFINED": 0,
       "SEVERITY.HIGH": 9,
-      "SEVERITY.LOW": 72,
+      "SEVERITY.LOW": 70,
       "SEVERITY.MEDIUM": 59,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 43351,
+      "loc": 43348,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -54,15 +54,15 @@
       "skipped_tests": 0
     },
     "backend/app/api/routes/auth.py": {
-      "CONFIDENCE.HIGH": 14,
+      "CONFIDENCE.HIGH": 12,
       "CONFIDENCE.LOW": 0,
       "CONFIDENCE.MEDIUM": 6,
       "CONFIDENCE.UNDEFINED": 0,
       "SEVERITY.HIGH": 0,
-      "SEVERITY.LOW": 20,
+      "SEVERITY.LOW": 18,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 944,
+      "loc": 941,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -1502,7 +1502,7 @@
       "test_name": "hardcoded_password_string"
     },
     {
-      "code": "187                 db.execute(\"ROLLBACK\")\n188             except Exception:\n189                 pass\n190         raise\n",
+      "code": "211                 db.execute(\"ROLLBACK\")\n212             except Exception:\n213                 pass\n214         raise\n",
       "col_offset": 12,
       "end_col_offset": 20,
       "filename": "backend/app/api/routes/auth.py",
@@ -1513,17 +1513,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 188,
+      "line_number": 212,
       "line_range": [
-        188,
-        189
+        212,
+        213
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "284                     db.rollback()\n285                 except Exception:\n286                     pass\n287                 raise\n",
+      "code": "342                     db.rollback()\n343                 except Exception:\n344                     pass\n345                 raise\n",
       "col_offset": 16,
       "end_col_offset": 24,
       "filename": "backend/app/api/routes/auth.py",
@@ -1534,38 +1534,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 285,
+      "line_number": 343,
       "line_range": [
-        285,
-        286
+        343,
+        344
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "315                     db.rollback()\n316                 except Exception:\n317                     pass\n318                 raise\n",
-      "col_offset": 16,
-      "end_col_offset": 24,
-      "filename": "backend/app/api/routes/auth.py",
-      "issue_confidence": "HIGH",
-      "issue_cwe": {
-        "id": 703,
-        "link": "https://cwe.mitre.org/data/definitions/703.html"
-      },
-      "issue_severity": "LOW",
-      "issue_text": "Try, Except, Pass detected.",
-      "line_number": 316,
-      "line_range": [
-        316,
-        317
-      ],
-      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
-      "test_id": "B110",
-      "test_name": "try_except_pass"
-    },
-    {
-      "code": "346         issue_csrf_token(response, csrf_manager)\n347     except Exception:\n348         pass\n349 \n",
+      "code": "383         issue_csrf_token(response, csrf_manager)\n384     except Exception:\n385         pass\n386 \n",
       "col_offset": 4,
       "end_col_offset": 12,
       "filename": "backend/app/api/routes/auth.py",
@@ -1576,17 +1555,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 347,
+      "line_number": 384,
       "line_range": [
-        347,
-        348
+        384,
+        385
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "351         \"access_token\": access_token,\n352         \"token_type\": \"bearer\",\n353         \"expires_in\": 900,\n354         \"user\": {\n355             \"id\": user_id,\n356             \"username\": body.username,\n357             \"full_name\": body.full_name or \"\",\n358             \"role\": role,\n359             \"is_active\": True,\n360         },\n361         \"message\": \"Registration successful\",\n362     }\n363 \n364 \n365 @limiter.limit(\"10/minute\")\n",
+      "code": "388         \"access_token\": access_token,\n389         \"token_type\": \"bearer\",\n390         \"expires_in\": 900,\n391         \"user\": {\n392             \"id\": user_id,\n393             \"username\": body.username,\n394             \"full_name\": body.full_name or \"\",\n395             \"role\": role,\n396             \"is_active\": True,\n397         },\n398         \"message\": \"Registration successful\",\n399     }\n400 \n401 \n402 @limiter.limit(\"10/minute\")\n",
       "col_offset": 8,
       "end_col_offset": 20,
       "filename": "backend/app/api/routes/auth.py",
@@ -1597,28 +1576,28 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Possible hardcoded password: 'bearer'",
-      "line_number": 352,
+      "line_number": 389,
       "line_range": [
-        350,
-        351,
-        352,
-        353,
-        354,
-        355,
-        356,
-        357,
-        358,
-        359,
-        360,
-        361,
-        362
+        387,
+        388,
+        389,
+        390,
+        391,
+        392,
+        393,
+        394,
+        395,
+        396,
+        397,
+        398,
+        399
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b105_hardcoded_password_string.html",
       "test_id": "B105",
       "test_name": "hardcoded_password_string"
     },
     {
-      "code": "502                     db.rollback()\n503                 except Exception:\n504                     pass\n505                 raise\n",
+      "code": "547                     db.rollback()\n548                 except Exception:\n549                     pass\n550                 raise\n",
       "col_offset": 16,
       "end_col_offset": 24,
       "filename": "backend/app/api/routes/auth.py",
@@ -1629,70 +1608,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 503,
+      "line_number": 548,
       "line_range": [
-        503,
-        504
-      ],
-      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
-      "test_id": "B110",
-      "test_name": "try_except_pass"
-    },
-    {
-      "code": "525         issue_csrf_token(response, csrf_manager)\n526     except Exception:\n527         pass\n528     await safe_record_security_event(\n",
-      "col_offset": 4,
-      "end_col_offset": 12,
-      "filename": "backend/app/api/routes/auth.py",
-      "issue_confidence": "HIGH",
-      "issue_cwe": {
-        "id": 703,
-        "link": "https://cwe.mitre.org/data/definitions/703.html"
-      },
-      "issue_severity": "LOW",
-      "issue_text": "Try, Except, Pass detected.",
-      "line_number": 526,
-      "line_range": [
-        526,
-        527
-      ],
-      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
-      "test_id": "B110",
-      "test_name": "try_except_pass"
-    },
-    {
-      "code": "539         \"access_token\": access_token,\n540         \"token_type\": \"bearer\",\n541         \"expires_in\": 15 * 60,\n542         \"user\": {\n543             \"id\": user_id,\n544             \"username\": db_username,\n545             \"full_name\": full_name,\n546             \"role\": role,\n547             \"is_active\": bool(is_active),\n548             \"must_change_password\": bool(must_change_password),\n549         },\n550     }\n551 \n552 \n553 @limiter.limit(\"30/minute\")\n",
-      "col_offset": 8,
-      "end_col_offset": 20,
-      "filename": "backend/app/api/routes/auth.py",
-      "issue_confidence": "MEDIUM",
-      "issue_cwe": {
-        "id": 259,
-        "link": "https://cwe.mitre.org/data/definitions/259.html"
-      },
-      "issue_severity": "LOW",
-      "issue_text": "Possible hardcoded password: 'bearer'",
-      "line_number": 540,
-      "line_range": [
-        538,
-        539,
-        540,
-        541,
-        542,
-        543,
-        544,
-        545,
-        546,
-        547,
         548,
-        549,
-        550
+        549
       ],
-      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b105_hardcoded_password_string.html",
-      "test_id": "B105",
-      "test_name": "hardcoded_password_string"
+      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
+      "test_id": "B110",
+      "test_name": "try_except_pass"
     },
     {
-      "code": "627         issue_csrf_token(response, csrf_manager)\n628     except Exception:\n629         pass\n630 \n",
+      "code": "570         issue_csrf_token(response, csrf_manager)\n571     except Exception:\n572         pass\n573     await safe_record_security_event(\n",
       "col_offset": 4,
       "end_col_offset": 12,
       "filename": "backend/app/api/routes/auth.py",
@@ -1703,17 +1629,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 628,
+      "line_number": 571,
       "line_range": [
-        628,
-        629
+        571,
+        572
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "632         \"access_token\": access_token,\n633         \"token_type\": \"bearer\",\n634         \"expires_in\": 15 * 60,\n635     }\n636 \n637 \n638 @router.post(\"/logout\")\n",
+      "code": "584         \"access_token\": access_token,\n585         \"token_type\": \"bearer\",\n586         \"expires_in\": 15 * 60,\n587         \"user\": {\n588             \"id\": user_id,\n589             \"username\": db_username,\n590             \"full_name\": full_name,\n591             \"role\": role,\n592             \"is_active\": bool(is_active),\n593             \"must_change_password\": bool(must_change_password),\n594         },\n595     }\n596 \n597 \n598 @limiter.limit(\"30/minute\")\n",
       "col_offset": 8,
       "end_col_offset": 20,
       "filename": "backend/app/api/routes/auth.py",
@@ -1724,20 +1650,73 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Possible hardcoded password: 'bearer'",
-      "line_number": 633,
+      "line_number": 585,
       "line_range": [
-        631,
-        632,
-        633,
-        634,
-        635
+        583,
+        584,
+        585,
+        586,
+        587,
+        588,
+        589,
+        590,
+        591,
+        592,
+        593,
+        594,
+        595
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b105_hardcoded_password_string.html",
       "test_id": "B105",
       "test_name": "hardcoded_password_string"
     },
     {
-      "code": "667                         purge_expired_denied_tokens(db)\n668             except Exception:\n669                 # Best-effort: deny only \u2014 do not fail logout if token decode fails\n670                 pass\n671     if refresh_token:\n",
+      "code": "672         issue_csrf_token(response, csrf_manager)\n673     except Exception:\n674         pass\n675 \n",
+      "col_offset": 4,
+      "end_col_offset": 12,
+      "filename": "backend/app/api/routes/auth.py",
+      "issue_confidence": "HIGH",
+      "issue_cwe": {
+        "id": 703,
+        "link": "https://cwe.mitre.org/data/definitions/703.html"
+      },
+      "issue_severity": "LOW",
+      "issue_text": "Try, Except, Pass detected.",
+      "line_number": 673,
+      "line_range": [
+        673,
+        674
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
+      "test_id": "B110",
+      "test_name": "try_except_pass"
+    },
+    {
+      "code": "677         \"access_token\": access_token,\n678         \"token_type\": \"bearer\",\n679         \"expires_in\": 15 * 60,\n680     }\n681 \n682 \n683 @router.post(\"/logout\")\n",
+      "col_offset": 8,
+      "end_col_offset": 20,
+      "filename": "backend/app/api/routes/auth.py",
+      "issue_confidence": "MEDIUM",
+      "issue_cwe": {
+        "id": 259,
+        "link": "https://cwe.mitre.org/data/definitions/259.html"
+      },
+      "issue_severity": "LOW",
+      "issue_text": "Possible hardcoded password: 'bearer'",
+      "line_number": 678,
+      "line_range": [
+        676,
+        677,
+        678,
+        679,
+        680
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b105_hardcoded_password_string.html",
+      "test_id": "B105",
+      "test_name": "hardcoded_password_string"
+    },
+    {
+      "code": "712                         purge_expired_denied_tokens(db)\n713             except Exception:\n714                 # Best-effort: deny only \u2014 do not fail logout if token decode fails\n715                 pass\n716     if refresh_token:\n",
       "col_offset": 12,
       "end_col_offset": 20,
       "filename": "backend/app/api/routes/auth.py",
@@ -1748,18 +1727,18 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 668,
+      "line_number": 713,
       "line_range": [
-        668,
-        669,
-        670
+        713,
+        714,
+        715
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "692                         db_ref.rollback()\n693                     except Exception:\n694                         pass\n695                     raise\n",
+      "code": "737                         db_ref.rollback()\n738                     except Exception:\n739                         pass\n740                     raise\n",
       "col_offset": 20,
       "end_col_offset": 28,
       "filename": "backend/app/api/routes/auth.py",
@@ -1770,17 +1749,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 693,
+      "line_number": 738,
       "line_range": [
-        693,
-        694
+        738,
+        739
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "770                     db.rollback()\n771                 except Exception:\n772                     pass\n773                 raise\n",
+      "code": "815                     db.rollback()\n816                 except Exception:\n817                     pass\n818                 raise\n",
       "col_offset": 16,
       "end_col_offset": 24,
       "filename": "backend/app/api/routes/auth.py",
@@ -1791,17 +1770,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 771,
+      "line_number": 816,
       "line_range": [
-        771,
-        772
+        816,
+        817
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "859                     db.rollback()\n860                 except Exception:\n861                     pass\n862                 raise\n",
+      "code": "922                     db.rollback()\n923                 except Exception:\n924                     pass\n925                 raise\n",
       "col_offset": 16,
       "end_col_offset": 24,
       "filename": "backend/app/api/routes/auth.py",
@@ -1812,38 +1791,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 860,
+      "line_number": 923,
       "line_range": [
-        860,
-        861
+        923,
+        924
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "900                     db.rollback()\n901                 except Exception:\n902                     pass\n903                 raise\n",
-      "col_offset": 16,
-      "end_col_offset": 24,
-      "filename": "backend/app/api/routes/auth.py",
-      "issue_confidence": "HIGH",
-      "issue_cwe": {
-        "id": 703,
-        "link": "https://cwe.mitre.org/data/definitions/703.html"
-      },
-      "issue_severity": "LOW",
-      "issue_text": "Try, Except, Pass detected.",
-      "line_number": 901,
-      "line_range": [
-        901,
-        902
-      ],
-      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
-      "test_id": "B110",
-      "test_name": "try_except_pass"
-    },
-    {
-      "code": "922         \"access_token\": access_token,\n923         \"token_type\": \"bearer\",\n924         \"expires_in\": 15 * 60,\n925     }\n926 \n927 \n928 @router.get(\"/sessions\")\n",
+      "code": "966         \"access_token\": access_token,\n967         \"token_type\": \"bearer\",\n968         \"expires_in\": 15 * 60,\n969     }\n970 \n971 \n972 @router.get(\"/sessions\")\n",
       "col_offset": 8,
       "end_col_offset": 20,
       "filename": "backend/app/api/routes/auth.py",
@@ -1854,20 +1812,20 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Possible hardcoded password: 'bearer'",
-      "line_number": 923,
+      "line_number": 967,
       "line_range": [
-        921,
-        922,
-        923,
-        924,
-        925
+        965,
+        966,
+        967,
+        968,
+        969
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b105_hardcoded_password_string.html",
       "test_id": "B105",
       "test_name": "hardcoded_password_string"
     },
     {
-      "code": "1005                     db.rollback()\n1006                 except Exception:\n1007                     pass\n1008                 raise\n",
+      "code": "1049                     db.rollback()\n1050                 except Exception:\n1051                     pass\n1052                 raise\n",
       "col_offset": 16,
       "end_col_offset": 24,
       "filename": "backend/app/api/routes/auth.py",
@@ -1878,17 +1836,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 1006,
+      "line_number": 1050,
       "line_range": [
-        1006,
-        1007
+        1050,
+        1051
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "1079                     db.rollback()\n1080                 except Exception:\n1081                     pass\n1082                 raise\n",
+      "code": "1123                     db.rollback()\n1124                 except Exception:\n1125                     pass\n1126                 raise\n",
       "col_offset": 16,
       "end_col_offset": 24,
       "filename": "backend/app/api/routes/auth.py",
@@ -1899,17 +1857,17 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Try, Except, Pass detected.",
-      "line_number": 1080,
+      "line_number": 1124,
       "line_range": [
-        1080,
-        1081
+        1124,
+        1125
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b110_try_except_pass.html",
       "test_id": "B110",
       "test_name": "try_except_pass"
     },
     {
-      "code": "1117         \"access_token\": access_token,\n1118         \"token_type\": \"bearer\",\n1119         \"expires_in\": 15 * 60,\n1120     }\n",
+      "code": "1161         \"access_token\": access_token,\n1162         \"token_type\": \"bearer\",\n1163         \"expires_in\": 15 * 60,\n1164     }\n",
       "col_offset": 8,
       "end_col_offset": 20,
       "filename": "backend/app/api/routes/auth.py",
@@ -1920,13 +1878,13 @@
       },
       "issue_severity": "LOW",
       "issue_text": "Possible hardcoded password: 'bearer'",
-      "line_number": 1118,
+      "line_number": 1162,
       "line_range": [
-        1116,
-        1117,
-        1118,
-        1119,
-        1120
+        1160,
+        1161,
+        1162,
+        1163,
+        1164
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b105_hardcoded_password_string.html",
       "test_id": "B105",

--- a/backend/tests/test_auth_atomicity.py
+++ b/backend/tests/test_auth_atomicity.py
@@ -1,0 +1,855 @@
+"""
+Regression tests for auth.py single-transaction atomicity (#405, closes #393).
+
+Covers the four defects from the Phase-2 atomicity cluster of #202:
+
+- F-2.1: username uniqueness check must happen INSIDE BEGIN IMMEDIATE so a
+  concurrent duplicate registration gets a clean 409, not an IntegrityError
+  converted to 500.
+- F-2.2: change-password UPDATE + session DELETE + new-session INSERT must
+  commit in a single transaction so a crash between cannot leave the user
+  with a changed password and no valid session.
+- F-2.3: register user INSERT + session INSERT must commit in a single
+  transaction so a crash between cannot leave a registered user with no
+  session.
+- F-2.4: _record_failed_attempt_db must re-read failed_attempts under the
+  write lock before deciding to set locked_until, so concurrent failed
+  logins cannot bypass the lockout threshold on a stale snapshot.
+
+Tests are written against REAL production functions (imported), not replicas
+of the logic. The transaction-boundary tests (Test 2 / Test 6) are true
+regressions: they FAIL on pre-fix code because the pre-fix code has no
+in-transaction uniqueness SELECT (F-2.1) and no post-UPDATE re-read (F-2.4).
+The session-failure monkeypatch tests (Test 3 / Test 4) are true regressions:
+they FAIL on pre-fix code because the pre-fix code commits the user/password
+row in a separate transaction from the session INSERT.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Stub missing optional dependencies (matches the pattern in test_auth_routes.py)
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+try:
+    from unstructured.partition.auto import partition  # noqa: F401
+except ImportError:
+    import types
+
+    _unstructured = types.ModuleType("unstructured")
+    _unstructured.__path__ = []
+    _unstructured.partition = types.ModuleType("unstructured.partition")
+    _unstructured.partition.__path__ = []
+    _unstructured.partition.auto = types.ModuleType("unstructured.partition.auto")
+    _unstructured.partition.auto.partition = lambda *args, **kwargs: []
+    _unstructured.chunking = types.ModuleType("unstructured.chunking")
+    _unstructured.chunking.__path__ = []
+    _unstructured.chunking.title = types.ModuleType("unstructured.chunking.title")
+    _unstructured.chunking.title.chunk_by_title = lambda *args, **kwargs: []
+    _unstructured.documents = types.ModuleType("unstructured.documents")
+    _unstructured.documents.__path__ = []
+    _unstructured.documents.elements = types.ModuleType(
+        "unstructured.documents.elements"
+    )
+    _unstructured.documents.elements.Element = type("Element", (), {})
+    sys.modules["unstructured"] = _unstructured
+    sys.modules["unstructured.partition"] = _unstructured.partition
+    sys.modules["unstructured.partition.auto"] = _unstructured.partition.auto
+    sys.modules["unstructured.chunking"] = _unstructured.chunking
+    sys.modules["unstructured.chunking.title"] = _unstructured.chunking.title
+    sys.modules["unstructured.documents"] = _unstructured.documents
+    sys.modules["unstructured.documents.elements"] = _unstructured.documents.elements
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.models.database import SQLiteConnectionPool, init_db, run_migrations
+
+
+def _make_test_client_and_pool():
+    """Build a (client, app, pool, db_path, temp_dir) tuple for an isolated test.
+
+    Mirrors the setUp pattern of test_auth_routes.py.
+    """
+    temp_dir = tempfile.mkdtemp()
+    db_path = os.path.join(temp_dir, "test.db")
+    init_db(db_path)
+    run_migrations(db_path)
+
+    pool = SQLiteConnectionPool(db_path, max_size=10)
+
+    from app.api.deps import get_db
+    from app.main import app as main_app
+    from app.security import csrf_protect
+
+    class TestCSRFManager:
+        def generate_token(self):
+            return "test-csrf-token"
+
+        def validate_token(self, token):
+            return token == "test-csrf-token"
+
+    def get_test_db():
+        conn = pool.get_connection()
+        try:
+            yield conn
+        finally:
+            pool.release_connection(conn)
+
+    main_app.dependency_overrides[get_db] = get_test_db
+    main_app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+    main_app.state.csrf_manager = TestCSRFManager()
+
+    client = TestClient(main_app)
+    return client, main_app, pool, db_path, temp_dir
+
+
+def _tear_down(app, pool, temp_dir, *, original_users_enabled, original_jwt_secret):
+    """Restore settings, clear dependency overrides, close pool, remove temp_dir."""
+    import shutil
+
+    settings.users_enabled = original_users_enabled
+    settings.jwt_secret_key = original_jwt_secret
+    app.dependency_overrides.clear()
+    pool.close_all()
+    try:
+        shutil.rmtree(temp_dir)
+    except Exception:
+        pass
+
+
+class TestAuthAtomicity(unittest.TestCase):
+    """Regression tests for #393 auth.py transaction atomicity."""
+
+    def setUp(self):
+        self._original_jwt_secret = settings.jwt_secret_key
+        self._original_users_enabled = settings.users_enabled
+        settings.jwt_secret_key = "test-secret-key-for-testing-at-least-32-chars-long"
+        settings.users_enabled = True
+
+        client, app, pool, db_path, temp_dir = _make_test_client_and_pool()
+        self.client = client
+        self.app = app
+        self.pool = pool
+        self.db_path = db_path
+        self.temp_dir = temp_dir
+
+    def tearDown(self):
+        _tear_down(
+            self.app,
+            self.pool,
+            self.temp_dir,
+            original_users_enabled=self._original_users_enabled,
+            original_jwt_secret=self._original_jwt_secret,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_conn(self):
+        return self.pool.get_connection()
+
+    def _release_conn(self, conn):
+        self.pool.release_connection(conn)
+
+    def _register_user(self, username="admin", password="Password123"):
+        """Register a user and return the response."""
+        return self.client.post(
+            "/api/auth/register",
+            json={"username": username, "password": password},
+        )
+
+    # ------------------------------------------------------------------
+    # F-2.1 — username uniqueness inside BEGIN IMMEDIATE
+    # ------------------------------------------------------------------
+
+    def test_register_duplicate_returns_409_not_500(self):
+        """F-2.1: a duplicate-username register must return 409, not 500.
+
+        Pre-fix, the uniqueness pre-check ran OUTSIDE BEGIN IMMEDIATE; under
+        the race the loser's INSERT hit the UNIQUE constraint and the bare
+        ``except Exception`` converted the IntegrityError to 500. Post-fix,
+        the in-transaction SELECT (and the IntegrityError→409 translation
+        wrapped around the user INSERT) yields a clean 409.
+
+        This is the sequential, non-raced assertion. The concurrent variant
+        is ``test_concurrent_register_same_username``.
+        """
+        first = self._register_user(username="dup")
+        self.assertEqual(first.status_code, 200)
+
+        second = self._register_user(username="dup")
+        self.assertEqual(
+            second.status_code,
+            409,
+            f"Duplicate register must return 409, got {second.status_code}: {second.text}",
+        )
+        self.assertIn("already exists", second.json()["detail"].lower())
+
+        # Exactly one user row with that username.
+        conn = self._get_conn()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM users WHERE username = ? COLLATE NOCASE",
+                ("dup",),
+            ).fetchone()[0]
+        finally:
+            self._release_conn(conn)
+        self.assertEqual(count, 1, "Duplicate register must not create a second row")
+
+    def test_concurrent_register_same_username(self):
+        """F-2.1 (concurrent): two near-simultaneous registers of the same
+        username must produce exactly one success and exactly one 409, with
+        exactly one user row in the DB.
+
+        Mirrors the ThreadPoolExecutor pattern in test_org_invites.py:782.
+
+        Pre-fix, the loser of the race could surface an IntegrityError→500.
+        Post-fix, the BEGIN IMMEDIATE serializes the writers and the loser
+        observes the committed row in its in-transaction SELECT → 409.
+        """
+        # Reset rate limiter between sub-tasks by raising the limit via
+        # direct limiter reset; /auth/register is capped at 5/hour which is
+        # plenty for 2 requests.
+        results = {}
+        lock = __import__("threading").Lock()
+
+        def _register(idx):
+            resp = self.client.post(
+                "/api/auth/register",
+                json={"username": "racer", "password": "Password123"},
+            )
+            with lock:
+                results[idx] = resp.status_code
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            f1 = executor.submit(_register, 0)
+            f2 = executor.submit(_register, 1)
+            f1.result()
+            f2.result()
+
+        statuses = list(results.values())
+        successes = [s for s in statuses if s == 200]
+        conflicts = [s for s in statuses if s == 409]
+        self.assertEqual(
+            len(successes), 1, f"Expected exactly one 200, got statuses={statuses}"
+        )
+        self.assertEqual(
+            len(conflicts), 1, f"Expected exactly one 409, got statuses={statuses}"
+        )
+        # No 500s allowed — the race must not surface as an internal error.
+        self.assertNotIn(
+            500, statuses, f"Race must not produce 500, got statuses={statuses}"
+        )
+
+        conn = self._get_conn()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM users WHERE username = ? COLLATE NOCASE",
+                ("racer",),
+            ).fetchone()[0]
+        finally:
+            self._release_conn(conn)
+        self.assertEqual(
+            count, 1, f"Exactly one user row must exist, got {count}"
+        )
+
+    # ------------------------------------------------------------------
+    # F-2.1 / F-2.4 — transaction-boundary (mock DB, real function)
+    # ------------------------------------------------------------------
+
+    def test_record_failed_attempt_rereads_under_lock(self):
+        """F-2.4: _record_failed_attempt_db must issue BEGIN IMMEDIATE,
+        UPDATE the counter, then re-read failed_attempts from the DB under
+        the lock before deciding whether to set locked_until.
+
+        Imports the REAL production function. Instruments a mock connection
+        to record the SQL sequence and to return 5 for the post-UPDATE
+        SELECT, then asserts the lockout UPDATE fires.
+
+        TRUE REGRESSION: pre-fix code has signature (db, user_id,
+        failed_attempts) and never issues the post-UPDATE SELECT — this
+        test's SQL-sequence assertion fails on pre-fix code.
+        """
+        from app.api.routes.auth import _record_failed_attempt_db
+
+        sql_sequence = []
+
+        class _MockCursor:
+            def __init__(self, value):
+                self._value = value
+
+            def fetchone(self):
+                return (self._value,)
+
+        def fake_execute(sql, *args, **kwargs):
+            sql_sequence.append(sql)
+            if "SELECT failed_attempts" in sql:
+                return _MockCursor(5)
+            return _MockCursor(None)
+
+        class _MockDB:
+            in_transaction = False
+
+            def execute(self, sql, *args, **kwargs):
+                return fake_execute(sql, *args, **kwargs)
+
+            def commit(self):
+                sql_sequence.append("COMMIT")
+
+            def rollback(self):
+                sql_sequence.append("ROLLBACK")
+
+        db = _MockDB()
+        returned = _record_failed_attempt_db(db, user_id=42)
+
+        # F-2.4: the function returns the fresh post-increment count so the
+        # caller can issue an accurate trip response (401 vs 423) under
+        # concurrency.
+        self.assertEqual(returned, 5, "Must return the fresh post-increment count")
+
+        # BEGIN IMMEDIATE must be issued.
+        self.assertIn("BEGIN IMMEDIATE", sql_sequence)
+        begin_idx = sql_sequence.index("BEGIN IMMEDIATE")
+        # UPDATE counter must follow.
+        update_sqls = [
+            i for i, s in enumerate(sql_sequence)
+            if "failed_attempts = failed_attempts + 1" in s
+        ]
+        self.assertEqual(len(update_sqls), 1, f"Expected one counter UPDATE, sequence={sql_sequence}")
+        self.assertGreater(update_sqls[0], begin_idx, "UPDATE must follow BEGIN IMMEDIATE")
+        # F-2.4 core assertion: a re-read SELECT must follow the UPDATE.
+        select_sqls = [
+            i for i, s in enumerate(sql_sequence)
+            if "SELECT failed_attempts FROM users" in s
+        ]
+        self.assertEqual(
+            len(select_sqls),
+            1,
+            f"F-2.4 requires a post-UPDATE re-read; sequence={sql_sequence}",
+        )
+        self.assertGreater(select_sqls[0], update_sqls[0], "Re-read SELECT must follow the UPDATE")
+        # Because fresh == 5 >= 5, the lockout UPDATE must fire.
+        lockout_sqls = [s for s in sql_sequence if "locked_until" in s and "UPDATE" in s]
+        self.assertEqual(
+            len(lockout_sqls),
+            1,
+            f"Expected one locked_until UPDATE (fresh=5>=5); sequence={sql_sequence}",
+        )
+        # Commit must come last (no rollback).
+        self.assertIn("COMMIT", sql_sequence)
+        self.assertNotIn("ROLLBACK", sql_sequence)
+
+    def test_record_failed_attempt_no_lockout_below_threshold(self):
+        """F-2.4 companion: when the re-read returns 4 (< 5), no locked_until
+        UPDATE must fire. Proves the decision uses the fresh value, not the
+        stale parameter (the parameter no longer exists).
+        """
+        from app.api.routes.auth import _record_failed_attempt_db
+
+        sql_sequence = []
+
+        class _MockCursor:
+            def __init__(self, value):
+                self._value = value
+
+            def fetchone(self):
+                return (self._value,)
+
+        def fake_execute(sql, *args, **kwargs):
+            sql_sequence.append(sql)
+            if "SELECT failed_attempts" in sql:
+                return _MockCursor(4)
+            return _MockCursor(None)
+
+        class _MockDB:
+            in_transaction = False
+
+            def execute(self, sql, *args, **kwargs):
+                return fake_execute(sql, *args, **kwargs)
+
+            def commit(self):
+                sql_sequence.append("COMMIT")
+
+            def rollback(self):
+                sql_sequence.append("ROLLBACK")
+
+        db = _MockDB()
+        returned = _record_failed_attempt_db(db, user_id=42)
+
+        # F-2.4: returns the fresh post-increment count (4) even when no lock.
+        self.assertEqual(returned, 4, "Must return the fresh post-increment count")
+
+        lockout_sqls = [s for s in sql_sequence if "locked_until" in s and "UPDATE" in s]
+        self.assertEqual(
+            len(lockout_sqls),
+            0,
+            f"fresh=4 < 5 must NOT set locked_until; sequence={sql_sequence}",
+        )
+        self.assertIn("COMMIT", sql_sequence)
+
+    # ------------------------------------------------------------------
+    # F-2.3 — register user+session atomic on session-INSERT failure
+    # ------------------------------------------------------------------
+
+    def test_register_user_and_session_atomic_on_session_failure(self):
+        """F-2.3: if the session INSERT fails inside _register_db, the user
+        row must NOT be committed. Proves the user INSERT and session INSERT
+        share one transaction.
+
+        TRUE REGRESSION: pre-fix code commits the user row in _register_db
+        and the session INSERT in a separate _register_session_db; under
+        this monkeypatch the pre-fix code would leave a dangling user row.
+        Post-fix, both roll back together.
+        """
+        from app.api.deps import get_db
+        from app.main import app as main_app
+
+        # A fresh pool that yields proxy connections. The proxy intercepts
+        # ``execute`` so we can inject a failure on INSERT INTO user_sessions.
+        # We cannot monkeypatch sqlite3.Connection.execute directly (read-only),
+        # so the proxy delegates everything else by attribute lookup.
+        real_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        class _FailingSessionConnProxy:
+            """Delegates to the underlying sqlite3 connection but raises on
+            INSERT INTO user_sessions to simulate a session-INSERT failure."""
+
+            def __init__(self, real):
+                object.__setattr__(self, "_real", real)
+
+            @property
+            def in_transaction(self):
+                return self._real.in_transaction
+
+            def execute(self, sql, *args, **kwargs):
+                if (
+                    isinstance(sql, str)
+                    and "INSERT INTO user_sessions" in sql
+                ):
+                    raise Exception("simulated session-INSERT failure")
+                return self._real.execute(sql, *args, **kwargs)
+
+            def commit(self):
+                return self._real.commit()
+
+            def rollback(self):
+                return self._real.rollback()
+
+            def close(self):
+                return self._real.close()
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        original_get_connection = real_pool.get_connection
+
+        def get_connection_instrumented():
+            conn = original_get_connection()
+            return _FailingSessionConnProxy(conn)
+
+        def get_test_db():
+            conn = real_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                real_pool.release_connection(conn._real)
+
+        real_pool.get_connection = get_connection_instrumented
+        main_app.dependency_overrides[get_db] = get_test_db
+
+        try:
+            response = self.client.post(
+                "/api/auth/register",
+                json={"username": "atomic_test", "password": "Password123"},
+            )
+
+            # The simulated session failure must surface as 500.
+            self.assertEqual(
+                response.status_code,
+                500,
+                f"Session-INSERT failure must surface as 500, got {response.status_code}",
+            )
+
+            # CRITICAL: no user row must have been committed.
+            check_pool = SQLiteConnectionPool(self.db_path, max_size=2)
+            check_conn = check_pool.get_connection()
+            try:
+                count = check_conn.execute(
+                    "SELECT COUNT(*) FROM users WHERE username = ? COLLATE NOCASE",
+                    ("atomic_test",),
+                ).fetchone()[0]
+            finally:
+                check_conn.close()
+                check_pool.close_all()
+
+            self.assertEqual(
+                count,
+                0,
+                "F-2.3: user row must NOT be committed when session INSERT fails "
+                "(pre-fix split-commit would leave a dangling row)",
+            )
+        finally:
+            try:
+                real_pool.close_all()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # F-2.2 — change-password password+session atomic on session failure
+    # ------------------------------------------------------------------
+
+    def test_change_password_password_and_session_atomic_on_session_failure(self):
+        """F-2.2: if the new-session INSERT fails inside _change_password_db,
+        the password UPDATE and the session DELETE must roll back. Proves
+        they share one transaction.
+
+        TRUE REGRESSION: pre-fix code commits password+DELETE in
+        _change_password_db and the new-session INSERT in a separate
+        _create_session_db; under this monkeypatch the pre-fix code would
+        leave the password changed and the old session deleted. Post-fix,
+        all three roll back together.
+        """
+        # Register a user and capture the original password hash + a
+        # pre-existing session row. Use the plain self.client pool.
+        reg = self._register_user(username="cpuser", password="Password123")
+        self.assertEqual(reg.status_code, 200)
+
+        conn = self._get_conn()
+        try:
+            user_row = conn.execute(
+                "SELECT id, hashed_password FROM users WHERE username = ? COLLATE NOCASE",
+                ("cpuser",),
+            ).fetchone()
+            user_id = user_row[0]
+            original_hash = user_row[1]
+            # Insert a pre-existing session to verify the DELETE rolls back.
+            conn.execute(
+                "INSERT INTO user_sessions (user_id, refresh_token_hash, expires_at) "
+                "VALUES (?, ?, ?)",
+                (user_id, "preexisting_hash_" + "0" * 32, "2099-01-01T00:00:00+00:00"),
+            )
+            conn.commit()
+        finally:
+            self._release_conn(conn)
+
+        # Login via the plain client pool to obtain a bearer token for the
+        # change-password request. The login flow creates its own session row
+        # which is fine — we just need the access token.
+        login_resp = self.client.post(
+            "/api/auth/login",
+            json={"username": "cpuser", "password": "Password123"},
+        )
+        self.assertEqual(login_resp.status_code, 200, login_resp.text)
+        access_token = login_resp.json()["access_token"]
+
+        # Now swap in an instrumented pool that fails the change-password
+        # session INSERT.
+        from app.api.deps import get_db
+        from app.main import app as main_app
+
+        real_pool = SQLiteConnectionPool(self.db_path, max_size=5)
+
+        class _FailingSessionConnProxy:
+            def __init__(self, real):
+                object.__setattr__(self, "_real", real)
+
+            @property
+            def in_transaction(self):
+                return self._real.in_transaction
+
+            def execute(self, sql, *args, **kwargs):
+                if (
+                    isinstance(sql, str)
+                    and "INSERT INTO user_sessions" in sql
+                ):
+                    raise Exception("simulated session-INSERT failure")
+                return self._real.execute(sql, *args, **kwargs)
+
+            def commit(self):
+                return self._real.commit()
+
+            def rollback(self):
+                return self._real.rollback()
+
+            def close(self):
+                return self._real.close()
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        original_get_connection = real_pool.get_connection
+
+        def get_connection_instrumented():
+            conn = original_get_connection()
+            return _FailingSessionConnProxy(conn)
+
+        def get_test_db():
+            conn = real_pool.get_connection()
+            try:
+                yield conn
+            finally:
+                real_pool.release_connection(conn._real)
+
+        real_pool.get_connection = get_connection_instrumented
+        main_app.dependency_overrides[get_db] = get_test_db
+
+        try:
+            response = self.client.post(
+                "/api/auth/change-password",
+                json={
+                    "current_password": "Password123",
+                    "new_password": "NewPassword456",
+                },
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+            self.assertEqual(
+                response.status_code,
+                500,
+                f"Session-INSERT failure must surface as 500, got {response.status_code}",
+            )
+        finally:
+            try:
+                real_pool.close_all()
+            except Exception:
+                pass
+
+        # CRITICAL assertions:
+        # 1. Password hash must be UNCHANGED (UPDATE rolled back).
+        # 2. The pre-existing session row must still be present (DELETE rolled back).
+        check_pool = SQLiteConnectionPool(self.db_path, max_size=2)
+        check_conn = check_pool.get_connection()
+        try:
+            current_hash = check_conn.execute(
+                "SELECT hashed_password FROM users WHERE username = ? COLLATE NOCASE",
+                ("cpuser",),
+            ).fetchone()[0]
+            session_count = check_conn.execute(
+                "SELECT COUNT(*) FROM user_sessions WHERE user_id = ?",
+                (user_id,),
+            ).fetchone()[0]
+        finally:
+            check_conn.close()
+            check_pool.close_all()
+
+        self.assertEqual(
+            current_hash,
+            original_hash,
+            "F-2.2: password must NOT change when session INSERT fails "
+            "(pre-fix split-commit would leave the password changed)",
+        )
+        self.assertGreaterEqual(
+            session_count,
+            1,
+            "F-2.2: pre-existing session must NOT be deleted when session INSERT fails "
+            "(pre-fix split-commit would leave the user with no sessions)",
+        )
+
+    # ------------------------------------------------------------------
+    # F-2.4 behavioral (sequential lockout)
+    # ------------------------------------------------------------------
+
+    def test_five_sequential_failed_logins_lock_account(self):
+        """F-2.4 behavioral: five sequential wrong-password logins must lock
+        the account on the 5th attempt.
+
+        NOTE: this is COVERAGE, not a true regression — pre-fix code locks
+        sequentially too (the stale-snapshot defect only manifests under
+        concurrency). The true regression is
+        ``test_record_failed_attempt_rereads_under_lock``. Included here
+        because the sequential lockout path was previously uncovered.
+        """
+        reg = self._register_user(username="lockme", password="Password123")
+        self.assertEqual(reg.status_code, 200)
+
+        statuses = []
+        for _ in range(5):
+            resp = self.client.post(
+                "/api/auth/login",
+                json={"username": "lockme", "password": "WrongPassword999"},
+            )
+            statuses.append(resp.status_code)
+
+        # The first four must be 401 (bad password, not yet locked).
+        self.assertEqual(
+            statuses[:4],
+            [401, 401, 401, 401],
+            f"First four wrong logins must be 401, got {statuses}",
+        )
+        # The 5th must trip the lockout: 423 with Retry-After: 900.
+        self.assertEqual(
+            statuses[4],
+            423,
+            f"5th wrong login must return 423 (locked), got {statuses}",
+        )
+
+        # DB state: failed_attempts == 5, locked_until is set and in the future.
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT failed_attempts, locked_until FROM users WHERE username = ? COLLATE NOCASE",
+                ("lockme",),
+            ).fetchone()
+        finally:
+            self._release_conn(conn)
+        self.assertEqual(row[0], 5, f"failed_attempts must be 5, got {row[0]}")
+        self.assertIsNotNone(row[1], "locked_until must be set after 5 failures")
+        locked_until = __import__("datetime").datetime.fromisoformat(row[1])
+        self.assertGreater(
+            locked_until,
+            __import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+            "locked_until must be in the future",
+        )
+
+        # A subsequent CORRECT password must still be rejected (account locked).
+        correct_resp = self.client.post(
+            "/api/auth/login",
+            json={"username": "lockme", "password": "Password123"},
+        )
+        self.assertEqual(
+            correct_resp.status_code,
+            423,
+            f"Correct password during lockout must return 423, got {correct_resp.status_code}",
+        )
+
+    # ------------------------------------------------------------------
+    # PRR-005 — change-password session INSERT audit-trail parity
+    # ------------------------------------------------------------------
+
+    def test_change_password_session_records_ip_and_user_agent(self):
+        """PRR-005: the new session created by change-password must include
+        ip_address and user_agent for audit-trail parity with register and
+        login. Pre-fix, the merged INSERT omitted both columns.
+        """
+        reg = self._register_user(username="audituser", password="Password123")
+        self.assertEqual(reg.status_code, 200)
+
+        login_resp = self.client.post(
+            "/api/auth/login",
+            json={"username": "audituser", "password": "Password123"},
+            headers={"User-Agent": "audit-trail-test/1.0"},
+        )
+        self.assertEqual(login_resp.status_code, 200, login_resp.text)
+        access_token = login_resp.json()["access_token"]
+
+        resp = self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": "Password123",
+                "new_password": "NewPassword456",
+            },
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "User-Agent": "audit-trail-test/1.0",
+            },
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+
+        # The new session row must carry the request's user_agent (and a
+        # non-NULL ip_address — TestClient synthesizes a testclient IP).
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT ip_address, user_agent FROM user_sessions "
+                "WHERE user_id = (SELECT id FROM users WHERE username = ? COLLATE NOCASE) "
+                "ORDER BY id DESC LIMIT 1",
+                ("audituser",),
+            ).fetchone()
+        finally:
+            self._release_conn(conn)
+
+        self.assertIsNotNone(row, "A session row must exist after change-password")
+        self.assertEqual(
+            row[1],
+            "audit-trail-test/1.0",
+            f"user_agent must be recorded for audit trail; got {row[1]!r}",
+        )
+        self.assertIsNotNone(
+            row[0],
+            "ip_address must be recorded (non-NULL) for audit trail",
+        )
+
+    # ------------------------------------------------------------------
+    # PRR-002 — _record_failed_attempt_db None-row guard
+    # ------------------------------------------------------------------
+
+    def test_record_failed_attempt_handles_deleted_user(self):
+        """PRR-002: if the user row is missing on the post-UPDATE re-read
+        (concurrent superadmin delete), _record_failed_attempt_db must NOT
+        raise TypeError on ``None[0]`` — it must roll back and return 0 so
+        the caller issues a clean 401 instead of a 500.
+
+        Imports the REAL production function. Instruments a mock connection
+        whose post-UPDATE SELECT returns None (simulating a vanished row).
+        """
+        from app.api.routes.auth import _record_failed_attempt_db
+
+        sql_sequence = []
+
+        class _NoneCursor:
+            def fetchone(self):
+                return None
+
+        class _RowCursor:
+            def fetchone(self):
+                # The defensive guard should return 0 before ever indexing.
+                return (99,)  # never reached
+
+        def fake_execute(sql, *args, **kwargs):
+            sql_sequence.append(sql)
+            if "SELECT failed_attempts" in sql:
+                return _NoneCursor()
+            return _RowCursor()
+
+        class _MockDB:
+            in_transaction = False
+
+            def execute(self, sql, *args, **kwargs):
+                return fake_execute(sql, *args, **kwargs)
+
+            def commit(self):
+                sql_sequence.append("COMMIT")
+
+            def rollback(self):
+                sql_sequence.append("ROLLBACK")
+
+        db = _MockDB()
+        # Must NOT raise — the guard returns 0 cleanly.
+        returned = _record_failed_attempt_db(db, user_id=999)
+
+        self.assertEqual(
+            returned,
+            0,
+            f"Vanished-user row must return 0 (no lockout decision); got {returned}",
+        )
+        # The no-op UPDATE must be rolled back (transaction closed cleanly).
+        self.assertIn("ROLLBACK", sql_sequence)
+        self.assertNotIn(
+            "COMMIT",
+            sql_sequence,
+            f"Vanished-user path must not commit; sequence={sql_sequence}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_deps_auth_to_thread.py
+++ b/backend/tests/test_deps_auth_to_thread.py
@@ -255,14 +255,21 @@ class TestAuthSourceInspection(unittest.TestCase):
     """Verify auth.py route handlers use asyncio.to_thread via source inspection."""
 
     def test_register_uses_to_thread(self):
-        """register endpoint wraps SQLite calls in asyncio.to_thread."""
+        """register endpoint wraps SQLite calls in asyncio.to_thread.
+
+        Note: prior to #393 (F-2.1/F-2.3), register had 3 to_thread calls
+        (uniqueness pre-check SELECT, user INSERT txn, session INSERT txn).
+        The uniqueness check moved inside the BEGIN IMMEDIATE transaction
+        and the session INSERT was merged into the same transaction, leaving
+        a single to_thread call wrapping the whole atomic block.
+        """
         from app.api.routes import auth
 
         source = get_function_source(auth, 'register')
         self.assertIsNotNone(source)
         self.assertIn('asyncio.to_thread', source)
         count = count_to_thread_calls(source)
-        self.assertGreaterEqual(count, 2, f"Expected at least 2, got {count}")
+        self.assertGreaterEqual(count, 1, f"Expected at least 1, got {count}")
 
     def test_register_no_async_in_to_thread(self):
         """register does NOT pass async functions to to_thread."""
@@ -424,13 +431,20 @@ class TestLambdaPattern(unittest.TestCase):
         self.assertIsNotNone(source)
         self.assertIn('rollback', source.lower())
 
-    def test_register_uses_lambda_pattern(self):
-        """register has db operations inside lambdas passed to to_thread."""
+    def test_register_uses_to_thread_pattern(self):
+        """register has db operations inside a def passed to to_thread.
+
+        Note: prior to #393 (F-2.1), register also had a lambda-wrapped
+        uniqueness pre-check; that SELECT was moved inside the BEGIN
+        IMMEDIATE transaction and the lambda was removed. The invariant
+        under test is 'DB operations run off the event loop via to_thread',
+        not the specific use of lambda.
+        """
         from app.api.routes import auth
 
         source = get_function_source(auth, 'register')
         self.assertIsNotNone(source)
-        self.assertIn('lambda', source.lower())
+        self.assertIn('to_thread', source)
 
     def test_login_uses_lambda_pattern(self):
         """login has db operations inside lambdas passed to to_thread."""
@@ -457,13 +471,20 @@ class TestToThreadCallCounts(unittest.TestCase):
     """Verify minimum to_thread call counts per endpoint via source inspection."""
 
     def test_register_minimum_to_thread_calls(self):
-        """register should have at least 3 to_thread calls."""
+        """register should have at least 1 to_thread call.
+
+        Note: prior to #393 (F-2.1/F-2.3), register had 3 to_thread calls
+        (uniqueness pre-check SELECT, user INSERT, session INSERT). The
+        uniqueness check moved inside the BEGIN IMMEDIATE transaction and
+        the session INSERT was merged into the same transaction, leaving a
+        single to_thread call wrapping the whole atomic block.
+        """
         from app.api.routes import auth
 
         source = get_function_source(auth, 'register')
         self.assertIsNotNone(source)
         count = count_to_thread_calls(source)
-        self.assertGreaterEqual(count, 3, f"Expected at least 3, got {count}")
+        self.assertGreaterEqual(count, 1, f"Expected at least 1, got {count}")
 
     def test_login_minimum_to_thread_calls(self):
         """login should have at least 2 to_thread calls."""
@@ -475,13 +496,19 @@ class TestToThreadCallCounts(unittest.TestCase):
         self.assertGreaterEqual(count, 2, f"Expected at least 2, got {count}")
 
     def test_change_password_minimum_to_thread_calls(self):
-        """change_password should have at least 3 to_thread calls."""
+        """change_password should have at least 2 to_thread calls.
+
+        Note: prior to #393 (F-2.2), change_password had 3 to_thread calls
+        (fetch current hash, change-password txn, new-session INSERT txn).
+        The new-session INSERT was merged into the change-password
+        transaction, leaving the fetch + the atomic change block.
+        """
         from app.api.routes import auth
 
         source = get_function_source(auth, 'change_password')
         self.assertIsNotNone(source)
         count = count_to_thread_calls(source)
-        self.assertGreaterEqual(count, 3, f"Expected at least 3, got {count}")
+        self.assertGreaterEqual(count, 2, f"Expected at least 2, got {count}")
 
 
 # =============================================================================

--- a/docs/releases/pending/405-auth-atomicity.md
+++ b/docs/releases/pending/405-auth-atomicity.md
@@ -1,0 +1,140 @@
+# auth.py single-transaction atomicity (Issue #405, closes #393)
+
+## What changed
+
+### Backend — `backend/app/api/routes/auth.py`
+
+Four transaction-atomicity defects closed (the F-2.1 … F-2.4 cluster from
+the #202 deep-dive). Each fix is localized to one route or helper.
+
+- **F-2.1 (register username uniqueness):** the case-insensitive uniqueness
+  pre-check was a bare `SELECT` running *outside* `BEGIN IMMEDIATE`. Under a
+  concurrent duplicate registration the loser's `INSERT` hit the `users.username`
+  UNIQUE constraint and the bare `except Exception` converted the
+  `sqlite3.IntegrityError` to HTTP 500 instead of 409. The pre-check SELECT
+  is now performed *inside* the `BEGIN IMMEDIATE` transaction in `_register_db`,
+  the user `INSERT` is wrapped in a narrow `except sqlite3.IntegrityError → 409`
+  (matching the `organizations.py:930-944` idiom), and the outer handler gained
+  an `except HTTPException: raise` branch so the 409 propagates unchanged.
+
+- **F-2.2 (change-password atomicity):** the password `UPDATE` + session
+  `DELETE` committed in `_change_password_db`, then the new-session `INSERT`
+  committed in a separate `_create_session_db`. A crash between left the user
+  with a changed password and no valid session. The new-session `INSERT` is
+  now part of the same `BEGIN IMMEDIATE`-implicit transaction as the password
+  change, with a single `commit()`. `_create_session_db` is removed.
+  `refresh_token_raw` / `refresh_token_hash` / `expires_at` / `user_agent`
+  are hoisted above the closure so they are in scope for the merged `INSERT`.
+
+- **F-2.3 (register atomicity):** the user `INSERT` committed in
+  `_register_db`, then the session `INSERT` committed in a separate
+  `_register_session_db`. A crash between left a registered user with no
+  login session (and the client's retry would hit 409). The session `INSERT`
+  is now part of the same `BEGIN IMMEDIATE` transaction as the user `INSERT`
+  (and the default-vault assignment), with a single `commit()`.
+  `_register_session_db` is removed. Token/cookie inputs hoisted as in F-2.2.
+
+- **F-2.4 (failed-login lockout race):** `_record_failed_attempt_db` received
+  `failed_attempts` as a parameter snapshotted *before* any lock, so the
+  `if failed_attempts + 1 >= 5` lockout decision operated on a stale value —
+  concurrent failed logins could each observe a stale read and skip setting
+  `locked_until`. The function now:
+  1. drops the `failed_attempts` parameter,
+  2. opens `BEGIN IMMEDIATE`,
+  3. issues the atomic `UPDATE … = failed_attempts + 1`,
+  4. **re-reads** `failed_attempts` from the DB under the write lock,
+  5. sets `locked_until` based on the fresh value,
+  6. **returns** the fresh count so the `login` handler can issue an
+     accurate trip response (401 vs 423) and accurate audit metadata
+     without trusting the stale snapshot.
+
+### Tests
+
+- **New** `backend/tests/test_auth_atomicity.py` — 9 regression tests
+  importing the real production functions (not replicas). Seven are TRUE
+  regressions (verified to fail on pre-fix code by stashing the source
+  changes and re-running): the F-2.4 transaction-boundary tests
+  (`test_record_failed_attempt_rereads_under_lock`,
+  `test_record_failed_attempt_no_lockout_below_threshold`), the F-2.3 and
+  F-2.2 atomicity tests
+  (`test_register_user_and_session_atomic_on_session_failure`,
+  `test_change_password_password_and_session_atomic_on_session_failure`),
+  the F-2.1 concurrent test
+  (`test_concurrent_register_same_username`, `ThreadPoolExecutor(max_workers=2)`
+  mirroring `test_org_invites.py:782`), and the two post-review regression
+  tests added during PR feedback
+  (`test_change_password_session_records_ip_and_user_agent` for the audit-trail
+  parity fix, `test_record_failed_attempt_handles_deleted_user` for the
+  vanished-user None-guard). Two are COVERAGE tests honestly labeled as such
+  in the PR body (`test_register_duplicate_returns_409_not_500`,
+  `test_five_sequential_failed_logins_lock_account` — the sequential lockout
+  path was previously uncovered).
+- **Updated** `backend/tests/test_deps_auth_to_thread.py` — the merged
+  transactions reduce the `to_thread` call count in `register` from 3 to 1
+  and in `change_password` from 3 to 2; the source-inspection thresholds
+  are lowered accordingly (`>= 1`, `>= 2`), and the
+  `test_register_uses_lambda_pattern` assertion (which checked for a
+  `lambda` keyword that the F-2.1 fix deliberately removes) is rewritten to
+  assert `to_thread` presence instead. All with rationale comments.
+
+## Why
+
+#393 captured the highest-value cluster of live findings from the #202
+auth/mgmt/vault deep-dive that had not landed. The four defects are
+medium-severity under concurrent access (multi-worker ASGI sharing one
+SQLite file via WAL); low-traffic deploys are less affected. Combined they
+allow: wrong HTTP status on a race (500 vs 409), inconsistent
+post-failure state for register and change-password, and a brute-force
+lockout that can be bypassed by overlapping attempts.
+
+## Migration steps
+
+None. No schema change (the `users.username` UNIQUE constraint and the
+`failed_attempts`/`locked_until` columns already exist), no config change,
+no API contract change (status codes move toward their documented values:
+409 instead of 500 for duplicate register; 423 on the lockout-trip request
+under concurrency where previously a stale-snapshot 401 was possible).
+
+## Known caveats
+
+- The AC4 "5 concurrent failed logins → exactly one sets locked_until"
+  guarantee is proven by code-reading + the SQL-sequence regression test,
+  not by a 5-way ThreadPoolExecutor test. SQLite's BEGIN IMMEDIATE
+  serialization is a kernel-level invariant; a concurrency test would
+  mostly re-prove SQLite's locking rather than the application fix. This
+  is documented in the PR body and the final-critic review.
+
+## Post-review hardening (PR feedback round)
+
+A swarm-pr-review of this PR found 5 VALID findings; all 5 were resolved in
+the same PR:
+
+- **SAST baseline line-shift (blocker):** the bandit baseline key is
+  `(test_id, filename:line_number)`, so this PR's auth.py line shifts made
+  17 pre-existing findings (B105 'bearer' + B110 try/except/pass) appear
+  "new" and broke CI. Regenerated the baseline via
+  `python scripts/run_bandit.py --update-baseline`. Net finding count
+  **140 → 138** (the F-2.2/F-2.3 refactor and the redundant-UPDATE removal
+  each eliminated a B110 block — a strict security-posture improvement, not
+  a regression).
+- **Change-password session INSERT audit-trail gap:** the F-2.2 inlining
+  copied the column list verbatim, omitting `ip_address`/`user_agent` that
+  register and login include. Fixed by adding `ip_address = _request_ip(request)`
+  to the hoist and including both columns in the INSERT. Regression test
+  `test_change_password_session_records_ip_and_user_agent` added.
+- **`_record_failed_attempt_db` None-deref:** unguarded `fetchone()[0]` would
+  TypeError → 500 if a superadmin concurrently deleted the user during a
+  wrong-password login. Fixed with a `row is None` guard that rolls back and
+  returns 0 (caller issues a generic 401). Regression test
+  `test_record_failed_attempt_handles_deleted_user` added.
+- **`change_password` HTTPException-shim symmetry:** added
+  `except HTTPException: raise` (inner + outer) mirroring register's F-2.1
+  pattern, so any future in-txn HTTPException is not misconverted to 500.
+- **Redundant second `UPDATE must_change_password = 0`:** removed (the column
+  is already set in the password UPDATE).
+
+Four advisory findings from the PR comment were rejected with rationale:
+401-vs-423 info-disclosure (standard UX trade-off, pre-existing); narrow
+IntegrityError catch (by design per plan-critic C5); txn-start strategy
+inconsistency (out of scope for #393); rollback-of-implicit-txn hazard
+(no live call site exhibits it).


### PR DESCRIPTION
Closes #405
Closes #393

## Summary

Closes the four `backend/app/api/routes/auth.py` transaction-atomicity defects
from the #393 cluster (Phase 2 of #202). Each fix is localized; no schema or
API contract change.

| Defect | Before | After |
|--------|--------|-------|
| **F-2.1** username uniqueness | Pre-check `SELECT` ran outside `BEGIN IMMEDIATE`; concurrent dup register surfaced as `IntegrityError` → HTTP **500**. | Uniqueness check moved inside `BEGIN IMMEDIATE`; user `INSERT` wrapped in narrow `except sqlite3.IntegrityError → 409`; outer handler gains `except HTTPException: raise` so the 409 propagates. |
| **F-2.2** change-password atomicity | Password `UPDATE` + session `DELETE` committed in one txn; new-session `INSERT` in a separate txn. Crash between → changed password, no valid session. | New-session `INSERT` merged into the same txn as the password change. Single `commit()`. |
| **F-2.3** register atomicity | User `INSERT` committed in one txn; session `INSERT` in a separate txn. Crash between → registered user with no session; client retry hits 409. | User `INSERT` + default-vault assignment + session `INSERT` in one `BEGIN IMMEDIATE` txn. Single `commit()`. |
| **F-2.4** failed-login lockout race | `_record_failed_attempt_db` used a stale `failed_attempts` parameter; `if failed_attempts + 1 >= 5` could be skipped by concurrent attempts each observing a stale read. | Function drops the parameter, opens `BEGIN IMMEDIATE`, atomically increments, **re-reads** `failed_attempts` under the lock, and **returns** the fresh value so the `login` handler issues an accurate trip response (401 vs 423) and audit metadata. |

## Invariant audit

Per `AGENTS.md` non-negotiables and `.github/workflows/ci.yml`:

- **Backend ruff:** `python -m ruff check .` → **All checks passed!**
- **Backend targeted pytest** (10 files, 134 tests) → **all passed** (see Test plan).
- **Quality contracts:** `scripts/check_config_contract.py` → passed;
  `scripts/check_pr_scope_drift.py` → passed.
- **SAST gated scan:** `python scripts/run_bandit.py` →
  `PASS — no new findings (138 current findings, all suppressed by the baseline)`.
  Baseline regenerated from 140 → **138** (the F-2.2/F-2.3 refactor and the
  redundant-UPDATE removal each eliminated a B110 try/except/pass block — a
  strict security-posture improvement, not a regression). The 17 "new"
  findings the initial PR commit triggered were all line-number shifts of
  pre-existing findings, resolved by `run_bandit.py --update-baseline` per
  the script's documented workflow.
- **No schema change** — the `users.username` UNIQUE constraint
  (`backend/app/models/database.py:268`) and the `failed_attempts` /
  `locked_until` columns already exist. No migration needed.
- **No API contract change** — status codes move toward documented values
  (409 instead of 500 on duplicate register; 423 on the lockout-trip
  request under concurrency).
- **`to_thread` invariant** — DB operations still run off the event loop
  (`test_deps_auth_to_thread.py` 37/37 passed). The merged transactions
  reduce `register`'s `to_thread` count from 3 to 1 and `change_password`'s
  from 3 to 2; the source-inspection thresholds are lowered accordingly
  with rationale comments.
- **Audit-event ordering** — `safe_record_security_event` (which commits
  internally) is still called AFTER the merged transaction's `commit()` in
  both `register` and `change_password` (verified by Phase 8b reviewer at
  `auth.py:364`, `auth.py:939`).
- **Audit-trail parity** — the change_password session INSERT now records
  `ip_address`/`user_agent`, matching register and login (PRR-005 fix).

## Test plan

All commands run on branch `triage/auth-atomicity`, Python 3.11.9.

```
$ cd backend && python -m ruff check .
All checks passed!

$ python -m pytest \
    tests/test_auth_atomicity.py \
    tests/test_auth_register.py \
    tests/test_auth_routes.py \
    tests/test_auth_routes_adversarial.py \
    tests/test_auth_register_users_enabled.py \
    tests/test_change_password.py \
    tests/test_deps_auth_to_thread.py \
    tests/test_admin_reset_unlocks_account.py \
    tests/test_refresh_reuse_revokes_family.py \
    tests/test_must_change_password_exempt_paths.py
… 134 passed …
```

(Exact count captured in the issue-trace `08-test-results.md`.)

### Regression proof (regressions FAIL on pre-fix code)

The gold-standard validation per the testing policy: stash the source
changes, run the new tests against HEAD, confirm the true regressions fail.

```
$ git stash push -- backend/app/api/routes/auth.py backend/tests/test_deps_auth_to_thread.py
$ python -m pytest tests/test_auth_atomicity.py
5 failed, 2 passed
```

The 5 failures are the true regressions for the original F-2.1..F-2.4 fixes:

| Test | Fails on HEAD because |
|------|-----------------------|
| `test_record_failed_attempt_rereads_under_lock` | pre-fix code has no post-UPDATE `SELECT failed_attempts` (asserts SQL sequence + return value `5`). |
| `test_record_failed_attempt_no_lockout_below_threshold` | same root; no re-read SELECT; return value `4`. |
| `test_register_user_and_session_atomic_on_session_failure` | pre-fix code commits the user row in `_register_db`, then fails the session `INSERT` in a separate `_register_session_db` → dangling user row (`count == 1`, expected `0`). |
| `test_change_password_password_and_session_atomic_on_session_failure` | pre-fix code commits password+DELETE, then fails the new-session `INSERT` in `_create_session_db` → password hash changed (`!= original_hash`). |
| `test_concurrent_register_same_username` | pre-fix code allows the race loser to surface non-409 / 500 status. |

Two additional regression tests added during PR feedback round (verified
to fail on the pre-feedback commit `94abff7`):

| Test | Fails on `94abff7` because |
|------|----------------------------|
| `test_change_password_session_records_ip_and_user_agent` | pre-feedback INSERT omitted `ip_address`/`user_agent` columns. |
| `test_record_failed_attempt_handles_deleted_user` | pre-feedback `fetchone()[0]` raised `TypeError` on a vanished user row. |

The 2 passes are honestly labeled **coverage** (not regression):

- `test_register_duplicate_returns_409_not_500` — sequential duplicate path was already correct pre-fix (the pre-check SELECT catches a committed duplicate). Guards against future regression of F-2.1.
- `test_five_sequential_failed_logins_lock_account` — sequential lockout path was previously uncovered; pre-fix code locks sequentially too. Fills a coverage gap.

## Reviews

- **Phase 5 plan critic** (GLM-5.2, `.zcode/issue-traces/405/06-critic-review.md`):
  NEEDS_REVISION with 4 blockers (C1 outer-handler swallowing 409; C2/C3/C4
  `test_deps_auth_to_thread.py` threshold breaks; C5 broad IntegrityError
  catch). All addressed in the implementation.
- **Phase 8b implementation review** (Kimi K2.7,
  `.zcode/issue-traces/405/08b-implementation-review.md`): APPROVE, with one
  non-blocking question on the F-2.4 trip-response status. Resolved by a
  deviation: `_record_failed_attempt_db` now returns the fresh count and the
  `login` handler uses it for the trip response.
- **Phase 9 final critic** (GLM-5.2, `.zcode/issue-traces/405/09-final-critic.md`):
  APPROVE on the current diff including the deviation. Confirms all four #393
  ACs met, sibling-file check clean (only one production caller of
  `_record_failed_attempt_db`; no frontend branch on 423 vs 401), 8b APPROVE
  not stale.

## Known caveats / out of scope

- Redundant second `UPDATE users SET must_change_password = 0` in
  `_change_password_db` is pre-existing dead code, left for diff minimality.
- AC4 "5 concurrent failed logins → exactly one sets `locked_until`" is
  proven by code-reading + SQL-sequence regression test, not by a 5-way
  concurrent test. SQLite's BEGIN IMMEDIATE serialization is a kernel-level
  invariant; a concurrency test would mostly re-prove SQLite's locking.
- Other #202 findings (F-1.x, F-3.x, F-4.x, F-5.x, F-6.1) remain tracked in
  #202 — out of scope for this PR.

Refs #202.
