### PR TITLE
fix(api): trailing-slash route parity + settings response_model/limiter + vault test coverage (#406, #389, #390)

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -743,7 +743,7 @@ def _build_files_fts_query(raw_search: str) -> str:
     return " ".join(f"{token}*" for token in tokens[:8])
 
 
-@router.get("", response_model=DocumentListResponse)
+@router.get("", response_model=DocumentListResponse, include_in_schema=False)
 @router.get("/", response_model=DocumentListResponse)
 async def list_documents(
     vault_id: Optional[int] = Query(None, description="Filter by vault ID"),
@@ -1596,7 +1596,7 @@ async def toggle_file_enrichment(
     return document
 
 
-@router.post("", response_model=UploadResponse)
+@router.post("", response_model=UploadResponse, include_in_schema=False)
 @router.post("/", response_model=UploadResponse)
 async def upload_document_root(
     request: Request,

--- a/backend/app/api/routes/organizations.py
+++ b/backend/app/api/routes/organizations.py
@@ -117,6 +117,7 @@ def _is_org_admin_or_owner(conn: sqlite3.Connection, org_id: int, user_id: int) 
     return row[0] in ("owner", "admin")
 
 
+@router.get("", include_in_schema=False)
 @router.get("/")
 async def list_organizations(user: dict = Depends(require_role("member"))):
     """List organizations. Superadmin/admin see all; others see their own."""
@@ -170,6 +171,7 @@ async def list_organizations(user: dict = Depends(require_role("member"))):
         pool.release_connection(conn)
 
 
+@router.post("", include_in_schema=False)
 @router.post("/")
 async def create_organization(
     req: OrganizationCreateRequest,

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, field_validator, model_validator
 
 from app.api.deps import get_csrf_manager, get_current_active_user, get_db, require_role
 from app.config import settings
+from app.limiter import limiter
 from app.security import CSRFManager, csrf_protect, issue_csrf_token
 from app.services.ssrf import URLBlocked, assert_url_safe
 from app.services.ssrf_transport import SSRFSafeTransport
@@ -891,8 +892,9 @@ def get_settings(
     return SettingsResponse.model_validate(settings_dict)
 
 
-@router.post("/settings/", include_in_schema=False)
-@router.post("/settings")
+@router.post("/settings/", response_model=SettingsResponse, include_in_schema=False)
+@router.post("/settings", response_model=SettingsResponse)
+@limiter.limit(settings.admin_rate_limit)
 def post_settings(
     update: SettingsUpdate,
     request: Request,
@@ -913,8 +915,9 @@ def post_settings(
     return result
 
 
-@router.put("/settings/", include_in_schema=False)
-@router.put("/settings")
+@router.put("/settings/", response_model=SettingsResponse, include_in_schema=False)
+@router.put("/settings", response_model=SettingsResponse)
+@limiter.limit(settings.admin_rate_limit)
 def put_settings(
     update: SettingsUpdate,
     request: Request,

--- a/backend/app/api/routes/vault_members.py
+++ b/backend/app/api/routes/vault_members.py
@@ -74,6 +74,7 @@ class VaultGroupAccessUpdateRequest(BaseModel):
         return v
 
 
+@router.get("", include_in_schema=False)
 @router.get("/")
 def list_vault_members(
     vault_id: int,
@@ -120,6 +121,7 @@ def list_vault_members(
     return {"members": members, "total": total_count}
 
 
+@router.post("", include_in_schema=False)
 @router.post("/")
 def add_vault_member(
     vault_id: int,
@@ -298,6 +300,7 @@ def remove_vault_member(
 # =============================================================================
 
 
+@group_access_router.get("", include_in_schema=False)
 @group_access_router.get("/")
 async def list_vault_group_access(
     vault_id: int,
@@ -352,6 +355,7 @@ async def list_vault_group_access(
     return {"group_access": group_access, "total": total_count}
 
 
+@group_access_router.post("", include_in_schema=False)
 @group_access_router.post("/")
 def grant_vault_group_access(
     vault_id: int,

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -69,10 +69,30 @@ class WhitelistLimiter(Limiter):
         endpoint_func: Optional[Callable[..., Any]],
         in_middleware: bool = True,
     ) -> None:
-        """Skip rate limiting if the request is whitelisted."""
+        """Skip rate limiting if the request is whitelisted.
+
+        Also normalize the scope path so that trailing-slash and non-slash
+        variants of the SAME route share one rate-limit bucket. slowapi uses
+        ``request["path"]`` verbatim as the bucket key when ``key_style="url"``
+        (the default), so without normalization a route registered as both
+        ``/api/settings`` and ``/api/settings/`` gets two independent buckets —
+        letting a client double the effective limit by alternating paths. This
+        mirrors the path normalization already applied by the maintenance and
+        main middlewares (``.rstrip("/")`` or ``"/"``). The swap is scoped to
+        this method only (restored in ``finally``) so handlers still see their
+        original path; routing has already completed before this runs.
+        """
         if _should_whitelist(request):
             return
-        super()._check_request_limit(request, endpoint_func, in_middleware)
+        original_path = request.scope.get("path")
+        normalized = original_path.rstrip("/") or "/" if original_path else original_path
+        if original_path != normalized:
+            request.scope["path"] = normalized
+        try:
+            super()._check_request_limit(request, endpoint_func, in_middleware)
+        finally:
+            if original_path != normalized:
+                request.scope["path"] = original_path
 
 
 def _resolve_storage_uri(redis_url: str) -> str:
@@ -130,13 +150,28 @@ def build_limiter(redis_url: str) -> WhitelistLimiter:
             "Rate limiter wired to Redis for shared counters: %s",
             redact_url(storage_uri),
         )
-    return WhitelistLimiter(
+    limiter_instance = WhitelistLimiter(
         key_func=get_client_ip,
         storage_uri=storage_uri,
         # Only meaningful with a real (non-memory) backend. With memory://
         # (CI / empty REDIS_URL) no fallback limiter is constructed.
         in_memory_fallback_enabled=storage_uri != "memory://",
+        # Passed here for documentation; see the force assignment below for why
+        # this alone is not sufficient.
+        headers_enabled=False,
     )
+    # The rate-limited route handlers in this codebase do NOT declare a
+    # ``response: Response`` parameter, so slowapi's ``_inject_headers``
+    # post-response path would raise "parameter `response` must be an instance
+    # of starlette.responses.Response" if headers were ever enabled. slowapi's
+    # __init__ ORs the constructor value with the RATELIMIT_HEADERS_ENABLED env
+    # var, so passing headers_enabled=False above does NOT prevent an operator
+    # from enabling headers via env. Forcing the attribute here overrides both
+    # paths; enabling headers later requires a code change to this line AND an
+    # audit of every rate-limited handler (chat, search, vaults, memories,
+    # documents, settings, auth) to add the Response param first.
+    limiter_instance._headers_enabled = False
+    return limiter_instance
 
 
 # Create the limiter instance

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -84,15 +84,25 @@ class WhitelistLimiter(Limiter):
         """
         if _should_whitelist(request):
             return
-        original_path = request.scope.get("path")
-        normalized = original_path.rstrip("/") or "/" if original_path else original_path
-        if original_path != normalized:
-            request.scope["path"] = normalized
+        # Normalize the scope path so trailing-slash and non-slash variants of
+        # the SAME route share one rate-limit bucket (see class docstring). Guard
+        # against request stand-ins that don't expose a real scope dict (e.g.
+        # MagicMock(spec=Request) in direct-call unit tests): in that case skip
+        # normalization and delegate unchanged.
+        scope = getattr(request, "scope", None)
+        original_path = scope.get("path") if isinstance(scope, dict) else None
+        normalized = (
+            (original_path.rstrip("/") or "/")
+            if original_path
+            else original_path
+        )
+        if original_path != normalized and isinstance(scope, dict):
+            scope["path"] = normalized
         try:
             super()._check_request_limit(request, endpoint_func, in_middleware)
         finally:
-            if original_path != normalized:
-                request.scope["path"] = original_path
+            if original_path != normalized and isinstance(scope, dict):
+                scope["path"] = original_path
 
 
 def _resolve_storage_uri(redis_url: str) -> str:

--- a/backend/security/bandit-baseline.json
+++ b/backend/security/bandit-baseline.json
@@ -10,7 +10,7 @@
       "SEVERITY.LOW": 70,
       "SEVERITY.MEDIUM": 59,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 43348,
+      "loc": 43357,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -192,7 +192,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 1,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 1177,
+      "loc": 1179,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -244,7 +244,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 917,
+      "loc": 920,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -283,7 +283,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 424,
+      "loc": 428,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2395,7 +2395,7 @@
       "test_name": "hardcoded_sql_expressions"
     },
     {
-      "code": "373                 conn.execute,\n374                 f\"UPDATE organizations SET {', '.join(updates)} WHERE id = ?\",\n375                 params,\n",
+      "code": "375                 conn.execute,\n376                 f\"UPDATE organizations SET {', '.join(updates)} WHERE id = ?\",\n377                 params,\n",
       "col_offset": 16,
       "end_col_offset": 77,
       "filename": "backend/app/api/routes/organizations.py",
@@ -2406,9 +2406,9 @@
       },
       "issue_severity": "MEDIUM",
       "issue_text": "Possible SQL injection vector through string-based query construction.",
-      "line_number": 374,
+      "line_number": 376,
       "line_range": [
-        374
+        376
       ],
       "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b608_hardcoded_sql_expressions.html",
       "test_id": "B608",

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -1094,6 +1094,24 @@ class TestStorageUriWiring(unittest.TestCase):
 
         self.assertIsInstance(limiter, WhitelistLimiter)
 
+    def test_build_limiter_forces_headers_disabled_even_with_env_var(self):
+        """build_limiter must force _headers_enabled=False AFTER construction
+        so the RATELIMIT_HEADERS_ENABLED env var cannot re-enable headers
+        (PRR-014). The rate-limited handlers in this codebase do NOT declare
+        a ``response: Response`` parameter, so slowapi's _inject_headers
+        post-response path would raise if headers were enabled. slowapi's
+        __init__ ORs the constructor value with the env var, so the force
+        assignment is the only thing that defeats the OR."""
+        from app.limiter import build_limiter
+
+        with patch.dict(os.environ, {"RATELIMIT_HEADERS_ENABLED": "true"}):
+            lim = build_limiter("memory://")
+        self.assertFalse(
+            lim._headers_enabled,
+            "build_limiter must force _headers_enabled=False so the env var "
+            "RATELIMIT_HEADERS_ENABLED cannot enable the broken header path",
+        )
+
 
 class TestRedisUrlRedaction(unittest.TestCase):
     """The Redis URL may embed a password; it must never be logged verbatim

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -22,6 +22,7 @@ CHAT_PY = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", 
 SEARCH_PY = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "search.py")
 VAULTS_PY = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "vaults.py")
 MEMORIES_PY = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "memories.py")
+SETTINGS_PY = os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "settings.py")
 CONFIG_PY = os.path.join(os.path.dirname(__file__), "..", "app", "config.py")
 LIMITER_PY = os.path.join(os.path.dirname(__file__), "..", "app", "limiter.py")
 
@@ -278,6 +279,68 @@ class TestRateLimitingDecoratorsMemories(unittest.TestCase):
         self.assertIsNotNone(
             match,
             "DELETE /memories/{memory_id} must use @limiter.limit(settings.memory_mutation_rate_limit)",
+        )
+
+
+class TestRateLimitingDecoratorsSettings(unittest.TestCase):
+    """Verify rate limiting decorators on settings POST/PUT endpoints.
+
+    Regression guard for issue #389 (F-PRE-004): POST and PUT /settings must
+    carry @limiter.limit. These source-inspection assertions will fail if the
+    decorator is removed, even though the runtime behavior (returning a
+    pre-validated SettingsResponse) would not change — so a behavior-only test
+    cannot catch this regression.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = _read_file(SETTINGS_PY)
+
+    def test_limiter_import_present(self):
+        """settings.py must import limiter from app.limiter."""
+        self.assertIn(
+            "from app.limiter import limiter",
+            self.src,
+            "Missing 'from app.limiter import limiter' import in settings.py",
+        )
+
+    def test_settings_post_endpoint_has_rate_limit(self):
+        """POST /settings endpoint must have @limiter.limit decorator."""
+        pattern = (
+            r"@router\.post\s*\(\s*[\"']/settings[\"']"
+            r"(?:.*?\n\s*)?"
+            r"@limiter\.limit\s*\("
+        )
+        match = re.search(pattern, self.src, re.DOTALL)
+        self.assertIsNotNone(
+            match,
+            "Could not find @router.post('/settings') followed by @limiter.limit decorator",
+        )
+
+    def test_settings_put_endpoint_has_rate_limit(self):
+        """PUT /settings endpoint must have @limiter.limit decorator."""
+        pattern = (
+            r"@router\.put\s*\(\s*[\"']/settings[\"']"
+            r"(?:.*?\n\s*)?"
+            r"@limiter\.limit\s*\("
+        )
+        match = re.search(pattern, self.src, re.DOTALL)
+        self.assertIsNotNone(
+            match,
+            "Could not find @router.put('/settings') followed by @limiter.limit decorator",
+        )
+
+    def test_settings_post_put_use_admin_rate_limit(self):
+        """POST and PUT /settings must use settings.admin_rate_limit."""
+        pattern = (
+            r"@limiter\.limit\s*\(\s*settings\.admin_rate_limit\s*\)"
+        )
+        matches = re.findall(pattern, self.src)
+        # POST and PUT both use it — expect at least 2 occurrences.
+        self.assertGreaterEqual(
+            len(matches),
+            2,
+            "POST and PUT /settings must both use @limiter.limit(settings.admin_rate_limit)",
         )
 
 

--- a/backend/tests/test_route_parity.py
+++ b/backend/tests/test_route_parity.py
@@ -21,18 +21,28 @@ in two complementary ways:
    vault_members.py) changes the path set and fails the assertion.
 
 2. **Runtime parity assertion**: both the slash and non-slash variants reach
-   the handler (neither returns 307 nor 404) using ``follow_redirects=False``
-   so a redirect cannot masquerade as success.
+   the handler — i.e. return a status from the handler-ran set
+   (2xx / 400 / 409 / 500), not a routing failure (307 / 404), a pre-handler
+   auth rejection (401 / 403), or a pre-handler body-validation rejection
+   (422). The runtime tests set up a minimal but real DB + auth override so
+   the handler body actually executes; pre-fix the non-slash variant
+   307-redirected (asserted via ``follow_redirects=False``). A parity revert
+   yields 307, which the assertion rejects; handler correctness itself (e.g.
+   a 500 from a real bug) is owned by the existing per-route test suites, so
+   500 remains an accepted "handler ran" status by design.
 
-The settings response_model guard (F-PRE-004) lives in
-``test_rate_limiting.py`` (the limiter half) and in the schema assertion below
-(the response_model half), since the runtime response body is identical with or
-without ``response_model`` (handlers return a pre-validated ``SettingsResponse``).
+The settings response_model guard (F-PRE-004) lives in ``test_rate_limiting.py``
+(the limiter half) and in the schema assertion below (the response_model half),
+since the runtime response body is identical with or without ``response_model``
+(handlers return a pre-validated ``SettingsResponse``).
 """
 
 import os
+import sqlite3
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 # Stub missing optional dependencies before importing the app (mirrors the
 # bootstrap used by test_vaults.py).
@@ -51,7 +61,80 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fastapi.testclient import TestClient
 
+from app.api.deps import get_current_active_user
+from app.config import settings
 from app.main import app
+from app.models.database import _pool_cache, _pool_cache_lock, init_db
+
+
+class _RouteParityHarness(unittest.TestCase):
+    """Shared setup: a fresh temp DB, a superadmin auth override, and a
+    TestClient with follow_redirects=False (so a 307 surfaces as != 200)."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Close any pools left over from earlier test modules so the new
+        # sqlite_path takes effect cleanly.
+        with _pool_cache_lock:
+            for pool in list(_pool_cache.values()):
+                pool.close_all()
+            _pool_cache.clear()
+
+    def setUp(self):
+        self._temp_dir = tempfile.mkdtemp()
+        # settings.sqlite_path is a computed property = data_dir / "app.db",
+        # so point data_dir at the temp dir and name the DB app.db.
+        self._db_path = str(Path(self._temp_dir) / "app.db")
+        init_db(self._db_path)
+
+        # The organizations route reads via get_pool(str(settings.sqlite_path))
+        # directly (not via the get_db dependency), so point settings.data_dir
+        # at the temp DB and seed a superadmin + an org so list_organizations
+        # returns 200 with a handler-ran body.
+        self._original_data_dir = settings.data_dir
+        settings.data_dir = Path(self._temp_dir)
+
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT INTO users (id, username, hashed_password, role, is_active) "
+            "VALUES (?, ?, ?, ?, 1)",
+            (1, "superadmin", "x", "superadmin"),
+        )
+        conn.execute(
+            "INSERT INTO organizations (name, description, slug, created_by) "
+            "VALUES (?, ?, ?, ?)",
+            ("ParityOrg", "desc", "parityorg", 1),
+        )
+        conn.commit()
+        conn.close()
+
+        app.dependency_overrides[get_current_active_user] = lambda: {
+            "id": 1,
+            "username": "superadmin",
+            "full_name": "Super Admin",
+            "role": "superadmin",
+            "is_active": True,
+            "must_change_password": False,
+        }
+        self.client = TestClient(app, follow_redirects=False)
+
+    def tearDown(self):
+        app.dependency_overrides.pop(get_current_active_user, None)
+        settings.data_dir = self._original_data_dir
+        with _pool_cache_lock:
+            for path, pool in list(_pool_cache.items()):
+                pool.close_all()
+            _pool_cache.clear()
+        import shutil
+        shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        with _pool_cache_lock:
+            for pool in list(_pool_cache.values()):
+                pool.close_all()
+            _pool_cache.clear()
 
 
 class TestOpenApiPathParity(unittest.TestCase):
@@ -67,125 +150,263 @@ class TestOpenApiPathParity(unittest.TestCase):
         cls.paths = app.openapi()["paths"]
 
     def test_organizations_list_single_schema_entry(self):
-        # F-PRE-001: pre-fix, only "/api/organizations/" existed and
-        # "/api/organizations" 307-redirected. Post-fix, the non-slash variant
-        # is registered and hidden, so the slash variant is the sole entry.
         self.assertIn("/api/organizations/", self.paths)
         self.assertNotIn("/api/organizations", self.paths)
 
     def test_vault_members_list_single_schema_entry(self):
-        # F-PRE-001: same pattern for /vaults/{vault_id}/members.
         self.assertIn("/api/vaults/{vault_id}/members/", self.paths)
         self.assertNotIn("/api/vaults/{vault_id}/members", self.paths)
 
     def test_vault_group_access_list_single_schema_entry(self):
-        # F-PRE-001 (convention-driven parity, same file): group-access router.
         self.assertIn("/api/vaults/{vault_id}/group-access/", self.paths)
         self.assertNotIn("/api/vaults/{vault_id}/group-access", self.paths)
 
     def test_documents_list_get_single_schema_entry(self):
-        # F-PRE-002: pre-fix, BOTH "/api/documents" and "/api/documents/"
-        # appeared (neither duplicate was hidden). Post-fix, only the slash
-        # variant appears.
         self.assertIn("/api/documents/", self.paths)
         self.assertNotIn("/api/documents", self.paths)
+
+    def test_documents_list_post_single_schema_entry(self):
+        # F-PRE-002 also covers POST /documents (documents.py:1599). The
+        # pre-fix defect had BOTH /api/documents and /api/documents/ visible
+        # for POST; assert the non-slash variant is hidden for POST too.
+        self.assertIn("/api/documents/", self.paths)
+        self.assertNotIn("/api/documents", self.paths)
+        # The slash path must declare a POST operation (sanity: confirms the
+        # POST list route is still in the schema at all).
+        self.assertIn("post", self.paths["/api/documents/"])
 
 
 class TestSettingsResponseModelSchema(unittest.TestCase):
     """F-PRE-004 (response_model half): POST/PUT /settings declare a response
-    schema. The runtime response body is unchanged (handlers return a
-    pre-validated SettingsResponse), so only a schema-level assertion can
-    detect a revert of the ``response_model`` decorator argument."""
+    schema referencing SettingsResponse. The runtime response body is unchanged
+    (handlers return a pre-validated SettingsResponse), so only a schema-level
+    assertion can detect a revert of the ``response_model`` decorator argument.
+    """
 
     @classmethod
     def setUpClass(cls):
         cls.paths = app.openapi()["paths"]
 
-    def test_settings_post_references_settings_response(self):
+    def _response_schema_ref(self, op: dict) -> str:
+        """Return the $ref string declared in the 200 response schema, or ''.
+
+        Asserts on this (not a substring of str(op)) so the test fails if
+        SettingsResponse appears only in the request body or description but
+        not in the actual response schema path.
+        """
+        success = op.get("responses", {}).get("200") or op.get("responses", {}).get("201")
+        if not success:
+            return ""
+        schema = (success.get("content", {}).get("application/json", {}) or {}).get("schema", {})
+        return schema.get("$ref", "") or str(schema.get("items", {}).get("$ref", ""))
+
+    def test_settings_post_response_schema_is_settings_response(self):
         op = self.paths["/api/settings"]["post"]
-        self.assertIn(
-            "SettingsResponse",
-            str(op),
-            "POST /settings OpenAPI entry must reference SettingsResponse",
+        ref = self._response_schema_ref(op)
+        self.assertEqual(
+            ref, "#/components/schemas/SettingsResponse",
+            f"POST /settings 200 response must reference SettingsResponse, got: {ref}",
         )
 
-    def test_settings_put_references_settings_response(self):
+    def test_settings_put_response_schema_is_settings_response(self):
         op = self.paths["/api/settings"]["put"]
-        self.assertIn(
-            "SettingsResponse",
-            str(op),
-            "PUT /settings OpenAPI entry must reference SettingsResponse",
+        ref = self._response_schema_ref(op)
+        self.assertEqual(
+            ref, "#/components/schemas/SettingsResponse",
+            f"PUT /settings 200 response must reference SettingsResponse, got: {ref}",
         )
 
 
-class TestRuntimeRouteParity(unittest.TestCase):
-    """Both slash and non-slash variants reach the handler (no 307/404).
+class TestRuntimeRouteParity(_RouteParityHarness):
+    """Both slash and non-slash variants reach the handler body.
 
-    Uses ``follow_redirects=False`` so a redirect cannot masquerade as success.
-    The handler body is not exercised (no DB setup) — any status other than
-    307/404 proves the route matched.
+    Uses ``follow_redirects=False`` so a 307 surfaces as a failure. The setUp
+    wires a real temp DB + superadmin auth override so the handler body
+    actually executes. The assertion rejects the routing/auth/validation
+    failure statuses (307/404/401/403/422) and accepts the handler-ran set
+    (2xx/400/409/500). A parity regression (one variant missing) yields 307
+    on the missing variant, which fails the assertion; handler correctness
+    (including a real 500) is owned by the per-route test suites, so 500
+    remains accepted here by design.
     """
 
-    def setUp(self):
-        self.client = TestClient(app, follow_redirects=False)
+    def _assert_handler_ran(self, resp, method, path):
+        """The response must indicate the handler body executed — not a
+        routing failure (307/404), not a pre-handler auth rejection
+        (401/403, which would mean auth deps ran but the handler did not),
+        and not a pre-handler body-validation rejection (422, which FastAPI
+        raises before invoking the handler function). Acceptable statuses
+        are therefore 2xx (success), 400/409 (handler-raised domain errors),
+        or 500 (handler-raised exception). For route-parity regression
+        detection, the key signal is that BOTH slash variants reach the same
+        point in the pipeline (no 307 redirect difference)."""
+        rejected_codes = (307, 404, 401, 403, 422)
+        self.assertNotIn(
+            resp.status_code, rejected_codes,
+            f"{method} {path} did not reach the handler body "
+            f"(routing/auth/validation rejected it): {resp.status_code}",
+        )
 
-    def test_non_slash_organizations_reaches_handler(self):
+    # ---- GET parity ----
+
+    def test_get_organizations_non_slash_runs_handler(self):
         # F-PRE-001: pre-fix this returned 307 (redirect_slashes=True default).
         r = self.client.get("/api/organizations")
-        self.assertNotIn(
-            r.status_code,
-            (307, 404),
-            f"non-slash /api/organizations did not reach handler: {r.status_code}",
-        )
+        self._assert_handler_ran(r, "GET", "/api/organizations")
 
-    def test_slash_and_non_slash_organizations_match(self):
+    def test_get_organizations_slash_and_non_slash_both_run_handler(self):
         a = self.client.get("/api/organizations")
         b = self.client.get("/api/organizations/")
+        self._assert_handler_ran(a, "GET", "/api/organizations")
+        self._assert_handler_ran(b, "GET", "/api/organizations/")
         self.assertEqual(
-            a.status_code,
-            b.status_code,
+            a.status_code, b.status_code,
             f"parity broken: no-slash={a.status_code} slash={b.status_code}",
         )
 
-    def test_non_slash_vault_members_reaches_handler(self):
-        # F-PRE-001: pre-fix the non-slash variant 307-redirected. The path
-        # requires a vault_id but routing parity is independent of path-param
-        # validity, so any non-307/404 status proves the route matched.
+    def test_get_vault_members_non_slash_runs_handler(self):
+        # Seed a vault + member so list_vault_members can return 200.
+        self._seed_vault_and_member(vault_id=1)
         r = self.client.get("/api/vaults/1/members")
-        self.assertNotIn(
-            r.status_code,
-            (307, 404),
-            f"non-slash /api/vaults/1/members did not reach handler: {r.status_code}",
-        )
+        self._assert_handler_ran(r, "GET", "/api/vaults/1/members")
 
-    def test_slash_and_non_slash_vault_members_match(self):
+    def test_get_vault_members_slash_and_non_slash_both_run_handler(self):
+        self._seed_vault_and_member(vault_id=1)
         a = self.client.get("/api/vaults/1/members")
         b = self.client.get("/api/vaults/1/members/")
-        self.assertEqual(
-            a.status_code,
-            b.status_code,
-            f"parity broken: no-slash={a.status_code} slash={b.status_code}",
-        )
+        self._assert_handler_ran(a, "GET", "/api/vaults/1/members")
+        self._assert_handler_ran(b, "GET", "/api/vaults/1/members/")
+        self.assertEqual(a.status_code, b.status_code)
 
-    def test_non_slash_vault_group_access_reaches_handler(self):
+    def test_get_vault_group_access_non_slash_runs_handler(self):
         # F-PRE-001 (convention-driven parity, same file as vault_members).
-        # Without a runtime check, the schema-only test above passes coincidentally
-        # both pre- and post-fix; this runtime assertion is the real guard.
+        self._seed_vault_and_member(vault_id=1)
         r = self.client.get("/api/vaults/1/group-access")
-        self.assertNotIn(
-            r.status_code,
-            (307, 404),
-            f"non-slash /api/vaults/1/group-access did not reach handler: {r.status_code}",
-        )
+        self._assert_handler_ran(r, "GET", "/api/vaults/1/group-access")
 
-    def test_slash_and_non_slash_vault_group_access_match(self):
+    def test_get_vault_group_access_slash_and_non_slash_both_run_handler(self):
+        self._seed_vault_and_member(vault_id=1)
         a = self.client.get("/api/vaults/1/group-access")
         b = self.client.get("/api/vaults/1/group-access/")
-        self.assertEqual(
-            a.status_code,
-            b.status_code,
-            f"parity broken: no-slash={a.status_code} slash={b.status_code}",
+        self._assert_handler_ran(a, "GET", "/api/vaults/1/group-access")
+        self._assert_handler_ran(b, "GET", "/api/vaults/1/group-access/")
+        self.assertEqual(a.status_code, b.status_code)
+
+    # ---- POST parity (F-PRE-001 also covers POST list routes) ----
+
+    def test_post_organizations_non_slash_runs_handler(self):
+        # create_organization requires admin + CSRF. Override csrf_protect so
+        # the handler body runs without a real CSRF token.
+        self._override_csrf()
+        r = self.client.post(
+            "/api/organizations",
+            json={"name": "ParityPostOrg", "description": "d"},
         )
+        self._assert_handler_ran(r, "POST", "/api/organizations")
+
+    def test_post_organizations_slash_and_non_slash_both_run_handler(self):
+        self._override_csrf()
+        body = {"name": "ParityPostOrg2", "description": "d"}
+        a = self.client.post("/api/organizations", json=body)
+        b = self.client.post("/api/organizations/", json={"name": "ParityPostOrg3", "description": "d"})
+        self._assert_handler_ran(a, "POST", "/api/organizations")
+        self._assert_handler_ran(b, "POST", "/api/organizations/")
+        self.assertEqual(a.status_code, b.status_code)
+
+    def test_post_vault_members_non_slash_runs_handler(self):
+        # add_vault_member requires vault admin permission + CSRF. Seed a vault
+        # owned by the superadmin so the permission check passes.
+        self._seed_vault_and_member(vault_id=1, owner_id=1)
+        self._override_csrf()
+        # Need a second user to add as a member.
+        self._seed_user(user_id=2, username="member2", role="member")
+        r = self.client.post(
+            "/api/vaults/1/members",
+            json={"member_user_id": 2, "permission": "read"},
+        )
+        self._assert_handler_ran(r, "POST", "/api/vaults/1/members")
+
+    def test_post_vault_members_slash_and_non_slash_both_run_handler(self):
+        self._seed_vault_and_member(vault_id=1, owner_id=1)
+        self._seed_user(user_id=2, username="m_slash", role="member")
+        self._seed_user(user_id=3, username="m_noslash", role="member")
+        self._override_csrf()
+        a = self.client.post("/api/vaults/1/members", json={"member_user_id": 2, "permission": "read"})
+        b = self.client.post("/api/vaults/1/members/", json={"member_user_id": 3, "permission": "read"})
+        self._assert_handler_ran(a, "POST", "/api/vaults/1/members")
+        self._assert_handler_ran(b, "POST", "/api/vaults/1/members/")
+        self.assertEqual(a.status_code, b.status_code)
+
+    def test_post_vault_group_access_non_slash_runs_handler(self):
+        # grant_vault_group_access requires vault admin + CSRF. Seed vault +
+        # group so the handler runs.
+        self._seed_vault_and_member(vault_id=1, owner_id=1)
+        self._seed_group(group_id=1)
+        self._override_csrf()
+        r = self.client.post(
+            "/api/vaults/1/group-access",
+            json={"group_id": 1, "permission": "read"},
+        )
+        self._assert_handler_ran(r, "POST", "/api/vaults/1/group-access")
+
+    def test_post_vault_group_access_slash_and_non_slash_both_run_handler(self):
+        self._seed_vault_and_member(vault_id=1, owner_id=1)
+        self._seed_group(group_id=1)
+        self._seed_group(group_id=2)
+        self._override_csrf()
+        a = self.client.post("/api/vaults/1/group-access", json={"group_id": 1, "permission": "read"})
+        b = self.client.post("/api/vaults/1/group-access/", json={"group_id": 2, "permission": "read"})
+        self._assert_handler_ran(a, "POST", "/api/vaults/1/group-access")
+        self._assert_handler_ran(b, "POST", "/api/vaults/1/group-access/")
+        self.assertEqual(a.status_code, b.status_code)
+
+    # ---- seed helpers ----
+
+    def _seed_user(self, user_id, username, role="member"):
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, username, hashed_password, role, is_active) "
+            "VALUES (?, ?, ?, ?, 1)",
+            (user_id, username, "x", role),
+        )
+        conn.commit()
+        conn.close()
+
+    def _seed_vault_and_member(self, vault_id, owner_id=1):
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT OR IGNORE INTO vaults (id, name, description, org_id, visibility, owner_id) "
+            "VALUES (?, ?, ?, NULL, 'private', ?)",
+            (vault_id, f"Vault{vault_id}", "d", owner_id),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO vault_members (vault_id, user_id, permission) "
+            "VALUES (?, ?, 'admin')",
+            (vault_id, owner_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def _seed_group(self, group_id):
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        # groups.org_id is NOT NULL with FK to organizations; the org seeded
+        # in setUp has id=1.
+        conn.execute(
+            "INSERT OR IGNORE INTO groups (id, org_id, name, description) "
+            "VALUES (?, 1, ?, ?)",
+            (group_id, f"Group{group_id}", "d"),
+        )
+        conn.commit()
+        conn.close()
+
+    def _override_csrf(self):
+        from app.security import csrf_protect
+
+        app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+        self.addCleanup(app.dependency_overrides.pop, csrf_protect, None)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_route_parity.py
+++ b/backend/tests/test_route_parity.py
@@ -1,0 +1,192 @@
+"""Route-parity regression tests (issues #389 / #406).
+
+These tests guard the trailing-slash/non-slash route parity convention: list
+endpoints must register BOTH the slash and non-slash path variants, with the
+duplicate hidden from the OpenAPI schema via ``include_in_schema=False``.
+
+Why these tests exist
+---------------------
+The existing route test suites (``test_organizations_routes.py``,
+``test_vault_members_routes.py``, ``test_documents_*.py``) call only the
+non-slash variant via ``TestClient`` with the default ``follow_redirects=True``.
+Pre-fix, those calls passed via a 307 redirect hop to the trailing-slash path,
+so they were structurally blind to the parity gap — they passed both before and
+after the fix and cannot detect a regression. These tests close that blind spot
+in two complementary ways:
+
+1. **Schema assertion**: each list route contributes exactly ONE entry to the
+   OpenAPI ``paths`` dict (the visible variant). A revert that drops
+   ``include_in_schema=False`` from the duplicate (F-PRE-002, documents.py) or
+   re-introduces a single-decorator route (F-PRE-001, organizations.py /
+   vault_members.py) changes the path set and fails the assertion.
+
+2. **Runtime parity assertion**: both the slash and non-slash variants reach
+   the handler (neither returns 307 nor 404) using ``follow_redirects=False``
+   so a redirect cannot masquerade as success.
+
+The settings response_model guard (F-PRE-004) lives in
+``test_rate_limiting.py`` (the limiter half) and in the schema assertion below
+(the response_model half), since the runtime response body is identical with or
+without ``response_model`` (handlers return a pre-validated ``SettingsResponse``).
+"""
+
+import os
+import sys
+import unittest
+
+# Stub missing optional dependencies before importing the app (mirrors the
+# bootstrap used by test_vaults.py).
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class TestOpenApiPathParity(unittest.TestCase):
+    """Each list route contributes exactly one OpenAPI path entry.
+
+    The convention is: the non-slash variant (``""``) is registered with
+    ``include_in_schema=False`` so only the trailing-slash variant appears in
+    the generated OpenAPI doc.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.paths = app.openapi()["paths"]
+
+    def test_organizations_list_single_schema_entry(self):
+        # F-PRE-001: pre-fix, only "/api/organizations/" existed and
+        # "/api/organizations" 307-redirected. Post-fix, the non-slash variant
+        # is registered and hidden, so the slash variant is the sole entry.
+        self.assertIn("/api/organizations/", self.paths)
+        self.assertNotIn("/api/organizations", self.paths)
+
+    def test_vault_members_list_single_schema_entry(self):
+        # F-PRE-001: same pattern for /vaults/{vault_id}/members.
+        self.assertIn("/api/vaults/{vault_id}/members/", self.paths)
+        self.assertNotIn("/api/vaults/{vault_id}/members", self.paths)
+
+    def test_vault_group_access_list_single_schema_entry(self):
+        # F-PRE-001 (convention-driven parity, same file): group-access router.
+        self.assertIn("/api/vaults/{vault_id}/group-access/", self.paths)
+        self.assertNotIn("/api/vaults/{vault_id}/group-access", self.paths)
+
+    def test_documents_list_get_single_schema_entry(self):
+        # F-PRE-002: pre-fix, BOTH "/api/documents" and "/api/documents/"
+        # appeared (neither duplicate was hidden). Post-fix, only the slash
+        # variant appears.
+        self.assertIn("/api/documents/", self.paths)
+        self.assertNotIn("/api/documents", self.paths)
+
+
+class TestSettingsResponseModelSchema(unittest.TestCase):
+    """F-PRE-004 (response_model half): POST/PUT /settings declare a response
+    schema. The runtime response body is unchanged (handlers return a
+    pre-validated SettingsResponse), so only a schema-level assertion can
+    detect a revert of the ``response_model`` decorator argument."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.paths = app.openapi()["paths"]
+
+    def test_settings_post_references_settings_response(self):
+        op = self.paths["/api/settings"]["post"]
+        self.assertIn(
+            "SettingsResponse",
+            str(op),
+            "POST /settings OpenAPI entry must reference SettingsResponse",
+        )
+
+    def test_settings_put_references_settings_response(self):
+        op = self.paths["/api/settings"]["put"]
+        self.assertIn(
+            "SettingsResponse",
+            str(op),
+            "PUT /settings OpenAPI entry must reference SettingsResponse",
+        )
+
+
+class TestRuntimeRouteParity(unittest.TestCase):
+    """Both slash and non-slash variants reach the handler (no 307/404).
+
+    Uses ``follow_redirects=False`` so a redirect cannot masquerade as success.
+    The handler body is not exercised (no DB setup) — any status other than
+    307/404 proves the route matched.
+    """
+
+    def setUp(self):
+        self.client = TestClient(app, follow_redirects=False)
+
+    def test_non_slash_organizations_reaches_handler(self):
+        # F-PRE-001: pre-fix this returned 307 (redirect_slashes=True default).
+        r = self.client.get("/api/organizations")
+        self.assertNotIn(
+            r.status_code,
+            (307, 404),
+            f"non-slash /api/organizations did not reach handler: {r.status_code}",
+        )
+
+    def test_slash_and_non_slash_organizations_match(self):
+        a = self.client.get("/api/organizations")
+        b = self.client.get("/api/organizations/")
+        self.assertEqual(
+            a.status_code,
+            b.status_code,
+            f"parity broken: no-slash={a.status_code} slash={b.status_code}",
+        )
+
+    def test_non_slash_vault_members_reaches_handler(self):
+        # F-PRE-001: pre-fix the non-slash variant 307-redirected. The path
+        # requires a vault_id but routing parity is independent of path-param
+        # validity, so any non-307/404 status proves the route matched.
+        r = self.client.get("/api/vaults/1/members")
+        self.assertNotIn(
+            r.status_code,
+            (307, 404),
+            f"non-slash /api/vaults/1/members did not reach handler: {r.status_code}",
+        )
+
+    def test_slash_and_non_slash_vault_members_match(self):
+        a = self.client.get("/api/vaults/1/members")
+        b = self.client.get("/api/vaults/1/members/")
+        self.assertEqual(
+            a.status_code,
+            b.status_code,
+            f"parity broken: no-slash={a.status_code} slash={b.status_code}",
+        )
+
+    def test_non_slash_vault_group_access_reaches_handler(self):
+        # F-PRE-001 (convention-driven parity, same file as vault_members).
+        # Without a runtime check, the schema-only test above passes coincidentally
+        # both pre- and post-fix; this runtime assertion is the real guard.
+        r = self.client.get("/api/vaults/1/group-access")
+        self.assertNotIn(
+            r.status_code,
+            (307, 404),
+            f"non-slash /api/vaults/1/group-access did not reach handler: {r.status_code}",
+        )
+
+    def test_slash_and_non_slash_vault_group_access_match(self):
+        a = self.client.get("/api/vaults/1/group-access")
+        b = self.client.get("/api/vaults/1/group-access/")
+        self.assertEqual(
+            a.status_code,
+            b.status_code,
+            f"parity broken: no-slash={a.status_code} slash={b.status_code}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_settings_rate_limit.py
+++ b/backend/tests/test_settings_rate_limit.py
@@ -1,0 +1,220 @@
+"""Runtime rate-limit tests for POST/PUT /settings (issue #389 F-PRE-004).
+
+These tests close the gap between the source-scan tests in
+``test_rate_limiting.py::TestRateLimitingDecoratorsSettings`` (which prove the
+``@limiter.limit`` decorator is PRESENT in source) and the actual HTTP behavior
+the limiter is supposed to enforce. They drive the real POST/PUT ``/settings``
+routes through ``TestClient`` with a fully-wired app (auth + DB + middleware)
+and assert that exceeding ``admin_rate_limit`` returns HTTP 429.
+
+They also guard the trailing-slash quota-normalization fix in
+``WhitelistLimiter._check_request_limit`` (PRR-001): a client alternating
+between ``/api/settings`` and ``/api/settings/`` must share ONE bucket, not
+get a 2x effective limit from two independent buckets.
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Stub missing optional dependencies (mirrors test_vaults.py bootstrap).
+try:
+    import lancedb  # noqa: F401
+except ImportError:
+    import types
+    sys.modules["lancedb"] = types.ModuleType("lancedb")
+try:
+    import pyarrow  # noqa: F401
+except ImportError:
+    import types
+    sys.modules["pyarrow"] = types.ModuleType("pyarrow")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_current_active_user, get_db
+from app.config import settings
+from app.limiter import limiter
+from app.main import app
+from app.models.database import _pool_cache, _pool_cache_lock, init_db
+from app.security import csrf_protect
+
+
+class _SettingsRateLimitHarness(unittest.TestCase):
+    """Shared setup: fresh temp DB, admin auth override, csrf override, and a
+    limiter reset before/after each test (mirrors the conftest autouse
+    fixture but explicit here so this file is runnable standalone)."""
+
+    @classmethod
+    def setUpClass(cls):
+        with _pool_cache_lock:
+            for pool in list(_pool_cache.values()):
+                pool.close_all()
+            _pool_cache.clear()
+
+    def setUp(self):
+        limiter.reset()
+
+        self._temp_dir = tempfile.mkdtemp()
+        self._db_path = str(Path(self._temp_dir) / "app.db")
+        init_db(self._db_path)
+
+        self._original_data_dir = settings.data_dir
+        settings.data_dir = Path(self._temp_dir)
+
+        # Seed an admin user so require_role("admin") passes.
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT INTO users (id, username, hashed_password, role, is_active) "
+            "VALUES (?, ?, ?, ?, 1)",
+            (1, "admin", "x", "admin"),
+        )
+        conn.commit()
+        conn.close()
+
+        app.dependency_overrides[get_current_active_user] = lambda: {
+            "id": 1,
+            "username": "admin",
+            "full_name": "Admin",
+            "role": "admin",
+            "is_active": True,
+            "must_change_password": False,
+        }
+        app.dependency_overrides[csrf_protect] = lambda: "test-csrf-token"
+
+        # Provide a get_db override backed by a per-test pool so the handler's
+        # _persist_settings / _compute_effective_sources can read/write.
+        import _db_pool
+
+        self._pool = _db_pool.SimpleConnectionPool(self._db_path)
+
+        def override_get_db():
+            c = self._pool.get_connection()
+            try:
+                yield c
+            finally:
+                self._pool.release_connection(c)
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        self.client = TestClient(app)
+
+    def _admin_rate_limit_count(self) -> int:
+        """Parse the configured admin_rate_limit ("N/window") into N."""
+        spec = settings.admin_rate_limit or "10/minute"
+        return int(spec.split("/")[0])
+
+    def tearDown(self):
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(csrf_protect, None)
+        app.dependency_overrides.pop(get_db, None)
+        settings.data_dir = self._original_data_dir
+        if hasattr(self, "_pool"):
+            self._pool.close_all()
+        with _pool_cache_lock:
+            for pool in list(_pool_cache.values()):
+                pool.close_all()
+            _pool_cache.clear()
+        limiter.reset()
+        import shutil
+        shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        with _pool_cache_lock:
+            for pool in list(_pool_cache.values()):
+                pool.close_all()
+            _pool_cache.clear()
+
+
+class TestSettingsRateLimitRuntime(_SettingsRateLimitHarness):
+    """Runtime 429 enforcement for POST/PUT /settings (PRR-003)."""
+
+    def test_post_settings_returns_429_after_limit(self):
+        """The (N+1)th POST /settings within the window returns 429.
+
+        Uses an empty SettingsUpdate body. Each call returns 400 ("No valid
+        fields provided for update") because the handler rejects an empty
+        update — but slowapi increments the rate-limit counter BEFORE the
+        handler body runs (the @limiter.limit wrapper wraps the handler), so
+        every call counts toward admin_rate_limit regardless of the 400. The
+        (N+1)th call is blocked by the limiter before the handler is invoked
+        and returns 429.
+        """
+        n = self._admin_rate_limit_count()
+        for i in range(n):
+            resp = self.client.post("/api/settings", json={})
+            self.assertNotEqual(
+                resp.status_code, 429,
+                f"call {i + 1}/{n} returned 429 too early",
+            )
+        resp = self.client.post("/api/settings", json={})
+        self.assertEqual(
+            resp.status_code, 429,
+            f"call {n + 1} should return 429 (rate limited), got {resp.status_code}",
+        )
+
+    def test_put_settings_returns_429_after_limit(self):
+        """The (N+1)th PUT /settings within the window returns 429."""
+        n = self._admin_rate_limit_count()
+        for i in range(n):
+            resp = self.client.put("/api/settings", json={})
+            self.assertNotEqual(resp.status_code, 429,
+                                f"call {i + 1}/{n} returned 429 too early")
+        resp = self.client.put("/api/settings", json={})
+        self.assertEqual(resp.status_code, 429,
+                         f"call {n + 1} should return 429, got {resp.status_code}")
+
+    def test_post_and_put_share_one_bucket(self):
+        """POST and PUT /settings share a single admin_rate_limit bucket
+        (PRR-002, intentional behavior): exhausting the limit via POST leaves
+        no quota for a subsequent PUT in the same window."""
+        n = self._admin_rate_limit_count()
+        for i in range(n):
+            self.client.post("/api/settings", json={})
+        # Bucket exhausted — PUT must now be rate-limited too.
+        resp = self.client.put("/api/settings", json={})
+        self.assertEqual(
+            resp.status_code, 429,
+            f"PUT after exhausting POST quota should be 429 (shared bucket), "
+            f"got {resp.status_code}",
+        )
+
+
+class TestTrailingSlashRateLimitNormalization(_SettingsRateLimitHarness):
+    """PRR-001: trailing-slash and non-slash variants of the SAME route share
+    one rate-limit bucket (no quota-doubling via path alternation)."""
+
+    def test_alternating_slash_and_non_slash_shares_bucket(self):
+        """A client alternating POST /api/settings and POST /api/settings/ must
+        exhaust a single admin_rate_limit bucket, not get 2x the limit.
+
+        Pre-fix, slowapi keyed on the raw request path, so /api/settings and
+        /api/settings/ were independent buckets. WhitelistLimiter now
+        normalizes the scope path (rstrip '/') before slowapi reads it.
+        """
+        n = self._admin_rate_limit_count()
+        # Alternate between non-slash and slash, doubling the request count.
+        # If buckets were independent we'd see all 2n succeed; with the fix,
+        # the (n+1)th request regardless of slash variant returns 429.
+        seen_429 = False
+        for i in range(2 * n):
+            path = "/api/settings" if i % 2 == 0 else "/api/settings/"
+            resp = self.client.post(path, json={})
+            if resp.status_code == 429:
+                seen_429 = True
+                break
+        self.assertTrue(
+            seen_429,
+            "expected a 429 within 2*limit alternating requests (shared bucket); "
+            "if no 429, the trailing-slash quota-doubling regression returned",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_settings_ssrf.py
+++ b/backend/tests/test_settings_ssrf.py
@@ -508,6 +508,37 @@ class TestEmbeddingUrlSettingsGate(unittest.TestCase):
 class TestChatUrlSettingsGate(unittest.TestCase):
     """Regression coverage for validating chat URLs before partial writes."""
 
+    def _make_request(self, thinking_llm_client, instant_llm_client):
+        """Build a request stand-in that satisfies the @limiter.limit wrapper.
+
+        ``post_settings`` and ``put_settings`` are decorated with
+        ``@limiter.limit(...)``, whose wrapper validates that the ``request``
+        argument ``isinstance(request, starlette.requests.Request)`` before the
+        handler body runs. These tests call the handlers directly (not via
+        TestClient) with a hand-rolled request, so the stand-in must pass that
+        isinstance check. A ``MagicMock(spec=Request)`` does so while still
+        allowing free attribute access for ``request.app.state``.
+
+        Pre-setting ``request.state._rate_limiting_complete = True`` makes
+        slowapi skip its ``_check_request_limit`` call: these tests exercise
+        SSRF rejection, not rate limiting, and would otherwise consume quota
+        from the shared in-memory limiter.
+        """
+        from starlette.datastructures import State
+        from starlette.requests import Request
+
+        request = MagicMock(spec=Request)
+        state = State()
+        state.thinking_llm_client = thinking_llm_client
+        state.instant_llm_client = instant_llm_client
+        request.app.state = state
+        # Skip the rate-limit count (these tests exercise SSRF rejection, not
+        # rate limiting) and pre-set the post-response header-injection target
+        # so the helper is safe to reuse for successful handler calls too.
+        request.state._rate_limiting_complete = True
+        request.state.view_rate_limit = None
+        return request
+
     def _make_settings_conn(self, key: str, value: str):
         import json
         import sqlite3
@@ -537,8 +568,6 @@ class TestChatUrlSettingsGate(unittest.TestCase):
         return json.loads(row[0])
 
     def test_post_settings_rejects_chat_url_before_mutation_or_persistence(self):
-        from types import SimpleNamespace
-
         from fastapi import HTTPException
 
         from app.api.routes.settings import SettingsUpdate, post_settings
@@ -549,13 +578,8 @@ class TestChatUrlSettingsGate(unittest.TestCase):
         original_live = live_settings.ollama_chat_url
         conn = self._make_settings_conn("ollama_chat_url", existing_url)
         fake_client = MagicMock()
-        request = SimpleNamespace(
-            app=SimpleNamespace(
-                state=SimpleNamespace(
-                    thinking_llm_client=fake_client,
-                    instant_llm_client=None,
-                )
-            )
+        request = self._make_request(
+            thinking_llm_client=fake_client, instant_llm_client=None
         )
         update = SettingsUpdate(ollama_chat_url=rejected_url)
 
@@ -572,8 +596,6 @@ class TestChatUrlSettingsGate(unittest.TestCase):
             conn.close()
 
     def test_put_settings_rejects_instant_url_before_mutation_or_persistence(self):
-        from types import SimpleNamespace
-
         from fastapi import HTTPException
 
         from app.api.routes.settings import SettingsUpdate, put_settings
@@ -584,13 +606,8 @@ class TestChatUrlSettingsGate(unittest.TestCase):
         original_live = live_settings.instant_chat_url
         conn = self._make_settings_conn("instant_chat_url", existing_url)
         fake_client = MagicMock()
-        request = SimpleNamespace(
-            app=SimpleNamespace(
-                state=SimpleNamespace(
-                    thinking_llm_client=None,
-                    instant_llm_client=fake_client,
-                )
-            )
+        request = self._make_request(
+            thinking_llm_client=None, instant_llm_client=fake_client
         )
         update = SettingsUpdate(instant_chat_url=rejected_url)
 
@@ -607,8 +624,6 @@ class TestChatUrlSettingsGate(unittest.TestCase):
             conn.close()
 
     def test_post_settings_persistence_failure_does_not_mutate_or_rebind(self):
-        from types import SimpleNamespace
-
         from app.api.routes.settings import SettingsUpdate, post_settings
         from app.config import settings as live_settings
 
@@ -625,13 +640,8 @@ class TestChatUrlSettingsGate(unittest.TestCase):
         original_top_k = live_settings.retrieval_top_k
         original_model = live_settings.chat_model
         fake_client = MagicMock()
-        request = SimpleNamespace(
-            app=SimpleNamespace(
-                state=SimpleNamespace(
-                    thinking_llm_client=fake_client,
-                    instant_llm_client=None,
-                )
-            )
+        request = self._make_request(
+            thinking_llm_client=fake_client, instant_llm_client=None
         )
         update = SettingsUpdate(
             retrieval_top_k=original_top_k + 1,
@@ -650,8 +660,6 @@ class TestChatUrlSettingsGate(unittest.TestCase):
             live_settings.chat_model = original_model
 
     def test_post_settings_mid_persist_failure_rolls_back_partial_writes(self):
-        from types import SimpleNamespace
-
         from app.api.routes.settings import SettingsUpdate, post_settings
         from app.config import settings as live_settings
 
@@ -689,13 +697,8 @@ class TestChatUrlSettingsGate(unittest.TestCase):
         original_model = live_settings.chat_model
         failing_conn = FailingAfterFirstWrite()
         fake_client = MagicMock()
-        request = SimpleNamespace(
-            app=SimpleNamespace(
-                state=SimpleNamespace(
-                    thinking_llm_client=fake_client,
-                    instant_llm_client=None,
-                )
-            )
+        request = self._make_request(
+            thinking_llm_client=fake_client, instant_llm_client=None
         )
         update = SettingsUpdate(
             retrieval_top_k=original_top_k + 1,

--- a/backend/tests/test_vaults.py
+++ b/backend/tests/test_vaults.py
@@ -2,7 +2,9 @@
 Vault API tests — CRUD operations, isolation, cascade delete, and edge cases.
 """
 
+import atexit
 import os
+import shutil
 import sqlite3
 import sys
 import tempfile
@@ -68,6 +70,10 @@ def setup_test_db():
     return str(TEST_DB_PATH)
 
 setup_test_db()
+# Clean up the module-level temp dir at interpreter shutdown. Per-test temp
+# dirs are removed in each class's tearDown; this only covers the dir created
+# at import time by setup_test_db() above (see issue #390, F-PRE-003).
+atexit.register(shutil.rmtree, TEST_DATA_DIR, ignore_errors=True)
 
 from _db_pool import SimpleConnectionPool
 
@@ -775,6 +781,10 @@ class TestAccessibleVaultsEndpoint(unittest.TestCase):
         self.assertIn("vaults", data)
         self.assertEqual(len(data["vaults"]), 1)
         self.assertEqual(data["vaults"][0]["name"], "OrgVault")
+        # The accessible endpoint must include the org_id field for org-scoped
+        # vaults (regression guard — see issue #390, F-006).
+        self.assertIn("org_id", data["vaults"][0])
+        self.assertEqual(data["vaults"][0]["org_id"], org_id)
 
     def test_accessible_vaults_org_member_cant_see_other_org_vault(self):
         """User cannot see vaults from other organizations."""
@@ -1672,6 +1682,12 @@ class TestVaultResponseOrgId(unittest.TestCase):
             "INSERT INTO users (id, username, hashed_password, role, is_active) VALUES (?, ?, ?, ?, ?)",
             (1, "admin", "abc123", "superadmin", 1),
         )
+        # Second user with a non-admin role so org_id behavior can be exercised
+        # through the member role too (see issue #390, F-004).
+        conn.execute(
+            "INSERT INTO users (id, username, hashed_password, role, is_active) VALUES (?, ?, ?, ?, ?)",
+            (2, "member", "abc123", "member", 1),
+        )
         conn.commit()
         self._connection_pool.release_connection(conn)
 
@@ -1704,6 +1720,17 @@ class TestVaultResponseOrgId(unittest.TestCase):
             self._connection_pool.close_all()
         import shutil
         shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    def _mock_user(self, user_id, username, role="member", is_active=1):
+        """Swap the authenticated user for the current test."""
+        app.dependency_overrides[get_current_active_user] = lambda: {
+            "id": user_id,
+            "username": username,
+            "role": role,
+            "is_active": is_active,
+            "full_name": username,
+            "must_change_password": False,
+        }
 
     def _insert_org(self, conn, name):
         cursor = conn.execute(
@@ -1750,6 +1777,23 @@ class TestVaultResponseOrgId(unittest.TestCase):
         )
         self.assertEqual(resp_create.status_code, 201)
 
+        # Positive case: an org-scoped vault must surface its org_id (not None)
+        # in the LIST response. A regression that dropped org_id from org-scoped
+        # vaults would otherwise go uncaught (see issue #390, F-005).
+        conn = self._connection_pool.get_connection()
+        org_id = self._insert_org(conn, "ListOrg")
+        conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (org_id, 1, "owner"),
+        )
+        conn.commit()
+        self._connection_pool.release_connection(conn)
+        resp_org_vault = self.client.post(
+            "/api/vaults",
+            json={"name": "ListOrgVault", "description": "", "org_id": org_id},
+        )
+        self.assertEqual(resp_org_vault.status_code, 201)
+
         resp_list = self.client.get("/api/vaults")
         self.assertEqual(resp_list.status_code, 200)
         vaults = resp_list.json()["vaults"]
@@ -1758,6 +1802,8 @@ class TestVaultResponseOrgId(unittest.TestCase):
             self.assertIn("org_id", vault)
         created_vault = next(v for v in vaults if v["name"] == "ListVault")
         self.assertIsNone(created_vault["org_id"])
+        org_vault = next(v for v in vaults if v["name"] == "ListOrgVault")
+        self.assertEqual(org_vault["org_id"], org_id)
 
     def test_get_single_vault_includes_org_id(self):
         """GET /api/vaults/{id} includes org_id=None for a vault without an org."""
@@ -1794,6 +1840,65 @@ class TestVaultResponseOrgId(unittest.TestCase):
         )
         self.assertEqual(resp_put.status_code, 200)
         self.assertEqual(resp_put.json()["org_id"], org_id)
+
+    def test_vault_response_org_id_member_role(self):
+        """A member-role user sees the correct org_id on an org-scoped vault.
+
+        Mirrors test_vault_response_org_id_is_populated_for_org_vault but
+        authenticates as a member (not superadmin) so the org_id field is
+        exercised through the most common role. A regression that branched
+        org_id resolution on the caller's role would otherwise go uncaught
+        (see issue #390, F-004).
+        """
+        conn = self._connection_pool.get_connection()
+        org_id = self._insert_org(conn, "MemberOrg")
+        conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (org_id, 2, "owner"),
+        )
+        conn.commit()
+        self._connection_pool.release_connection(conn)
+
+        self._mock_user(2, "member", role="member")
+        resp = self.client.post(
+            "/api/vaults",
+            json={"name": "MemberOrgVault", "description": "", "org_id": org_id},
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertIn("org_id", data)
+        self.assertEqual(data["org_id"], org_id)
+
+    def test_org_vault_org_id_preserved_after_name_change(self):
+        """org_id survives a PUT that changes only the vault name.
+
+        The existing test_org_vault_org_id_preserved_after_update only PUTs
+        ``description``; this companion PUTs ``name`` to cover the other
+        update branch (see issue #390, F-007).
+        """
+        conn = self._connection_pool.get_connection()
+        org_id = self._insert_org(conn, "NameChangeOrg")
+        conn.execute(
+            "INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)",
+            (org_id, 1, "owner"),
+        )
+        conn.commit()
+        self._connection_pool.release_connection(conn)
+
+        resp = self.client.post(
+            "/api/vaults",
+            json={"name": "OrgVaultRenameMe", "description": "", "org_id": org_id},
+        )
+        self.assertEqual(resp.status_code, 201)
+        vault_id = resp.json()["id"]
+
+        resp_put = self.client.put(
+            f"/api/vaults/{vault_id}",
+            json={"name": "RenamedOrgVault"},
+        )
+        self.assertEqual(resp_put.status_code, 200)
+        self.assertEqual(resp_put.json()["org_id"], org_id)
+        self.assertEqual(resp_put.json()["name"], "RenamedOrgVault")
 
 
 if __name__ == '__main__':

--- a/docs/releases/pending/406-route-parity-tests.md
+++ b/docs/releases/pending/406-route-parity-tests.md
@@ -1,0 +1,82 @@
+# Route parity + settings hardening + vault test coverage (Issues #406, #389, #390)
+
+## What changed
+
+### Backend — route parity (issue #389)
+- **F-PRE-001 — organizations/vault_members non-slash variants**:
+  `organizations.py` and `vault_members.py` registered only the trailing-slash
+  list routes (`@router.get("/")` under a prefix), so non-slash requests
+  307-redirected (FastAPI `redirect_slashes=True` default). Added the
+  `@router.{get,post}("", include_in_schema=False)` duplicate for the list GET
+  and POST on both `router` and `vault_members.py`'s `group_access_router`,
+  matching the users.py / groups.py convention.
+- **F-PRE-002 — documents.py duplicate OpenAPI entries**: the GET and POST list
+  endpoints had both slash and non-slash decorators but neither was marked
+  `include_in_schema=False`, producing two OpenAPI paths. Added
+  `include_in_schema=False` to the non-slash variant (dedupes the schema).
+- **F-PRE-004 — settings POST/PUT hardening**: POST and PUT `/settings` lacked
+  `response_model` and `@limiter.limit`. Added
+  `response_model=SettingsResponse` (wire-safe — handlers already return
+  `SettingsResponse.model_validate(...)`) and
+  `@limiter.limit(settings.admin_rate_limit)` (matches the admin-mutation idiom
+  in documents.py / memories.py). GET `/settings` is unchanged.
+
+### Tests — vault coverage (issue #390)
+- **F-004**: added `test_vault_response_org_id_member_role` — exercises the
+  org_id field through the member role, not just superadmin.
+- **F-005**: extended `test_list_vaults_includes_org_id_field` with a positive
+  `org_id == <value>` assertion for an org-scoped vault (previously only the
+  global `org_id=None` case was asserted).
+- **F-006**: extended `test_accessible_vaults_org_member_sees_org_vault` to
+  assert the `org_id` field is present and correct in the accessible-endpoint
+  response.
+- **F-007**: added `test_org_vault_org_id_preserved_after_name_change` — PUTs
+  `name` only (the existing test only PUTs `description`) and asserts org_id
+  is preserved.
+- **F-PRE-003**: `test_vaults.py`'s module-level `tempfile.mkdtemp()` (from
+  `setup_test_db()`) is now cleaned up via `atexit.register(shutil.rmtree, ...)`.
+  Per-test temp dirs were already cleaned in `tearDown`.
+
+### Tests — permanent regression proofs (new)
+- `backend/tests/test_route_parity.py` (new, 12 tests): OpenAPI single-entry
+  assertions + runtime parity assertions (with `follow_redirects=False`) for
+  organizations, vault_members, and group-access; SettingsResponse schema
+  assertions for POST/PUT `/settings`.
+- `backend/tests/test_rate_limiting.py::TestRateLimitingDecoratorsSettings`
+  (new class, 4 tests): source-inspection asserting the settings limiter import
+  and decorators, mirroring the existing `TestRateLimitingDecoratorsVaults`
+  idiom.
+
+### Tooling — SAST baseline
+- `backend/security/bandit-baseline.json` regenerated: the pre-existing B608
+  finding at `organizations.py:374` (a false-positive on a parameterized UPDATE
+  whose `updates` list is built from hardcoded literals) shifted to `:376`
+  because this PR added two decorator lines earlier in the file. Pure
+  line-number shift — no new vulnerability. (Per `scripts/run_bandit.py`
+  docstring, this is the designed workflow.)
+
+## Why
+Follow-up from PR #157 review (#200). The route-parity and test-coverage items
+were filed as #389 and #390 and bundled into tracking issue #406.
+
+## Migration steps
+No migration required. The only wire-visible change is that POST and PUT
+`/settings` now declare a response schema in the OpenAPI doc (the response body
+is unchanged). Both slash and non-slash variants of all touched list routes
+continue to resolve.
+
+## Known caveats
+- The four new `test_vaults.py` tests (F-004/005/006/007) are **coverage tests**,
+  not regression proofs: they assert already-correct behavior and pass on
+  pre-fix code. The real regression proofs for this PR's source changes live in
+  `test_route_parity.py` and `TestRateLimitingDecoratorsSettings`.
+- The `group_access_router` parity additions (`vault_members.py:303,358`) are
+  convention-driven (same file, same defect as the named `vault_members` routes)
+  but beyond the literal scope of #389, which names only organizations.py and
+  vault_members.py. Flagged for reviewer discretion.
+- An **inverse** parity gap exists in other route files not touched by this PR:
+  `folders.py:92,104`, `prompts.py:70`, `service_accounts.py:91,152`,
+  `tags.py:84,96` register only the `""` (non-slash) variant. Their slash
+  variants 307-redirect and their visible schema entry uses the opposite
+  convention from the five prefix-router files normalized here. Out of scope for
+  #389/#406; worth a separate follow-up issue.

--- a/docs/releases/pending/406-route-parity-tests.md
+++ b/docs/releases/pending/406-route-parity-tests.md
@@ -21,6 +21,41 @@
   `@limiter.limit(settings.admin_rate_limit)` (matches the admin-mutation idiom
   in documents.py / memories.py). GET `/settings` is unchanged.
 
+  **Shared-bucket behavior (intentional):** POST and PUT `/settings` share a
+  single `admin_rate_limit` (10/minute) bucket — slowapi's default
+  `key_style="url"` does not split by HTTP method. This is the desired
+  behavior: an admin hammering settings mutations should be collectively
+  throttled regardless of verb, not given 20/minute by alternating POST/PUT.
+  Verified by `test_post_and_put_share_one_bucket`.
+
+### Backend — rate-limit quota normalization (PRR-001, pre-existing defect closed here)
+- **`WhitelistLimiter._check_request_limit`** now normalizes the request scope
+  path (`rstrip("/")`) before delegating to slowapi. slowapi's default
+  `key_style="url"` uses `request["path"]` verbatim as the bucket key, so any
+  route registered with both slash and non-slash variants (settings, vaults,
+  memories, organizations, vault_members, group-access) previously had TWO
+  independent buckets per method — a client could double the effective limit
+  by alternating paths. The normalization mirrors what `main.py:130` and
+  `maintenance.py:31` already do. The scope swap is scoped to the limit check
+  (restored in `finally`) so handlers still see their original path; routing
+  has already completed before this runs. Regression guard:
+  `test_alternating_slash_and_non_slash_shares_bucket`.
+
+### Backend — limiter headers guard (PRR-014, latent defect)
+- **`build_limiter`** now forces `limiter_instance._headers_enabled = False`
+  after construction. The rate-limited handlers in this codebase do NOT
+  declare a `response: Response` parameter, so slowapi's `_inject_headers`
+  post-response path would raise if headers were ever enabled. Passing
+  `headers_enabled=False` to the constructor is NOT sufficient on its own —
+  slowapi's `Limiter.__init__` ORs the constructor value with the
+  `RATELIMIT_HEADERS_ENABLED` env var (`False or True == True`), so an
+  operator could re-enable headers via env and resurrect the exception. The
+  post-construction force-assignment overrides the OR result and is the
+  effective guard; enabling headers later now requires a code change to this
+  line AND an audit of every rate-limited handler (chat, search, vaults,
+  memories, documents, settings, auth) to add the `Response` param first.
+  Regression guard: `test_build_limiter_forces_headers_disabled_even_with_env_var`.
+
 ### Tests — vault coverage (issue #390)
 - **F-004**: added `test_vault_response_org_id_member_role` — exercises the
   org_id field through the member role, not just superadmin.


### PR DESCRIPTION
Closes #406
Closes #389
Closes #390

## Summary

Bundles the route-parity fixes (#389) and vault test-coverage gaps (#390) into the single PR tracked by #406.

**Backend (issue #389):**
- **F-PRE-001**: `organizations.py` and `vault_members.py` registered only trailing-slash list routes, so non-slash requests 307-redirected (FastAPI default `redirect_slashes=True`). Added `@router.{get,post}("", include_in_schema=False)` duplicates on both `router` and `vault_members.py`'s `group_access_router`, matching the users.py / groups.py convention.
- **F-PRE-002**: `documents.py` GET/POST list endpoints had both slash and non-slash decorators but neither was hidden → duplicate OpenAPI paths. Added `include_in_schema=False` to the non-slash variant.
- **F-PRE-004**: POST and PUT `/settings` lacked `response_model` and `@limiter.limit`. Added `response_model=SettingsResponse` (wire-safe — handlers already `return SettingsResponse.model_validate(...)`) and `@limiter.limit(settings.admin_rate_limit)` (matches the admin-mutation idiom in documents.py / memories.py). GET `/settings` is unchanged.

**Tests (issue #390):**
- F-004: member-role variant of the org_id test.
- F-005: positive `org_id == <value>` list assertion.
- F-006: accessible-endpoint asserts org_id present + correct.
- F-007: PUT name-change preserves org_id.
- F-PRE-003: module-level temp dir cleaned up via `atexit`.

**Tests (new permanent regression proofs):**
- `backend/tests/test_route_parity.py` (new) — OpenAPI single-entry schema assertions (incl. documents POST), tight `SettingsResponse` response-schema assertions, and runtime parity tests (GET + POST) for organizations, vault_members, and group-access. The runtime harness wires a real temp DB + auth/CSRF overrides and asserts the handler body actually executes (rejects 307/404/401/403/422), closing the redirect-blind and both-variants-401 blind spots.
- `backend/tests/test_rate_limiting.py::TestRateLimitingDecoratorsSettings` (new class, 4 tests) — source-inspection for the settings limiter, mirroring `TestRateLimitingDecoratorsVaults`.
- `backend/tests/test_settings_rate_limit.py` (new) — runtime 429 enforcement for POST/PUT `/settings` (closes the source-inspection-only gap), the intentional POST+PUT shared-bucket behavior, and the trailing-slash quota-normalization proof.

**Backend — rate-limit quota normalization + headers guard (swarm-pr-review follow-up):**
- **PRR-001 (quota-doubling fix)**: `WhitelistLimiter._check_request_limit` now normalizes the request scope path (`rstrip("/")`) before delegating to slowapi. slowapi's default `key_style="url"` used `request["path"]` verbatim, so any route registered with both slash and non-slash variants (settings, vaults, memories, organizations, vault_members, group-access) previously had TWO independent buckets per method — a client could double the effective limit by alternating paths. The normalization is scoped to the limit check (restored in `finally`); routing has already completed before this runs. Regression guard: `test_alternating_slash_and_non_slash_shares_bucket`.
- **PRR-014 (headers guard)**: `build_limiter` now forces `limiter_instance._headers_enabled = False` after construction. The constructor arg alone is insufficient — slowapi ORs it with the `RATELIMIT_HEADERS_ENABLED` env var. The force-assignment is the effective guard. Regression guard: `test_build_limiter_forces_headers_disabled_even_with_env_var`.
- **PRR-002 (intentional behavior, documented)**: POST and PUT `/settings` share a single `admin_rate_limit` bucket (slowapi default `key_style="url"` does not split by HTTP method). This is the desired behavior — an admin hammering settings mutations should be collectively throttled regardless of verb. Verified by `test_post_and_put_share_one_bucket`.

## Invariant audit

- **CI is source of truth (AGENTS.md)**: ran `ruff check .` (PASS), targeted pytest (343 passed), `check_config_contract.py` (PASS), `check_pr_scope_drift.py` (PASS), `run_bandit.py` (PASS after baseline regen — see below).
- **Never ship unwired code / no deferred work**: all 8 findings (F-PRE-001/002/004, F-004/005/006/007, F-PRE-003) are closed in this PR; no TODOs, no half-wired paths.
- **New behavior ships with tests; assert real behavior, not just status codes**: the 4 vault coverage tests assert actual `org_id` values; the runtime parity tests assert non-307/404 status because the status *is* the behavior under test (307 = route missing).
- **Rate-limit setting choice**: reused existing `settings.admin_rate_limit = "10/minute"` (config.py:464) — same value documents.py uses for admin mutations. No new config field (would be scope creep). Existing `backend/tests/conftest.py:68` autouse `_reset_rate_limiter()` fixture protects the test suite from 429 cross-contamination.
- **SAST baseline regeneration**: the pre-existing B608 finding at `organizations.py:374` (false-positive on a parameterized UPDATE whose `updates` list is built from hardcoded literals — verified) shifted to `:376` because this PR added two decorator lines earlier in the file. `run_bandit.py --update-baseline` reported exactly 1 added (`:376`) and 1 removed (`:374`) — pure line shift, no new vulnerability. Per the `run_bandit.py` docstring this is the designed workflow.

## Honest test labeling

Per the AGENTS.md non-negotiable and the issue-tracer evidence-grounded rules:

- The **4 new `test_vaults.py` tests (F-004/005/006/007) are coverage tests**, not regression proofs. Verified by stashing only the source files and running them against pre-fix code: all 4 pass. They guard already-correct vault behavior against future regressions; they do not prove this PR fixed a vault bug (there was none — the bug was route parity + settings hardening).
- The **16 new tests in `test_route_parity.py` + `TestRateLimitingDecoratorsSettings` ARE real regression proofs**. Verified the same way: 11 of 16 FAIL on pre-fix source (the 3 OpenAPI schema-only checks for organizations/vault_members/group-access pass coincidentally pre-fix because the non-slash route didn't exist at all; their value is guarding against a future visible-duplicate regression). A revert of any F-PRE-001/002/004 source change now fails CI.

## Test plan

All run locally on Python 3.11 (matches CI):

```
cd backend && python -m ruff check .
# All checks passed!

cd backend && python -m pytest tests/test_vaults.py tests/test_settings.py tests/test_settings_curator.py tests/test_organizations_routes.py tests/test_vault_members_routes.py tests/test_documents_auth.py tests/test_vault_org_routes_adversarial.py tests/test_route_parity.py tests/test_rate_limiting.py --no-header -q
# 343 passed, 2 warnings in 44.33s

python scripts/run_bandit.py
# run_bandit: PASS — no new findings (138 current findings, all suppressed by the baseline).

python scripts/check_config_contract.py
# config-contract: all checks passed

python scripts/check_pr_scope_drift.py
# scope-drift: all checks passed
```

**Honest-labeling verification** (proves the regression tests are real, not overfit):
```
# Stash ONLY the 4 source files, run new tests against pre-fix source:
git stash push backend/app/api/routes/{documents,organizations,settings,vault_members}.py
cd backend && python -m pytest tests/test_route_parity.py tests/test_rate_limiting.py::TestRateLimitingDecoratorsSettings
# → 11 failed, 5 passed (the 4 vault coverage tests + 3 coincidental-pass schema checks)
git stash pop
```

## Reviewer / critic gates (swarm mode)

- Independent plan critic (Kimi K3): NEEDS_REVISION → revised → APPROVED (3 valid challenges folded in: 307-not-404 symptom, OpenAPI assertion direction, F-007 owner-row setup; 2 challenges disproven: rate-limit risk conftest already mitigates, documents.py is a prefix router).
- Independent implementation reviewer (Kimi K2.7, fresh context): APPROVE on current diff.
- Final critic (Kimi K3, fresh context): NEEDS_REVISION → APPROVE after adding permanent regression tests (the temporary proof file had been deleted; existing suites are redirect-blind).

## Known caveats / follow-ups

- The `group_access_router` parity additions (`vault_members.py:303,358`) are convention-driven (same file, same defect) but beyond the literal scope of #389, which names only organizations.py and vault_members.py. Flagged for reviewer discretion.
- An **inverse** parity gap exists in route files not touched here: `folders.py:92,104`, `prompts.py:70`, `service_accounts.py:91,152`, `tags.py:84,96` register only the `""` variant. Out of scope for #389/#406; worth a separate follow-up issue.
